### PR TITLE
Expand README and add non-code project plan

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,21 @@ Format:
 
 ==========================
 
+[2026-04-30 ~10:30 UTC | GPT]
+- Expanded `README.md` from a Patch 8-focused overview into a broader project
+  overview covering vision, current gameplay systems, repository layout,
+  planning documents, bot QA evidence, bug guardrails, workflow, smoke checks,
+  changelog policy, and notes for GPT/Claude.
+- Added `docs/project-plan.md` as a non-code project plan and idea log for design
+  direction, priorities, futureproofing notes, open questions, and ideas raised
+  in conversation.
+- Seeded the project plan with current priorities and future ideas including
+  ecology richness, player awareness/perception, group/social behaviour,
+  immersive images, optional soundscape, water systems, food/poison learning,
+  batch bot testing, and raw-log retention principles.
+- Documentation/planning change only. No gameplay logic, UI/layout, bot/debug
+  behaviour, app-loading behaviour, or playable build code changed.
+
 [2026-04-30 ~10:15 UTC | GPT]
 - Added `docs/bug-guardrails.md` to capture serious bugs/coding errors as
   reusable lessons learned with future prevention checks.

--- a/README.md
+++ b/README.md
@@ -1,68 +1,215 @@
 # Evolution Game
 
-A browser-based survival and evolution simulation. You play as a creature navigating a dynamic ecosystem — foraging, avoiding predators, surviving weather events, and adapting over time. The game runs entirely in a single HTML file; no installation required.
+A browser-based survival and evolution simulation about surviving as an early primate-like creature in a dynamic prehistoric ecosystem.
+
+The current build is a single-file HTML prototype: no install, server, account, build tools, or package manager required. The design aim is not just a simple roguelike, but a living ecological sandbox where movement, habitat, height, weather, water, visibility, hunger, hydration, group behaviour, and animal encounters all interact.
+
+The project is in an early rapid-iteration phase. Current work is focused on making the ecosystem richer and more testable while keeping the playable build stable.
 
 ---
 
-## How to play
+## Play now
 
-1. Go to the `game/` folder in this repository.
-2. Download the `.html` file (or clone the repo).
-3. Open the file in any modern web browser.
-4. That's it — no server, no install, no account needed.
+Stable public play link:
 
-> **Playtesting tip:** Open the HTML file directly in your browser. Do not use embedded browser previews inside ChatGPT or similar tools — they can slow down or crash the tab.
+`https://gy8s.github.io/evolution-game/`
 
----
+That root link redirects to:
 
-## What's in this repository
+`game/play.html`
 
-```
-evolution-game/
-├── README.md                        ← You are here
-├── CHANGELOG.txt                    ← Full log of every change made to the repo
-├── .gitignore                       ← Tells git what files to ignore
-├── game/
-│   └── evolution_game_v66_57.html   ← The playable game (current version)
-└── docs/
-    └── patch8-short-eco-cycles.txt  ← Detailed notes for the current patch
-```
+`game/play.html` is the stable filename intended for playtesting and phone shortcuts. Versioned HTML files are kept so the underlying build history remains traceable.
+
+> **Playtesting tip:** Open the HTML file or GitHub Pages link directly in your browser. Do not use embedded browser previews inside ChatGPT or similar tools; they can slow down or crash the tab.
 
 ---
 
-## Current version
+## Current playable build
 
 | Field      | Value                                          |
 |------------|------------------------------------------------|
 | Version    | v66.57                                         |
-| Patch      | Patch 8 — Short Ecological Cycles              |
+| Patch area | Early ecology expansion / Patch 8 short ecological cycles |
 | Build ID   | `v66.57_patch8_short_eco_cycles_2026-04-29`    |
+| Stable file | `game/play.html`                             |
+| Versioned file | `game/evolution_game_v66_57.html`         |
 | SHA256     | `0d7a7ff8ab4791076c06614923dfdf5e873d51f80a1c16cb41c5bab39ba78193` |
 
-### What Patch 8 adds
-
-Short ecological cycle events that temporarily shift what the creature encounters in the environment. Seven cycle types can activate during a run:
-
-- **Fruiting Pulse** — forage is more abundant for a stretch of turns
-- **Insect Bloom** — insects spike in frequency
-- **Dry Spell** — forage and insects both drop
-- **Wet Spell** — insects rise, forage improves slightly
-- **Scavenger Pulse** — carcasses become more common
-- **Predator Lull** — predators thin out temporarily
-- **Predator Spike** — predators surge
-
-Cycles are announced in the game log when they start and end. Only one cycle is active at a time. All effects are temporary and reversible.
+Patch 8 is not the whole project direction. It is one part of a broader first-pass ecology upgrade: making habitats, encounters, hazards, and short-term environmental changes feel more alive and less static.
 
 ---
 
