### PR TITLE
Fix compact bot death-cause aggregation and dedupe runs

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+[2026-04-30 10:40 UTC | GPT]
+- Bot/debug/QA tooling fix: compact bot report death-cause aggregation now prefers encounter names and meaningful death context before falling back to `unknown`.
+- Compact death-cause summary now deduplicates run summaries by `runIndex` before counting to avoid duplicate death totals from repeated run-end records.
+- Updated both playable HTML files (`game/play.html` and `game/evolution_game_v66_57.html`) to keep bot export logic aligned.
+- No gameplay logic, UI/layout, app-loading behaviour, or playable mechanics changed.
+
 CHANGELOG — Evolution Game
 ==========================
 

--- a/docs/bug-guardrails.md
+++ b/docs/bug-guardrails.md
@@ -86,6 +86,37 @@ Do not describe a PR as ready to merge unless `CHANGELOG.txt` status is explicit
 
 ---
 
+## BG-003 — Bot compact death-cause summaries must use meaningful source fields and dedupe runs
+
+**Status:** Active guardrail
+
+**Observed failure:**
+Compact bot summaries reported deaths mostly as `unknown` and could over-count deaths because duplicate run summaries for the same `runIndex` were both counted.
+
+**Player/tester symptom:**
+QA evidence in compact exports became misleading: detailed run lines showed meaningful encounter/predator context, while the top-level death-cause rollup hid that context and inflated totals.
+
+**Root cause:**
+Death-cause aggregation used shallow fallback fields (`cause/type`) and did not deduplicate repeated per-run terminal summaries before counting.
+
+**Known affected area:**
+- `game/play.html`
+- `game/evolution_game_v66_57.html`
+- bot compact report/export functions (`compactDeathStats`, related helpers)
+
+**Future guardrail:**
+Compact report summaries must derive death causes from the richest available death context and must deduplicate by `runIndex` before aggregate counting.
+
+**Required PR check:**
+- Verify compact death-cause output contains meaningful encounter/context labels when present.
+- Verify duplicate terminal summaries for one `runIndex` do not increase death totals.
+- Run `node scripts/check_html_js_syntax.mjs` after HTML script edits.
+
+**Reviewer instruction:**
+If a compact report still shows mostly `unknown` while run-level context is present, or if duplicate run records inflate counts, block merge until fixed.
+
+---
+
 ## Entry template for future bugs
 
 ```md

--- a/game/evolution_game_v66_57.html
+++ b/game/evolution_game_v66_57.html
@@ -11902,8 +11902,42 @@ function compactRunLine(run) {
   return `Run ${run.runIndex}: reason=${run.reason}; steps=${run.steps}; botSteps=${run.startBotStep}->${run.endBotStep}; turns=${run.startTurn}->${run.endTurn}; dead=${finalState.dead}; F=${finalState.fitness}; E=${finalState.energy}; H=${finalState.hydration}; issues=${run.issues ? run.issues.length : 0}; deathContext=${deathContext ? compactSafeString(deathContext, 500) : "none"}`;
 }
 
+function botDeathCauseFromRun(run) {
+  const finalState = run && run.finalState ? run.finalState : {};
+  const deathContext = finalState.deathContext || (run && run.death && run.death.state && run.death.state.deathContext) || {};
+  const encounterName = deathContext && deathContext.encounterAtDeath && deathContext.encounterAtDeath.name;
+  if (encounterName) return String(encounterName);
+  const context = deathContext.context || {};
+  if (context.predator) return String(context.predator);
+  if (context.source && String(context.source).toLowerCase() !== "unknown") return String(context.source);
+  const message = [deathContext.message, context.message, finalState.deathReason, run && run.reason].filter(Boolean).join(" ").toLowerCase();
+  if (message.includes("drown")) return "drowning";
+  if (message.includes("dehydration")) return "dehydration";
+  if (message.includes("starvation") || message.includes("starve")) return "starvation";
+  if (message.includes("poison") || message.includes("venom")) return "poison/venom";
+  return "unknown";
+}
+
+function dedupeBotRunsByRunIndex(runs) {
+  const input = Array.isArray(runs) ? runs : [];
+  const seen = new Set();
+  const deduped = [];
+  input.forEach(run => {
+    if (!run) return;
+    const key = run.runIndex;
+    if (key === null || key === undefined) {
+      deduped.push(run);
+      return;
+    }
+    if (seen.has(key)) return;
+    seen.add(key);
+    deduped.push(run);
+  });
+  return deduped;
+}
+
 function compactDeathStats(runs) {
-  const completed = Array.isArray(runs) ? runs : [];
+  const completed = dedupeBotRunsByRunIndex(runs);
   const deathRuns = completed.filter(run => run && run.finalState && run.finalState.dead);
   const durations = deathRuns.map(run => Math.max(0, (run.endTurn || 0) - (run.startTurn || 0))).sort((a,b) => a-b);
   const mean = durations.length ? Math.round(durations.reduce((a,b) => a + b, 0) / durations.length) : "n/a";
@@ -11918,8 +11952,7 @@ function compactDeathStats(runs) {
   });
   const causes = {};
   deathRuns.forEach(run => {
-    const ctx = (run.finalState && run.finalState.deathContext) || (run.death && run.death.state && run.death.state.deathContext) || {};
-    const cause = ctx.cause || ctx.type || "unknown";
+    const cause = botDeathCauseFromRun(run);
     causes[cause] = (causes[cause] || 0) + 1;
   });
   const longest = completed.length ? Math.max(...completed.map(run => Math.max(0, (run.endTurn || 0) - (run.startTurn || 0)))) : 0;
@@ -11932,7 +11965,6 @@ function compactDeathStats(runs) {
     `Death causes: ${Object.entries(causes).sort((a,b)=>b[1]-a[1]).map(([k,v]) => `${k}: ${v}`).join(" | ") || "not recorded"}`
   ].join("\n");
 }
-
 function buildBotCompactLines(report) {
   const issueCountText = Object.entries(report.issueCounts || {}).sort((a,b) => b[1]-a[1]).map(([code, count]) => `${code}: ${count}`).join("\n") || "No issue codes.";
   const issueText = compactListBlock(report.issues || [], compactIssueLine, "No QA issues flagged.", 250, "recorded order");

--- a/game/play.html
+++ b/game/play.html
@@ -12109,8 +12109,42 @@ function compactRunLine(run) {
   return `Run ${run.runIndex}: reason=${run.reason}; steps=${run.steps}; botSteps=${run.startBotStep}->${run.endBotStep}; turns=${run.startTurn}->${run.endTurn}; dead=${finalState.dead}; F=${finalState.fitness}; E=${finalState.energy}; H=${finalState.hydration}; issues=${run.issues ? run.issues.length : 0}; deathContext=${deathContext ? compactSafeString(deathContext, 500) : "none"}`;
 }
 
+function botDeathCauseFromRun(run) {
+  const finalState = run && run.finalState ? run.finalState : {};
+  const deathContext = finalState.deathContext || (run && run.death && run.death.state && run.death.state.deathContext) || {};
+  const encounterName = deathContext && deathContext.encounterAtDeath && deathContext.encounterAtDeath.name;
+  if (encounterName) return String(encounterName);
+  const context = deathContext.context || {};
+  if (context.predator) return String(context.predator);
+  if (context.source && String(context.source).toLowerCase() !== "unknown") return String(context.source);
+  const message = [deathContext.message, context.message, finalState.deathReason, run && run.reason].filter(Boolean).join(" ").toLowerCase();
+  if (message.includes("drown")) return "drowning";
+  if (message.includes("dehydration")) return "dehydration";
+  if (message.includes("starvation") || message.includes("starve")) return "starvation";
+  if (message.includes("poison") || message.includes("venom")) return "poison/venom";
+  return "unknown";
+}
+
+function dedupeBotRunsByRunIndex(runs) {
+  const input = Array.isArray(runs) ? runs : [];
+  const seen = new Set();
+  const deduped = [];
+  input.forEach(run => {
+    if (!run) return;
+    const key = run.runIndex;
+    if (key === null || key === undefined) {
+      deduped.push(run);
+      return;
+    }
+    if (seen.has(key)) return;
+    seen.add(key);
+    deduped.push(run);
+  });
+  return deduped;
+}
+
 function compactDeathStats(runs) {
-  const completed = Array.isArray(runs) ? runs : [];
+  const completed = dedupeBotRunsByRunIndex(runs);
   const deathRuns = completed.filter(run => run && run.finalState && run.finalState.dead);
   const durations = deathRuns.map(run => Math.max(0, (run.endTurn || 0) - (run.startTurn || 0))).sort((a,b) => a-b);
   const mean = durations.length ? Math.round(durations.reduce((a,b) => a + b, 0) / durations.length) : "n/a";
@@ -12125,8 +12159,7 @@ function compactDeathStats(runs) {
   });
   const causes = {};
   deathRuns.forEach(run => {
-    const ctx = (run.finalState && run.finalState.deathContext) || (run.death && run.death.state && run.death.state.deathContext) || {};
-    const cause = ctx.cause || ctx.type || "unknown";
+    const cause = botDeathCauseFromRun(run);
     causes[cause] = (causes[cause] || 0) + 1;
   });
   const longest = completed.length ? Math.max(...completed.map(run => Math.max(0, (run.endTurn || 0) - (run.startTurn || 0)))) : 0;
@@ -12139,7 +12172,6 @@ function compactDeathStats(runs) {
     `Death causes: ${Object.entries(causes).sort((a,b)=>b[1]-a[1]).map(([k,v]) => `${k}: ${v}`).join(" | ") || "not recorded"}`
   ].join("\n");
 }
-
 function buildBotCompactLines(report) {
   const issueCountText = Object.entries(report.issueCounts || {}).sort((a,b) => b[1]-a[1]).map(([code, count]) => `${code}: ${count}`).join("\n") || "No issue codes.";
   const issueText = compactListBlock(report.issues || [], compactIssueLine, "No QA issues flagged.", 250, "recorded order");


### PR DESCRIPTION
### Motivation
- Compact bot reports were collapsing death causes to `unknown` despite richer per-run context and could double-count deaths when duplicate end-of-run summaries for the same `runIndex` were present. 
- The change is narrowly scoped to bot/debug/QA tooling so future compact exports provide meaningful, de-duplicated death-cause rollups without touching gameplay, UI, or app-loading behavior.

### Description
- Added `botDeathCauseFromRun(run)` which extracts a preferred death label in order: `deathContext.encounterAtDeath.name`, `deathContext.context.predator`, non-`unknown` `deathContext.context.source`, message-derived categories (`drowning`, `dehydration`, `starvation`, `poison/venom`), then `unknown` as a fallback. 
- Added `dedupeBotRunsByRunIndex(runs)` that keeps the first summary for each `runIndex` and wired it into `compactDeathStats(runs)` so aggregation does not double-count duplicate terminal summaries. 
- Updated both playable builds (`game/play.html` and `game/evolution_game_v66_57.html`) to include the new helpers and to use them when building the compact report, and updated `docs/bug-guardrails.md` and `CHANGELOG.txt` to record the fix and a new guardrail (BG-003). 

### Testing
- Ran the mandatory syntax/render safety check: `node scripts/check_html_js_syntax.mjs` and it passed for `game/play.html` and `game/evolution_game_v66_57.html`. 
- Verified the new helpers and usages are present in both HTML files by searching for `botDeathCauseFromRun` and `dedupeBotRunsByRunIndex`. 
- Browser smoke tests were not executed in this non-browser CLI environment and are noted as not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35fe1f3448328a9f7c662d740c585)