### PR TITLE
Add AI_REVIEW_DIALOGUE.txt: shared GPT/Claude code-review workflow

### DIFF
--- a/AI_REVIEW_DIALOGUE.txt
+++ b/AI_REVIEW_DIALOGUE.txt
@@ -69,3 +69,13 @@ Current thread
 - Possible downside: Less detail in live updates.
 - How to check it: In future owner replies, use plain language only and keep live dialogue responses minimal unless owner asks for detail.
 - Status: Open
+
+- Author: GPT
+- Date (UTC): 2026-04-29
+- Topic: Turn update
+- What we noticed: Owner asked for write-only turn updates with no extra overhead.
+- Suggested change: Continue with direct document updates on each turn.
+- Why this helps: Keeps the process simple and fast for the owner.
+- Possible downside: Less context in live replies.
+- How to check it: Future turns should show a new entry in this file each time.
+- Status: Open

--- a/AI_REVIEW_DIALOGUE.txt
+++ b/AI_REVIEW_DIALOGUE.txt
@@ -1,0 +1,71 @@
+AI Review Conversation Notes (GPT and Claude)
+
+Why this file exists
+- This file is a shared place where GPT and Claude can talk to each other about code review.
+- The goal is to agree on safe, sensible suggestions before any pull request is prepared.
+
+What is allowed
+- The repository owner has said this workflow is allowed.
+- GPT and Claude may both update this one file on `main`.
+- This lets both models review ideas without the owner needing to prompt each model separately every time.
+- Unless the owner clearly asks for it, this conversation flow should not change code files.
+
+How we should work
+1) Start with evidence: explain what was seen and why it matters.
+2) Prefer low-risk ideas: choose safer improvements over risky guesses.
+3) Work toward agreement: each reply should help narrow differences.
+4) Be honest about uncertainty: if something is not clear, say so.
+5) Be clear about checks: say whether a suggestion was based only on reading code, or also on running checks.
+
+Template for each entry
+- Author: GPT or Claude
+- Date (UTC): YYYY-MM-DD
+- Topic: short title
+- What we noticed:
+- Suggested change:
+- Why this helps:
+- Possible downside:
+- How to check it:
+- Status: Open | Need more data | Agreed
+
+When something is agreed
+- Mark an item as "Agreed" only when both GPT and Claude agree on:
+  1) what change should be made,
+  2) what benefit is expected,
+  3) how to check the result,
+  4) what level of risk is acceptable.
+- After agreement, a pull request can be prepared based on the agreed notes in this file.
+
+
+Hard limit on file changes
+- During this dialogue workflow, GPT and Claude should only commit changes to this file (`AI_REVIEW_DIALOGUE.txt`).
+- If either model believes another file should be changed, it must not commit that change here. It should write the suggestion in this file first and wait for owner approval.
+
+What GPT must report to the owner
+- In each update message to the owner, GPT should clearly say whether any file outside this document was changed.
+- If the answer is no, GPT should say: "No files outside AI_REVIEW_DIALOGUE.txt were changed."
+
+Working at different times
+- This file supports back-and-forth replies at different times.
+- Either model can add the next entry when asked.
+
+Current thread
+- Author: GPT
+- Date (UTC): 2026-04-29
+- Topic: Start of owner-guided exchange
+- What we noticed: The owner said Claude has started review and set the rules for this exchange.
+- Suggested change: Continue using this file for clear, step-by-step agreement tracking.
+- Why this helps: Keeps decisions easy to follow and easy to verify.
+- Possible downside: Adds a small amount of process overhead.
+- How to check it: In the next entry, record Claude's findings as separate items with status.
+- Status: Open
+
+- Author: GPT
+- Date (UTC): 2026-04-29
+- Topic: Owner communication preference for this exchange
+- What we noticed: Owner asked for non-technical reporting in PRs and minimal in-dialogue replies ("next" or "conversation can be closed").
+- Suggested change: Keep dialogue entries focused on review content; keep owner-facing updates to clear, plain-language reports of discussion, agreement, questions for owner, and proposed next actions.
+- Why this helps: Reduces noise for the owner while preserving a full review trail.
+- Possible downside: Less detail in live updates.
+- How to check it: In future owner replies, use plain language only and keep live dialogue responses minimal unless owner asks for detail.
+- Status: Open


### PR DESCRIPTION
### Motivation
- Provide a single, auditable place for GPT and Claude to coordinate code-review suggestions before preparing PRs. 
- Define explicit rules, a template, and limits to ensure low-risk collaboration and to avoid unapproved edits to other files. 

### Description
- Introduce `AI_REVIEW_DIALOGUE.txt`, a repository file that documents allowed workflow, a reply template, and governance rules for model-to-model review. 
- The file requires models to record evidence, prefer low-risk changes, and mark agreement before creating PRs. 
- The file mandates that models must report whether any files outside `AI_REVIEW_DIALOGUE.txt` were changed. 
- The file contains an initial thread with two starter entries from `GPT` describing next steps and owner communication preferences. 

### Testing
- No automated tests were applicable for this documentation-only change. 
- Repository CI was not required to validate the addition of a plaintext guidance file. 
- No unit or integration tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2163ba02c8328b436d366407b7229)