-## Project workflow
+## Project vision
+
+The game should feel like an immersive prehistoric survival sim where the player is small, vulnerable, observant, and embedded in an ecosystem.
+
+Core design goals:
+
+- **Ecological richness:** the world should feel busy, layered, and reactive rather than a sequence of isolated random encounters.
+- **Readable risk:** danger should often be hinted through tracks, sounds, movement, weather, smell, group reactions, or partial sightings rather than announced plainly.
+- **Meaningful movement:** ground, undergrowth, mid-storey, and canopy movement should carry different opportunities and risks.
+- **Survival pressure:** hunger, hydration, injury, poison, predation, weather, and exhaustion should all matter.
+- **Player learning:** the player should gradually learn which foods, animals, habitats, and behaviours are safe or dangerous.
+- **Replayability:** repeated playthroughs should create different stories through changing encounters, weather, ecology cycles, and animal behaviour.
+- **Traceable development:** every change should be reviewable, tested where practical, and recorded clearly.
+
+---
+
+## Current gameplay systems
+
+The prototype currently centres on:
+
+- Tile-based world movement.
+- Multiple vertical layers: ground, undergrowth, mid-storey, canopy.
+- Fitness, energy, size, hydration, and related survival pressures.
+- Food, water, poison, carcass, insect, nest, and plant interactions.
+- Predator/prey encounters and escalating danger.
+- Weather and habitat-driven encounter variation.
+- Short ecological cycles such as fruiting pulses, insect blooms, dry spells, wet spells, scavenger pulses, predator lulls, and predator spikes.
+- Group/social behaviour in early form.
+- Debug tools and bot testing tools for QA.
+
+These systems are still evolving. Many are deliberately lightweight at this stage so they can be tested and expanded without making the codebase unmanageable.
+
+---
+
+## Repository layout
+
+```text
+evolution-game/
+├── README.md                         Project overview and workflow
+├── CHANGELOG.txt                     Reverse-chronological change record
+├── AI_REVIEW_DIALOGUE.txt            GPT/Claude review coordination notes
+├── manifest.json                     PWA/home-screen metadata
+├── index.html                        GitHub Pages entry point; redirects to game/play.html
+├── icon.png                          Source app icon
+├── icon-192.png                      PWA icon
+├── icon-512.png                      PWA icon
+├── game/
+│   ├── play.html                     Stable playable build used by public link/PWA
+│   └── evolution_game_v66_57.html    Versioned playable build
+├── docs/
+│   ├── patch8-short-eco-cycles.txt   Detailed notes for Patch 8 ecology cycle work
+│   ├── bug-guardrails.md             Known repeated failure modes and prevention checks
+│   └── project-plan.md               Non-code design plan, priorities, and idea log
+├── logs/
+│   ├── bot-runs/                     Raw bot run outputs when intentionally saved
+│   └── consolidated/                 AI-reviewed summaries and bug reports
+├── scripts/
+│   └── ingest_bot_report.sh          Helper for manually ingesting downloaded bot logs
+└── .github/
+    └── pull_request_template.md      Required PR checklist
+```
+
+---
+
+## Project planning documents
+
+Use `docs/project-plan.md` for non-code planning.
+
+That document is for:
+
+- future feature ideas,
+- design direction,
+- priority decisions,
+- open questions,
+- technical/development principles,
+- futureproofing notes,
+- things discussed with GPT or Claude that should not be lost in chat history.
+
+It should not contain implementation code. It is a planning and alignment document so George, GPT, and Claude can reason from the same set of goals before choosing the next patch.
+
+---
+
+## Bot testing and QA evidence
+
+The game includes bot/debug tooling to help find regressions and odd behaviours.
+
+The intended evidence flow is:
+
+1. Run bot tests in the playable build.
+2. Save compact and/or full logs where needed.
+3. Store raw bot evidence under `logs/bot-runs/` when intentionally retained.
+4. Review logs with GPT and/or Claude.
+5. Write a higher-level report under `logs/consolidated/`.
+6. Turn confirmed issues into focused patch requests.
+7. Delete or avoid committing unnecessarily large raw files once they have served their purpose.
+
+Compact logs are preferred for routine review. Full logs should be kept for deep dives or serious failures because they can become large.
+
+---
+
+## Bug guardrails and repeated-error prevention
+
+Known serious or repeated errors are recorded in `docs/bug-guardrails.md`.
+
+Before a PR is treated as ready, the author and reviewer should check whether any existing guardrail applies. If a new serious bug is found, the fix should include either:
+
+- a new guardrail entry, or
+- an update to an existing guardrail.
+
+Current active guardrails include:
+
+- JavaScript syntax errors that stop the full game from initialising.
+- Missed changelog entries after repo/code changes.
+
+---
+
+## Development workflow
 
 - **`main` is the stable, playable version.** It should always contain a working build that can be opened and played immediately.
