### PR TITLE
Add GPT-reviewed consolidated bot report 20260430-001

### DIFF
--- a/logs/consolidated/20260430-001-draft.md
+++ b/logs/consolidated/20260430-001-draft.md
@@ -1,8 +1,9 @@
-# Bot Run Consolidated Report — DRAFT
+# Bot Run Consolidated Report — GPT Reviewed Draft
 
-**Reviewed by**: Claude (first draft — awaiting GPT review)
+**Reviewed by**: Claude (first draft), GPT (evidence check against saved RandomBot compact/meta logs)
 **Review date**: 2026-04-30
 **Consolidated report ID**: 20260430-001
+**Status**: Reviewed draft — suitable to merge as a QA report; IntelligentBot conclusions remain limited by missing saved log
 
 ---
 
@@ -11,10 +12,14 @@
 | Run ID | Bot | Date | Build | Actions | Runs | Deaths | Stop Reason | Log available |
 |--------|-----|------|-------|---------|------|--------|-------------|---------------|
 | 20260430-101214 | RandomBot | 2026-04-30 | v66.57_patch8_short_eco_cycles_2026-04-29 | 1000/1000 | 139 | 138 | turn limit reached | compact + full in repo |
-| *(screenshot)* | IntelligentBot | 2026-04-30 | v66.57 (branch: claude/intelligent-bot-agent-oCneM) | 1000/1000 | 71 | 70 | turn limit reached | **not saved — save failed (network error)** |
+| *(screenshot)* | IntelligentBot | 2026-04-30 | v66.57 / IntelligentBot branch before or around merge | 1000/1000 | 71 | 70 | turn limit reached | **not saved — save failed (network error)** |
 
-*RandomBot source: `logs/bot-runs/20260430-101214/compact.txt`*
-*IntelligentBot data: screenshot evidence only. Numbers are reliable; per-run detail is unavailable.*
+RandomBot sources:
+- `logs/bot-runs/20260430-101214/compact.txt`
+- `logs/bot-runs/20260430-101214/meta.json`
+
+IntelligentBot source:
+- screenshot evidence only. Headline numbers can be treated as useful, but per-run details, death causes, and warning details cannot be independently checked from repo evidence.
 
 ---
 
@@ -22,11 +27,13 @@
 
 | Check | RandomBot | IntelligentBot |
 |-------|-----------|----------------|
-| Action crashes / ERR_ACTION_EXCEPTION | NONE | NONE (screenshot) |
-| Turn-backwards errors | NONE | NONE (screenshot) |
-| Warnings requiring review | 1 | 0 (screenshot) |
+| Action crashes / ERR_ACTION_EXCEPTION | NONE | NONE reported in screenshot |
+| Turn-backwards errors | NONE reported in compact log | NONE reported in screenshot |
+| Warnings requiring review | 1 | 0 reported in screenshot |
 
-Both bots passed with no errors. The one warning (WARN_STATIC_QUEUED_ENCOUNTER_DISAPPEARED) is carried over from prior runs and is not new.
+RandomBot passed the patch gate with no error issue codes and one warning: `WARN_STATIC_QUEUED_ENCOUNTER_DISAPPEARED`.
+
+The IntelligentBot headline result appears clean from screenshot evidence, but should be rerun with saved compact/full logs before making strong conclusions about behaviour.
 
 ---
 
