### PR TITLE
Hotfix: remove syntax error breaking the game (no map, no creatures)

### DIFF
--- a/game/evolution_game_v66_57.html
+++ b/game/evolution_game_v66_57.html
@@ -12020,7 +12020,6 @@ async function pushBotRunToGitHub() {
 
   botSaveInFlight = true;
   botSaveStatus("Saving to repo…");
-  try {
 
   const report = collectBotReport(true);
   const runId = botFileTimestamp(report.startedAt);

--- a/game/play.html
+++ b/game/play.html
@@ -12020,7 +12020,6 @@ async function pushBotRunToGitHub() {
 
   botSaveInFlight = true;
   botSaveStatus("Saving to repo…");
-  try {
 
   const report = collectBotReport(true);
   const runId = botFileTimestamp(report.startedAt);


### PR DESCRIPTION
## Problem

A bare `try {` with no `catch` or `finally` was accidentally left wrapping the inner try-catch-finally block inside `pushBotRunToGitHub()`. In JavaScript, `try` without `catch` or `finally` is a SyntaxError — the browser refuses to parse the entire script, so the game loads with no map and no creatures.

## Fix

Remove the two erroneous lines (`try {` and its blank line) from both `game/evolution_game_v66_57.html` and `game/play.html`. The inner try-catch-finally block already handles errors correctly on its own.

## Test plan
- [ ] Merge and open `https://gy8s.github.io/evolution-game/` — map and creatures should appear normally

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDFN8t9jAL7uFADpeM1g4p)_