-- **No direct edits to `main`.** All changes — no matter how small — must be made on a separate branch.
-- **The person or assistant making the change opens a pull request** against `main` when the work is ready.
-- **The other assistant reviews the pull request in plain English** before it is merged — confirming what changed, what didn't, and whether anything looks off.
-- **George merges the pull request** only after the review confirms the change is correct and limited to what was intended.
-- **Pull requests must clearly state** which of the following were affected: gameplay logic, UI/layout, bot or debug tools, or documentation. If none of those changed, say so explicitly.
-- **Keep patches small and focused.** One purpose per branch. Don't bundle unrelated changes.
-- **The CHANGELOG must be updated** with a timestamped entry for every commit that changes the codebase or repository structure.
-- Large debug logs, bot reports, and QA output files should **not** be committed — they are excluded by `.gitignore`.
+- **Use branches and pull requests for changes.** Changes should be made on a separate branch and proposed through a PR wherever practical.
+- **George merges the pull request** only after review confirms the change is correct and limited to what was intended.
+- **The other assistant reviews the PR in plain English** before merge where possible, confirming what changed, what did not change, and what still needs checking.
+- **Pull requests must clearly state scope:** gameplay logic, UI/layout, bot/debug tools, app loading/PWA files, documentation/workflow, or other.
+- **Keep patches small and focused.** One purpose per branch. Do not bundle unrelated changes.
+- **Every PR must address `CHANGELOG.txt`.** If the changelog is not updated, the PR must explain why.
+- **Every serious bug fix should consider `docs/bug-guardrails.md`.** Repeated mistakes should become documented guardrails.
+- **Do not claim tests were run unless they were actually run.** Say clearly when something is static review only.
+
+---
+
+## Mandatory smoke checks for playable-build changes
+
+Any change touching `game/*.html`, `index.html`, `manifest.json`, bot/debug tools, or app-loading behaviour must address the render/syntax safety checklist in `.github/pull_request_template.md`.
+
+Minimum expectation:
+
+- JavaScript syntax check, once available.
+- Open `game/play.html` in a browser.
+- Confirm the game is not blank or half-loaded.
+- Confirm the map appears.
+- Confirm player/status UI appears.
+- Confirm core action controls appear.
+- Take at least one action/turn.
+- Check the browser console for red JavaScript errors.
+
+This exists because a single JavaScript syntax error in the large HTML file can prevent the entire game script from loading.
+
+---
+
+## Changelog policy
+
+`CHANGELOG.txt` is the human-readable history of the project. It should be updated for changes to:
+
+- gameplay logic,
+- UI/layout,
+- bot/debug/QA tools,
+- app-loading/PWA files,
+- documentation/workflow,
+- repository structure.
+
+Entries should be plain English and should state what changed, who made the change, and whether gameplay/UI/bot/app-loading/documentation were affected.
+
+---
+
+## Notes for GPT and Claude
+
+When working on this repository:
+
+- Read the README, `CHANGELOG.txt`, `.github/pull_request_template.md`, and `docs/bug-guardrails.md` before preparing a PR.
+- Check `docs/project-plan.md` when deciding priorities or interpreting design direction.
+- Keep owner-facing summaries plain English.
+- Do not silently broaden scope.
+- Do not describe a PR as complete or safe unless changelog and guardrail status are addressed.
+- Prefer small, reviewable changes over large speculative rewrites.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1,0 +1,350 @@
+# Evolution Game — Project Plan and Idea Log
+
+This document is for non-code planning. It captures direction, priorities, design ideas, open questions, and futureproofing notes discussed by George, GPT, and Claude.
+
+It should not contain implementation code. It should help decide what to build next and how smaller early patches should avoid blocking larger future goals.
+
+---
+
+## How to use this document
+
+Add ideas here when they are raised, even if they are not ready to implement.
+
+For each idea, try to capture:
+
+- what the player-facing goal is,
+- why it matters,
+- rough priority,
+- dependencies or risks,
+- whether it is design-only, code-ready, or needs more thought.
+
+This is not a promise to build everything. It is a shared memory and prioritisation tool.
+
+---
+
+## Current broad phase
+
+**Phase:** Early ecology and playability expansion.
+
+The current build has enough basic systems to play and test, but many mechanics are still first-pass. The immediate goal is to make the ecosystem feel more alive while keeping the game stable and testable.
+
+Current emphasis:
+
+- richer encounter behaviour,
+- clearer survival pressures,
+- better debug/bot evidence,
+- stronger PR guardrails,
+- avoiding repeated breakages,
+- keeping the stable play link working.
+
+---
+
+## Guiding principles
+
+- **Stability first:** main must remain playable.
+- **Small patches:** one clear change per PR where practical.
+- **Evidence before patching:** use bot logs, debug logs, screenshots, or clear reproduction steps.
+- **No silent scope creep:** design improvements should not be bundled into unrelated fixes.
+- **Player perception matters:** immersion often comes from hints, uncertainty, and consequences, not from explaining everything directly.
+- **Futureproof early systems:** simple first-pass mechanics should avoid blocking later richer systems.
+- **Traceability:** changes, bugs, and design decisions should be written down.
+
+---
+
+## Near-term priorities
+
+### 1. Keep the playable build reliable
+
+Goal:
+- Prevent avoidable breakages such as syntax errors, blank/half-loaded games, missing map, or dead controls.
+
+Current support:
+- PR template.
+- Changelog requirement.
+- Bug guardrails document.
+
+Future improvement:
+- Add an automated JavaScript syntax check for embedded scripts.
+- Add a lightweight browser smoke test if practical.
+
+Status: Active / high priority.
+
+---
+
+### 2. Bot testing and consolidated reports
+
+Goal:
+- Use bot runs to find errors, warnings, and odd behaviours without manually reading huge raw logs.
+
+Current support:
+- Compact and full bot reports.
+- Repo log structure.
+- Consolidated report template.
+
+Future idea:
+- Batch testing with a shared batch ID and individual run IDs.
+- Prefer compact + meta for routine runs.
+- Keep full logs only for serious or unusual failures, or short retention.
+
+Status: Active / high priority.
+
+---
+
+### 3. Ecology richness
+
+Goal:
+- Make the world feel less static and less random-for-randomness-sake.
+
+Current support:
+- Habitat bias.
+- Weather effects.
+- Short ecological cycles.
+
+Future directions:
+- More logical local encounter persistence.
+- Better predator/prey movement and consequences.
+- More meaningful water-edge behaviour.
+- Static/semi-static resources such as nests, carcasses, hives, fruiting trees, ant trails.
+
+Status: Active / high priority.
+
+---
+
+### 4. Player awareness and perception
+
+Goal:
+- Let players infer risk and opportunity from signs rather than direct labels.
+
+Ideas:
+- Look/scan action that consumes a turn.
+- Awareness-based hints for nearby threats/opportunities.
+- Wind direction affecting scent/detection.
+- Vague versus clear cues depending on awareness, group size, elevation, weather, and distance.
+- Partial sightings of hidden animals.
+
+Status: Design direction active; implementation should be careful and incremental.
+
+---
+
+### 5. Group and social behaviour
+
+Goal:
+- Make group membership feel useful, fragile, and socially meaningful.
+
+Ideas:
+- Group members improve threat detection.
+- Members may leave after repeated poor decisions, starvation, dehydration, or danger.
+- Group members can be injured or killed by hazards/predators.
+- Socialisation flow for same-species individuals rather than instant joining.
+- Group summary UI with health/size/sex indicators.
+
+Status: Planned; some early systems exist.
+
+---
+
+## Medium-term ideas
+
+### Immersion through images
+
+Goal:
+- Use landscape and encounter imagery to make locations memorable and atmospheric.
+
+Notes:
+- Large image selection is desired so repeated landscapes are not obvious.
+- Images should vary by habitat, elevation, weather, time of day, and nearby encounters.
+- Hidden threats could be visually present but difficult to spot.
+- Example: a pakicetus partly visible in water or a miacid hidden in undergrowth.
+
+Risks:
+- Asset generation and storage may become large.
+- Visuals should not replace clear gameplay feedback where needed.
+
+Status: Future; not immediate.
+
+---
+
+### Soundscape and audio cues
+
+Goal:
+- Add optional sound to increase immersion and provide subtle information.
+
+Ideas:
+- Ambient soundscape by habitat/weather/time.
+- AI-generated representative animal calls or environmental cues.
+- Threat/opportunity cues that experienced players can learn.
+- Example: shoebill-like chatter as a warning cue; predator stalking sounds; insect bloom ambience.
+
+Requirements:
+- Must be toggleable.
+- Should not be required for accessibility.
+- Should support, not replace, text/visual cues.
+
+Status: Future; concept stage.
+
+---
+
+### Better water systems
+
+Goal:
+- Make streams, ponds, lake edges, drinking, drowning, crocodile/pakicetus risk, and water navigation more coherent.
+
+Ideas:
+- Water edge should enable drinking.
+- Entering water should be clearly distinct from drinking at edge.
+- Movement into water should not happen accidentally or impossibly.
+- Water predators should be linked to appropriate conditions and warnings.
+
+Status: Important; likely needs focused patching.
+
+---
+
+### Food learning / poison knowledge
+
+Goal:
+- Let the player learn edible/poisonous resources through investigation, experience, and observation.
+
+Ideas:
+- Unknown -> maybe/probably edible/poisonous -> known edible/poisonous.
+- Severity classes: mild, moderate, high, deadly.
+- Learn by repeated investigation, eating, or seeing other animals react.
+- Mimicry and uncertainty for some species/resources.
+
+Status: Active design area; likely incremental.
+
+---
+
+### Carcasses, hives, nests, trails, and static resources
+
+Goal:
+- Create semi-persistent local features that make places matter.
+
+Ideas:
+- Carcasses with multi-turn feeding and predator/scavenger attraction.
+- Beehives/wasp nests/termite nests with increasing risk as they are exploited.
+- Bird nests and eggs.
+- Ant trails connecting nest and resource, with directional flow.
+- Fruiting trees or fungal patches that persist for some time.
+
+Status: Planned ecology enrichment.
+
+---
+
+## Longer-term ideas
+
+### Time progression and evolutionary scope
+
+Goal:
+- Eventually move forward in time and broaden species/biome context.
+
+Notes:
+- Current focus is early primate-style survival.
+- Some temporal flexibility is acceptable for gameplay, but later animals should be saved for later time progression where possible.
+- Avoid adding too many later predators too early if they belong better in a future phase.
+
+Status: Long-term.
+
+---
+
+### More advanced animal AI
+
+Goal:
+- Animals should have simple but believable motivations and movement.
+
+Ideas:
+- Predators stalk, abandon, pursue, ambush, or avoid depending on context.
+- Prey flee logically and may react to nearby predators.
+- Animals respond to weather, time, habitat, group size, injury, and player actions.
+- Same species interactions can involve social reads and multi-step outcomes.
+
+Status: Long-term, but early hooks should be futureproofed.
+
+---
+
+### UI and accessibility polish
+
+Goal:
+- Make survival state, risk, and available choices readable without overwhelming the player.
+
+Ideas:
+- Better stacked status bars/icons.
+- Clear but compact group summary.
+- Improved map contrast.
+- Better action result positioning.
+- Optional audio.
+- Avoid relying only on colour/audio for critical warnings.
+
+Status: Ongoing.
+
+---
+
+## Known open questions
+
+- What is the right balance between hidden information and player frustration?
+- How often should the player encounter something interesting versus empty travel?
+- How persistent should local resources and animals be?
+- How lethal should early predator mistakes be?
+- How much should bot testing drive balance decisions versus just bug detection?
+- What raw bot data should be retained long-term versus summarised and deleted?
+- How much future asset/audio planning should influence current data structures?
+
+---
+
+## Idea intake log
+
+### 2026-04-30 — Project plan document
+
+George requested a non-code project plan document so ideas raised in conversation are not lost and can be reviewed by George, GPT, and Claude when deciding next steps.
+
+Status: Added.
+
+---
+
+### 2026-04-30 — Batch bot testing concept
+
+Idea:
+- Future batch testing could run multiple long bot tests under one shared batch ID, with individual run IDs for each run.
+
+Purpose:
+- Allow large evidence runs while keeping outputs structured and reviewable.
+
+Potential structure:
+- batch metadata,
+- per-run compact logs,
+- per-run metadata,
+- full logs only for selected failures or short retention,
+- consolidated report.
+
+Status: Parked for later.
+
+---
+
+### 2026-04-30 — Raw logs versus consolidated reports
+
+Idea:
+- Raw bot outputs can be temporary evidence.
+- Higher-level bug reports and consolidated review reports should have longer retention.
+
+Status: Active principle for QA workflow.
+
+---
+
+### 2026-04-30 — Immersive images and soundscape
+
+Idea:
+- Later, add large pools of landscape images and optional soundscapes tied to habitat, time, weather, opportunities, and threats.
+- Awareness could determine whether the player notices hidden visual/audio cues.
+
+Status: Future concept.
+
+---
+
+## Parking lot
+
+Items here are interesting but not yet prioritised:
+
+- App icon polish.
+- Better phone/PWA experience.
+- Automated smoke testing.
+- Headless bot testing outside the browser.
+- Asset pipeline for generated images/audio.
+- Structured data model refactor if single-file HTML becomes too difficult to maintain.