@@ -38,70 +45,74 @@ Both bots passed with no errors. The one warning (WARN_STATIC_QUEUED_ENCOUNTER_D
 | Runs | 139 | 71 |
 | Deaths | 138 | 70 |
 | Death rate | 99.3% | 98.6% |
-| Avg turns per run | ~14 | ~(est.) 27 |
+| Mean / estimated turns per recorded run | 14 in compact log | ~14.1 actions per run if calculated as 1000 actions / 71 runs; not directly comparable to RandomBot death-turn mean |
 | Median death turn | 7 | unknown |
 | Longest run | 75 turns | unknown |
 
-The IntelligentBot ran roughly half as many runs in the same number of actions, which means it survived roughly twice as long per run on average. This validates the heuristic approach. Both bots are still dying in almost every run, which is expected at this difficulty level and with these spawn rates.
+The IntelligentBot had roughly half as many runs/deaths across the same 1000 actions. That suggests it survived longer per life than RandomBot, but the original draft's "roughly twice as long per run" conclusion should be treated cautiously until an IntelligentBot compact log is saved. RandomBot's mean death turn is calculated from death durations; the IntelligentBot figure currently available is only actions divided by runs.
 
 ---
 
 ## Observations
 
-### OBS-001: Death cause summary is uninformative — all 138 deaths recorded as "unknown"
+### OBS-001: Death cause summary is uninformative — all 138 RandomBot deaths recorded as "unknown"
 
 **Severity**: Low (QA tooling / observability issue)
 **Evidence**: `Death causes: unknown: 138` in compact summary
 
-The per-run data clearly shows named killers (Lesmesodon-like creodont, pitviper, mesonychid-like ground predator, etc.) in `deathContext.encounterAtDeath.name`. However, the death context `context.source` field is `"unknown"` for the majority of kills, and the compact summary reads from this field rather than from the encounter name.
+The per-run summaries often contain a useful `deathContext.encounterAtDeath.name` value, such as Lesmesodon-like creodont, pitviper, Gastornis, mesonychid-like ground predator, Masillaraptor-like raptor, or Pakicetus-like water hunter. However, the top-level death cause summary collapses all RandomBot deaths into `unknown`.
 
-This means the top-level death cause breakdown is currently useless for identifying which predators are causing the most deaths. The summary should also (or instead) read `deathContext.encounterAtDeath.name` where available.
+This makes the compact summary much less useful for quickly identifying which predators or hazards are driving mortality.
 
-**Recommended action**: Update death cause summary to use encounter name as the primary source, falling back to `context.source`.
-
----
-
-### OBS-002: Very high sub-10-turn death rate — 60% of runs end before turn 10
-
-**Severity**: Design observation — may or may not need action
-**Evidence**: Distribution: `<10t: 84 | 10-29t: 34 | 30-59t: 14 | 60-89t: 6 | 90+t: 0`
-
-84 of 139 RandomBot runs (60%) ended before turn 10. The Lesmesodon-like creodont is the most frequent killer across the log, appearing in a large number of 1–3 turn runs with the player at full fitness/energy/hydration — indicating instant ambush kills before the player has any chance to act. The mesonychid-like ground predator and pitviper together account for much of the rest of the short-run deaths.
-
-While RandomBot makes no attempt to flee, the sheer frequency of these encounters suggests the spawn rate for dangerous ground predators may be high. A new player would face the same encounter rates and many would die before understanding the game.
-
-**Question for George**: Is the current predator encounter frequency intentional at this difficulty stage? This is worth tracking across future bot runs to see if it shifts with ecological cycles.
+**Recommended action**: Update the compact death cause aggregation so it uses `deathContext.encounterAtDeath.name` where available, falling back to `deathContext.context.source`, and finally `unknown` only when neither is useful.
 
 ---
 
-### OBS-003: Pitviper and deadly poison are a major death category with no counterplay for the bot
+### OBS-002: Very high early death rate in RandomBot — 60% of deaths occur before turn 10
+
+**Severity**: Design / balance observation, not yet a confirmed bug
+**Evidence**: Compact distribution: `<10t: 84 | 10-29t: 34 | 30-59t: 14 | 60-89t: 6 | 90+t: 0`
+
+84 of 138 RandomBot deaths occurred before turn 10. The compact run summaries show repeated early deaths involving Lesmesodon-like creodont, pitviper, Gastornis, and mesonychid-like ground predator.
+
+Because RandomBot chooses randomly and often makes suicidal choices, this should not be treated as direct evidence that the game is unfair to a human player. It is still useful as a baseline: if future intelligent or human-like bot runs also show a very high sub-10-turn death rate, predator spawn pressure and opening survivability should be reviewed.
+
+**Recommended action**: Track this in future RandomBot and IntelligentBot reports rather than immediately changing spawn rates from this single RandomBot run.
+
+---
+
+### OBS-003: Pitviper and deadly poison are prominent in the visible run summaries
 
 **Severity**: Design observation
-**Evidence**: At least 8 runs ended from `"Untreated deadly poisoning kills you"` / `critical-poison-timer` reaching zero
+**Evidence**: Visible compact run summaries include pitviper ambush deaths and `Untreated deadly poisoning kills you` / `critical-poison-timer` deaths
 
-The pitviper's deadly venom has a 5-turn critical timer. The bot has no remedy-seeking behaviour, so once bitten it inevitably dies. A human player in the same position would need to find a remedy encounter within 5 turns, which is tight. The intelligent bot partially addresses this (it avoids `venomous_ambush` encounters), but ambush attacks can still land before the encounter is visible.
+Pitviper venom has a deadly critical timer. RandomBot has no remedy-seeking behaviour, so venom can become an inevitable death once applied. Human fairness cannot be judged from RandomBot alone, but this is an important mechanic to keep watching.
 
-Worth noting for when remedy/antidote mechanics are expanded.
+The IntelligentBot is designed to avoid `venomous_ambush` encounters when visible, but the screenshot-only run does not provide enough detail to confirm how it performs after bites or near hidden ambushes.
+
+**Recommended action**: In the next saved IntelligentBot run, specifically check poison deaths, hidden ambush bites, and whether any remedy/avoidance counterplay is actually available.
 
 ---
 
-### OBS-004: Drowning death — bot walked into water over 6 turns
+### OBS-004: Drowning death occurred in RandomBot run 13
 
-**Severity**: Low (expected bot limitation; design observation)
-**Evidence**: Run 13 — `"You drown." context: {source: "drowning", waterState: {inWater: true, turns: 6}}`
+**Severity**: Low for RandomBot; potential bot-navigation check for IntelligentBot
+**Evidence**: Run 13 death context: `source: "drowning"`, `waterState: {inWater: true, turns: 6}`
 
-RandomBot has no water-avoidance logic. The IntelligentBot's `intelligentMoveTowardWater` function approaches water to drink but does not currently distinguish between "standing at the water edge" and "entering the water tile". If the bot steps onto a water tile while navigating toward it, it could repeat this. Worth verifying with a saved IntelligentBot log.
+RandomBot has no water-avoidance logic, so one drowning death is not surprising. The more useful follow-up is to verify that IntelligentBot's water-seeking behaviour approaches drinkable water edges without stepping into water tiles and remaining there.
+
+**Recommended action**: Rerun IntelligentBot with saved logs and check whether `intelligentMoveTowardWater` ever pathfinds into actual water tiles rather than safe adjacent drink positions.
 
 ---
 
 ### OBS-005: WARN_STATIC_QUEUED_ENCOUNTER_DISAPPEARED — 1 occurrence
 
 **Severity**: Warning / low priority
-**Evidence**: Run 29, step 482, turn 17, at X53,Y42,Z0. Action: `investigate Messelornis-like bird`. After the investigation, the active encounter changed to `small carcass (kind=carcass)` and the queue dropped from 1 to 0.
+**Evidence**: Run 29, bot step 482, turn 17, X53/Y42/Z0. Action: `investigate Messelornis-like bird`. Before: active encounter `Messelornis-like bird`, queue length 1. After: active encounter `small carcass`, queue length 0.
 
-A static queued encounter vanished after an investigation action that should not resolve it. This has appeared in prior bot logs and is a known intermittent issue. No new information here — carrying forward.
+A queued encounter disappeared after an investigation action. This appears to be a recurring intermittent warning rather than a new failure introduced by the IntelligentBot work.
 
-**Status**: OPEN / low priority
+**Recommended action**: Keep open as low priority. Escalate if frequency increases, if it causes visible gameplay confusion, or if a focused reproduction is found.
 
 ---
 
@@ -109,18 +120,28 @@ A static queued encounter vanished after an investigation action that should not
 
 In rough priority order:
 
-1. **Death cause summary (OBS-001)** — Small tooling fix, high value for readability of all future bot reports. Read `encounterAtDeath.name` in the death cause summary.
+1. **Fix compact death cause aggregation (OBS-001)** — Small QA tooling fix with high value for future reports. Prefer encounter name where available.
 
-2. **Predator spawn rate review (OBS-002)** — Review Lesmesodon-like creodont and mesonychid-like ground predator spawn frequency. If intentional at this stage, note it here so it can be tracked across patches. A sub-10-turn median death rate makes it hard to distinguish signal from noise in longer bot runs.
+2. **Save a proper IntelligentBot log for comparison** — The screenshot result is promising but not enough for detailed behavioural review. Next IntelligentBot run should save at least compact + meta, and full log if there are warnings/errors.
 
-3. **IntelligentBot log saved for comparison** — The IntelligentBot data from this session was lost due to the save failure. Next test session should save both compact logs so a proper side-by-side comparison can be produced.
+3. **Track early death distribution across both bots (OBS-002)** — Do not rebalance from this RandomBot run alone, but keep the sub-10-turn death rate visible in future reports.
 
-4. **WARN_STATIC_QUEUED_ENCOUNTER_DISAPPEARED (OBS-005)** — Recurring but infrequent. If it reappears at higher frequency in future runs, escalate to a formal bug.
+4. **Watch pitviper/deadly poison outcomes (OBS-003)** — Especially in IntelligentBot and human-like play, where avoidance/remedy behaviour should matter.
 
-5. **Drowning via water navigation (OBS-004)** — Verify IntelligentBot doesn't enter water tiles when navigating toward water to drink. If it does, fix `intelligentMoveTowardWater` to exclude water tiles as destinations.
+5. **Verify IntelligentBot water navigation (OBS-004)** — Ensure thirst navigation targets water edges/drink actions, not drowning-prone water tiles.
+
+6. **Carry forward WARN_STATIC_QUEUED_ENCOUNTER_DISAPPEARED (OBS-005)** — Low priority unless frequency or gameplay impact increases.
+
+---
+
+## GPT Review Notes
+
+GPT checked the RandomBot figures against the saved compact and meta logs. The headline RandomBot figures match: 1000 actions, 139 runs recorded, 138 deaths, turn-limit stop, no errors, one warning.
+
+The main correction is interpretive: the IntelligentBot comparison should be treated as provisional because the log was not saved. It is fair to say the headline run count suggests improved survival, but not fair to draw detailed behavioural conclusions from screenshot-only evidence.
 
 ---
 
 *Runs included: 20260430-101214 (RandomBot), IntelligentBot screenshot (no run ID — log not saved)*
 *Draft prepared: 2026-04-30*
-*Status: DRAFT — awaiting GPT review before finalisation and commit*
+*GPT review added: 2026-04-30*

--- a/logs/consolidated/20260430-001-draft.md
+++ b/logs/consolidated/20260430-001-draft.md
@@ -1,0 +1,126 @@
+# Bot Run Consolidated Report — DRAFT
+
+**Reviewed by**: Claude (first draft — awaiting GPT review)
+**Review date**: 2026-04-30
+**Consolidated report ID**: 20260430-001
+
+---
+
+## Runs Analysed
+
+| Run ID | Bot | Date | Build | Actions | Runs | Deaths | Stop Reason | Log available |
+|--------|-----|------|-------|---------|------|--------|-------------|---------------|
+| 20260430-101214 | RandomBot | 2026-04-30 | v66.57_patch8_short_eco_cycles_2026-04-29 | 1000/1000 | 139 | 138 | turn limit reached | compact + full in repo |
+| *(screenshot)* | IntelligentBot | 2026-04-30 | v66.57 (branch: claude/intelligent-bot-agent-oCneM) | 1000/1000 | 71 | 70 | turn limit reached | **not saved — save failed (network error)** |
+
+*RandomBot source: `logs/bot-runs/20260430-101214/compact.txt`*
+*IntelligentBot data: screenshot evidence only. Numbers are reliable; per-run detail is unavailable.*
+
+---
+
+## Patch Gate Status
+
+| Check | RandomBot | IntelligentBot |
+|-------|-----------|----------------|
+| Action crashes / ERR_ACTION_EXCEPTION | NONE | NONE (screenshot) |
+| Turn-backwards errors | NONE | NONE (screenshot) |
+| Warnings requiring review | 1 | 0 (screenshot) |
+
+Both bots passed with no errors. The one warning (WARN_STATIC_QUEUED_ENCOUNTER_DISAPPEARED) is carried over from prior runs and is not new.
+
+---
+
+## Bot Comparison
+
+| Metric | RandomBot | IntelligentBot |
+|--------|-----------|----------------|
+| Actions | 1000 | 1000 |
+| Runs | 139 | 71 |
+| Deaths | 138 | 70 |
+| Death rate | 99.3% | 98.6% |
+| Avg turns per run | ~14 | ~(est.) 27 |
+| Median death turn | 7 | unknown |
+| Longest run | 75 turns | unknown |
+
+The IntelligentBot ran roughly half as many runs in the same number of actions, which means it survived roughly twice as long per run on average. This validates the heuristic approach. Both bots are still dying in almost every run, which is expected at this difficulty level and with these spawn rates.
+
+---
+
+## Observations
+
+### OBS-001: Death cause summary is uninformative — all 138 deaths recorded as "unknown"
+
+**Severity**: Low (QA tooling / observability issue)
+**Evidence**: `Death causes: unknown: 138` in compact summary
+
+The per-run data clearly shows named killers (Lesmesodon-like creodont, pitviper, mesonychid-like ground predator, etc.) in `deathContext.encounterAtDeath.name`. However, the death context `context.source` field is `"unknown"` for the majority of kills, and the compact summary reads from this field rather than from the encounter name.
+
+This means the top-level death cause breakdown is currently useless for identifying which predators are causing the most deaths. The summary should also (or instead) read `deathContext.encounterAtDeath.name` where available.
+
+**Recommended action**: Update death cause summary to use encounter name as the primary source, falling back to `context.source`.
+
+---
+
+### OBS-002: Very high sub-10-turn death rate — 60% of runs end before turn 10
+
+**Severity**: Design observation — may or may not need action
+**Evidence**: Distribution: `<10t: 84 | 10-29t: 34 | 30-59t: 14 | 60-89t: 6 | 90+t: 0`
+
+84 of 139 RandomBot runs (60%) ended before turn 10. The Lesmesodon-like creodont is the most frequent killer across the log, appearing in a large number of 1–3 turn runs with the player at full fitness/energy/hydration — indicating instant ambush kills before the player has any chance to act. The mesonychid-like ground predator and pitviper together account for much of the rest of the short-run deaths.
+
+While RandomBot makes no attempt to flee, the sheer frequency of these encounters suggests the spawn rate for dangerous ground predators may be high. A new player would face the same encounter rates and many would die before understanding the game.
+
+**Question for George**: Is the current predator encounter frequency intentional at this difficulty stage? This is worth tracking across future bot runs to see if it shifts with ecological cycles.
+
+---
+
+### OBS-003: Pitviper and deadly poison are a major death category with no counterplay for the bot
+
+**Severity**: Design observation
+**Evidence**: At least 8 runs ended from `"Untreated deadly poisoning kills you"` / `critical-poison-timer` reaching zero
+
+The pitviper's deadly venom has a 5-turn critical timer. The bot has no remedy-seeking behaviour, so once bitten it inevitably dies. A human player in the same position would need to find a remedy encounter within 5 turns, which is tight. The intelligent bot partially addresses this (it avoids `venomous_ambush` encounters), but ambush attacks can still land before the encounter is visible.
+
+Worth noting for when remedy/antidote mechanics are expanded.
+
+---
+
+### OBS-004: Drowning death — bot walked into water over 6 turns
+
+**Severity**: Low (expected bot limitation; design observation)
+**Evidence**: Run 13 — `"You drown." context: {source: "drowning", waterState: {inWater: true, turns: 6}}`
+
+RandomBot has no water-avoidance logic. The IntelligentBot's `intelligentMoveTowardWater` function approaches water to drink but does not currently distinguish between "standing at the water edge" and "entering the water tile". If the bot steps onto a water tile while navigating toward it, it could repeat this. Worth verifying with a saved IntelligentBot log.
+
+---
+
+### OBS-005: WARN_STATIC_QUEUED_ENCOUNTER_DISAPPEARED — 1 occurrence
+
+**Severity**: Warning / low priority
+**Evidence**: Run 29, step 482, turn 17, at X53,Y42,Z0. Action: `investigate Messelornis-like bird`. After the investigation, the active encounter changed to `small carcass (kind=carcass)` and the queue dropped from 1 to 0.
+
+A static queued encounter vanished after an investigation action that should not resolve it. This has appeared in prior bot logs and is a known intermittent issue. No new information here — carrying forward.
+
+**Status**: OPEN / low priority
+
+---
+
+## Notes for Next Patch
+
+In rough priority order:
+
+1. **Death cause summary (OBS-001)** — Small tooling fix, high value for readability of all future bot reports. Read `encounterAtDeath.name` in the death cause summary.
+
+2. **Predator spawn rate review (OBS-002)** — Review Lesmesodon-like creodont and mesonychid-like ground predator spawn frequency. If intentional at this stage, note it here so it can be tracked across patches. A sub-10-turn median death rate makes it hard to distinguish signal from noise in longer bot runs.
+
+3. **IntelligentBot log saved for comparison** — The IntelligentBot data from this session was lost due to the save failure. Next test session should save both compact logs so a proper side-by-side comparison can be produced.
+
+4. **WARN_STATIC_QUEUED_ENCOUNTER_DISAPPEARED (OBS-005)** — Recurring but infrequent. If it reappears at higher frequency in future runs, escalate to a formal bug.
+
+5. **Drowning via water navigation (OBS-004)** — Verify IntelligentBot doesn't enter water tiles when navigating toward water to drink. If it does, fix `intelligentMoveTowardWater` to exclude water tiles as destinations.
+
+---
+
+*Runs included: 20260430-101214 (RandomBot), IntelligentBot screenshot (no run ID — log not saved)*
+*Draft prepared: 2026-04-30*
+*Status: DRAFT — awaiting GPT review before finalisation and commit*


### PR DESCRIPTION
## Summary

Adds a GPT-reviewed draft consolidated bot report for the first saved RandomBot run and screenshot-only IntelligentBot comparison.

This is a QA/reporting PR only. It does not change gameplay, UI, bot code, app-loading files, or repo tooling.

## Scope check

- [ ] Gameplay logic / mechanics
- [ ] UI / layout / presentation
- [ ] Bot / debug / QA tools
- [ ] GitHub Pages / app loading / PWA files
- [x] Documentation / workflow only
- [x] Other: QA report under `logs/consolidated/`

## Known bug guardrails

- [x] Reviewed `docs/bug-guardrails.md`
- [x] Any applicable guardrail checks have been completed
- [x] If this PR fixes a bug/coding error, a new guardrail entry was added or an existing one was updated — not applicable, this PR is a report only
- [x] If no guardrail applies, state why here: report-only PR; does not change code or fix a bug

## Mandatory syntax/render safety check

Required for any PR touching `game/*.html`, `index.html`, `manifest.json`, bot/debug tooling, or app-loading behaviour.

- [ ] `node scripts/check_html_js_syntax.mjs` passed, or equivalent syntax check performed
- [ ] `game/play.html` opened in a browser
- [ ] Game renders without a blank or half-loaded screen
- [ ] Map is visible
- [ ] Player/status UI is visible
- [ ] Core action controls are visible
- [ ] At least one action/turn can be taken
- [ ] Browser console checked for red JavaScript errors
- [ ] If bot/debug tools were touched: bot can start and stop without crashing

> Syntax/render safety check not run. This PR only adds/updates a consolidated QA report and does not touch playable HTML, app-loading files, manifest/PWA files, or bot/debug code.

## Mandatory CHANGELOG reminder

- [ ] `CHANGELOG.txt` updated with a timestamped plain-English entry for this PR
- [ ] Entry states who made the change
- [ ] Entry states whether gameplay logic, UI/layout, bot/debug tools, app-loading behaviour, or documentation changed
- [x] If the changelog was intentionally not updated, explain why here: this is a bot/report artefact under `logs/consolidated/`, not a codebase/workflow change. The report itself is the retained record.

## Commit message check

- [x] No `claude.ai/code/session_...` URLs in the PR's latest report-review commit message

## What changed

- Added `logs/consolidated/20260430-001-draft.md`.
- Reviewed RandomBot headline figures against the saved compact/meta logs.
- Tightened the IntelligentBot conclusions because its run was screenshot-only and the detailed log was not saved.
- Preserved useful observations about death-cause aggregation, early death distribution, poison/pitviper outcomes, drowning/water navigation, and `WARN_STATIC_QUEUED_ENCOUNTER_DISAPPEARED`.

## Testing / review notes

- RandomBot source checked against:
  - `logs/bot-runs/20260430-101214/compact.txt`
  - `logs/bot-runs/20260430-101214/meta.json`
- No game render/smoke test run because this PR does not change playable or app-loading files.

## Reviewer confirmation

- `Bug guardrails reviewed; applicable checks passed.`
- `Syntax/render safety check not run.`
- `CHANGELOG not updated: report artefact only; report file is the retained record.`