### PR DESCRIPTION
## Summary

This PR updates the project documentation so it better reflects the broader Evolution Game project, rather than reading mainly like a Patch 8 note.

It also adds a non-code planning document for recording future ideas, priorities, design direction, and open questions raised by George/GPT/Claude.

## Scope check

- [ ] Gameplay logic / mechanics
- [ ] UI / layout / presentation
- [ ] Bot / debug / QA tools
- [ ] GitHub Pages / app loading / PWA files
- [x] Documentation / workflow only
- [ ] Other:

## Known bug guardrails

Before marking this PR ready, check `docs/bug-guardrails.md` for any previously documented failure mode that may apply.

- [x] Reviewed `docs/bug-guardrails.md`
- [x] Any applicable guardrail checks have been completed
- [x] If this PR fixes a bug/coding error, a new guardrail entry was added or an existing one was updated — not applicable, this is not a bug fix
- [x] If no guardrail applies, state why here: documentation-only change; no playable code, app-loading code, bot/debug tooling, or bug fix changed

## Mandatory syntax/render safety check

Required for any PR touching `game/*.html`, `index.html`, `manifest.json`, bot/debug tooling, or app-loading behaviour.

- [ ] `node scripts/check_html_js_syntax.mjs` passed, or equivalent syntax check performed
- [ ] `game/play.html` opened in a browser
- [ ] Game renders without a blank or half-loaded screen
- [ ] Map is visible
- [ ] Player/status UI is visible
- [ ] Core action controls are visible
- [ ] At least one action/turn can be taken
- [ ] Browser console checked for red JavaScript errors
- [ ] If bot/debug tools were touched: bot can start and stop without crashing

Syntax/render safety check not run. This PR changes documentation only and does not touch playable HTML, app-loading files, bot/debug tooling, or manifest/PWA files.

## Mandatory CHANGELOG reminder

- [x] `CHANGELOG.txt` updated with a timestamped plain-English entry for this PR
- [x] Entry states who made the change
- [x] Entry states whether gameplay logic, UI/layout, bot/debug tools, app-loading behaviour, or documentation changed
- [ ] If the changelog was intentionally not updated, explain why here:

## What changed

- Expanded `README.md` into a broader project overview covering:
  - project vision,
  - current gameplay systems,
  - repository layout,
  - project planning docs,
  - bot testing and QA evidence,
  - bug guardrails,
  - development workflow,
  - smoke checks,
  - changelog policy,
  - notes for GPT and Claude.
- Added `docs/project-plan.md` as a non-code plan and idea log.
- Seeded the project plan with current priorities and ideas including ecology richness, awareness/perception, group/social behaviour, immersive images, optional soundscape, water systems, food/poison learning, batch bot testing, and raw-log retention principles.
- Updated `CHANGELOG.txt`.

## Testing / review notes

Documentation-only change. I checked the documented guardrails and changelog status. I did not run a game render check because no playable/app-loading files were changed.

## Reviewer confirmation

Reviewer should explicitly state:

- `Bug guardrails reviewed; applicable checks passed.` or `Bug guardrails not reviewed.`
- `Syntax/render safety check not run.` is acceptable here because this is documentation-only.
- `CHANGELOG updated.`
