### PR TITLE
Centralize narrative sanitization and polish player-facing dialogue; add audit & consensus plan

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,53 @@
+[2026-05-01 patch19 | GPT]
+- Added `CONSENSUS_DIALOGUE_PLAN.txt` comparing four dialogue solution variants (v1-v4) and defining a consensus implementation plan.
+- Includes variant strengths/weaknesses, reject list, root-cause-oriented recommended approach, exact target functions/files, acceptance checks, and staged-PR recommendation.
+- Documentation/planning change only; no gameplay mechanics, spawn rates, bot logic, map generation, or survival-balance changes.
+
+[2026-05-01 patch18 | GPT]
+- Added `PLAYER_FACING_DIALOGUE_AUDIT.txt` as a full audit of player-facing dialogue sources.
+- Audit covers combat/damage, feeding/drinking, poison/alcohol/status, growth, perception/look/senses, encounter-card/multi-encounter UI text, group behaviour, raw debug/code leak risks, anti-pattern inventory, and a structural fix plan.
+- Documentation/audit change only; no gameplay mechanics, spawn rates, bot logic, map generation, or survival balance changes.
+
+[2026-05-01 patch17 | GPT]
+- Centralised/cleaned player-facing narrative output through shared sanitisation and narration text guards.
+- Removed raw debug/code leak and hardened object interpolation handling for narration/cue/log text.
+- Reduced number-first/system-log phrasing in main player narration pathways.
+- Fixed drink labels on food resources by restricting drink actions to true water sources.
+- Reduced duplicate Look/scene/sense output and removed residual "Last look" replay.
+- Clarified encounter card/noise hierarchy by removing player-facing "Encounter:" / "same tile" system labels.
+- Improved plausibility guards for feeding/competition text.
+- No intentional change to spawn rates, bot logic, survival balance, map generation, or damage values.
+
+[2026-05-01 patch16 | GPT]
+- Follow-up presentation-system cleanup for stacked outcomes and narration consistency.
+- Removed additional look/card duplication by removing per-card "Look result" replay in encounter cards.
+- Reworked several core outcome messages (growth, poison, alcohol, feeding, clean-kill, group cohesion, group injury) away from system/number-first phrasing toward sensory-first narration.
+- Kept numerical effects in gameplay/UI systems while reducing mechanical wording in primary player-facing narration.
+- No intentional changes to core balance, spawn rates, bot logic, map generation, or survival maths.
+
+[2026-05-01 patch15 | GPT]
+- Fixed narration/presentation logic after text polish.
+- Removed object interpolation bug in Look narration context handling.
+- Reduced stale/over-certain Look warning phrasing for cross-layer threat cues.
+- Clarified transient vs interactable presentation by reducing redundant multi-encounter system banners and removing player-facing queued Focus button noise.
+- Removed noisy multi-encounter labels and duplicate "also in this tile" card text.
+- Improved plausibility guards for feeding/competition text (prevents implausible small nectar-bird feeding outcomes).
+- Improved sting/attack narration so repeated stings and kill-with-sting outcomes are called out clearly.
+- No intentional changes to core balance, spawn rates, bot logic, map generation, or survival maths.
+
+[2026-05-01 patch14 | GPT]
+- Follow-up text-only narration polish.
+- Reduced repeated scene/sense/card phrasing by separating short sensory cues from encounter-card detail text.
+- Added variation pools for common sensory wording (nearby movement, uncertain movement, forage scent cues, wet/still-air smell lines) to reduce repetitive debug-like phrasing.
+- Improved investigation prose tone for uncertain food/defence reads so interpretation sounds observational rather than clinical.
+- No intentional gameplay mechanics, bot logic, spawn rates, hydration/death logic, movement, map generation, or encounter persistence changes.
+
+[2026-05-01 patch13 | GPT]
+- Text-only narration/action-label patch.
+- Look output and encounter flavour phrasing were revised to read as restrained natural-history narration rather than debug-like scan text.
+- Drink labels were clarified so water-source actions read explicitly as water interactions (for example "drink at water edge" / "drink from water") instead of a generic "drink" label.
+- No intentional gameplay mechanics, bot logic, spawn weights, hydration/death logic, encounter persistence, queue handling, map generation, or UI layout changes.
+
 [2026-05-01 patch12 | Claude]
 IntelligentBot resource discipline and observability — 7 targeted fixes from post-Patch11 run 082425 analysis.
 - Fix A (CRITICAL): Cross-run threat memory false positives. hasRecentAerialThreat() and hasRecentGroundThreat() now guard against t.turn > now (previous-run threats stored with old turn numbers that appear "recent" when player.turn resets to 0 after death). This was the root cause of the Run 10 ground-look bootstrap failure: the aerial raptor from the prior run was flagged as a recent threat at turn 0, blocking the ground-bootstrap climb, causing the bot to take 'look' instead of climbing immediately and then dying to mesonychid on turn 3.

--- a/CONSENSUS_DIALOGUE_PLAN.txt
+++ b/CONSENSUS_DIALOGUE_PLAN.txt
@@ -1,0 +1,140 @@
+CONSENSUS DIALOGUE PLAN
+Repo: gy8s/evolution-game
+Date: 2026-05-01 UTC
+Task: Compare four dialogue-audit/fix variants (v1-v4) and define consensus implementation plan.
+Status: Review/synthesis only. No merge or implementation in this step.
+
+Assumptions and evidence basis
+- The repository currently contains one finalized comparison/audit branch and one prior implementation branch.
+- "v1-v4" are treated as four sequential solution variants from recent iterations (text-narration pass, dedup/sensory polish, encounter narration logic cleanup, central sanitize/audit pass).
+- This synthesis uses the currently available code state + prior variant summaries.
+
+====================================================================
+COMPARISON TABLE
+====================================================================
+
+| Variant | Files changed (typical) | Scope | Strengths | Weaknesses | Missed requirements | Break risk | Root-cause vs surface | Gameplay-change risk |
+|---|---|---|---|---|---|---|---|---|
+| v1 (initial narration pass) | `game/play.html`, `CHANGELOG.txt` | Text wording + drink labels + look prose | Fast tone improvement; introduced context drink labels; started look prose helper | Mostly surface text edits; duplication + stale-warning architecture still present | Multi-channel dedupe, certainty tiers, central output control | Low-Med (many string touches) | Mostly surface | Low |
+| v2 (dedup/sensory polish) | `game/play.html`, `CHANGELOG.txt` | Cue/card split; sensory variants; investigation prose improvements | Better cue/card separation; reduced robotic repetition; improved uncertainty prose | Still many direct emitters (`addLog`/`setNarration`) across systems; no unified turn-output model | Full anti-pattern elimination, stack sequencing, single event channel | Medium | Mixed (partial root cause) | Low |
+| v3 (encounter logic cleanup) | `game/play.html`, `CHANGELOG.txt` | Encounter presentation noise reduction, focus removal, plausibility guard, wasp/constrictor lines | Tackled systemic presentation noise (`Focus`, "same tile", stack text); fixed implausible feeding class | Outcome sequencing still fragmented; several number-first and generic combat lines remained | Centralized controller, full status/combat/feed normalization | Medium | Mixed | Low-Med (touches encounter flow presentation) |
+| v4 (sanitization + audit pass) | `game/play.html`, `PLAYER_FACING_DIALOGUE_AUDIT.txt`, `CHANGELOG.txt` | Added sanitization guard; broad inventory of bad templates; removed code leak class | Best root-cause direction: safety gate + explicit full audit + architectural plan | Not full implementation of central narrative controller yet; still many direct legacy templates | Unified event model + builder pipeline | Medium (broad hooks in output path) | Most root-cause aligned | Low (if bounded to presentation only) |
+
+====================================================================
+BEST IDEAS TO KEEP
+====================================================================
+
+1) Best from v1
+- Context-safe drink labels and water-source wording discipline.
+- Initial look narration helper insertion and tone guard comment.
+
+2) Best from v2
+- Separation model: short sensory cue vs encounter card detail vs investigation interpretation.
+- Sensory variation pools for non-repetitive perception.
+
+3) Best from v3
+- Remove player-facing queue/focus/system-noise labels.
+- Plausibility guard pattern for impossible feeding pairings.
+- Better threat-specific narration (e.g., constrictor/wasp handling paths).
+
+4) Best from v4
+- `sanitizeNarrativeText()` as output safety gate.
+- Full audit inventory (`PLAYER_FACING_DIALOGUE_AUDIT.txt`) with anti-pattern map and function-level hotspots.
+- Clear root-cause framing: many independent text emitters need central orchestration.
+
+====================================================================
+THINGS TO REJECT BY VARIANT
+====================================================================
+
+Reject from v1
+- One-off string replacement approach without architecture changes.
+
+Reject from v2
+- Treating duplication mainly as wording problem rather than channel ownership problem.
+
+Reject from v3
+- Ad-hoc narrative cleanup in many isolated functions without common event/output contract.
+
+Reject from v4
+- Expanding sanitization usage without completing event-assembly architecture can hide but not solve all coherence issues.
+
+====================================================================
+FINAL RECOMMENDED APPROACH
+====================================================================
+
+Adopt v4 as base, then execute staged architecture refactor:
+A) Build a single turn-output controller (presentation layer only).
+B) Convert major systems to emit structured events, not direct prose.
+C) Generate channels once per turn:
+   - primary event box
+   - scene continuity
+   - sense lines
+   - encounter card detail
+D) Keep numbers in stats/debug channels, not primary prose.
+E) Maintain uncertainty tiers for perception/threat warnings.
+
+====================================================================
+EXACT FILES/FUNCTIONS TO CHANGE (NEXT IMPLEMENTATION PATCH)
+====================================================================
+
+Primary target
+- `game/play.html`
+
+Phase 1 (output boundary + channel ownership)
+- `addLog()`
+- `setNarration()`
+- `renderSenses()`
+- `renderLogPanel()` / outcome panel helpers
+- `formatCueText()`
+
+Phase 2 (event emitters to structured events)
+- Combat: `attack()`, `exposeCarelessActionToThreat()`, predator reaction functions
+- Feeding: `eat()`, `eatCarcass()`, `drinkWater()`, swarm handlers
+- Conditions: `tickPoison()`, `tickAlcohol()`, `applyPoison()`, growth block in turn progression
+- Group: `changeGroupCohesion()`, `stressGroupForRisk()`
+- Perception: `lookAround()`, remote-sense builders (`makeClue`, ambient cue generators)
+- Encounter stack/UI: `setTileEncounterStack()`, queued card render helpers
+
+Phase 3 (new helpers to add)
+- `buildTurnNarrative(events, state)`
+- `buildCombatNarrative(event, state)`
+- `buildFeedingNarrative(event, state)`
+- `buildConditionNarrative(event, state)`
+- `buildGrowthNarrative(event, state)`
+- `buildGroupNarrative(event, state)`
+- `buildSenseLines(state, events)`
+- `suppressDuplicateNarration(lines)`
+
+Documentation support
+- `PLAYER_FACING_DIALOGUE_AUDIT.txt` (keep updated as checklist)
+- `CHANGELOG.txt` entry per patch stage
+
+====================================================================
+SPECIFIC ACCEPTANCE CHECKS (FOR IMPLEMENTATION PRs)
+====================================================================
+
+1. No raw JS/debug leaks in UI text.
+2. No `[object Object]` in any player-facing channel.
+3. No non-water "Drink from water" labels on food resources.
+4. No player-facing system labels: "Encounter:", "Main threat/opportunity", "Also in this tile", "same tile:".
+5. Look output appears once per turn action (no scene/sense replay dump).
+6. No number-first primary narration for damage/energy/hydration/poison/alcohol/growth/cohesion.
+7. Damage narration includes physical mechanism.
+8. Group hunting/injury narration differs from solo where applicable.
+9. Threat language certainty scales with visibility/actionability.
+10. Syntax check passes (`node scripts/check_html_js_syntax.mjs`).
+11. Browser smoke check verifies map/status/actions/cards render.
+
+====================================================================
+ONE PATCH OR STAGED?
+====================================================================
+
+Recommendation: STAGED PRs (3 stages)
+- Stage 1: Output channel ownership + dedupe guardrails (lowest risk)
+- Stage 2: Structured event emitters for combat/feed/conditions/group
+- Stage 3: Perception certainty + multi-outcome sequencing polish
+
+Why staged
+- Safer rollback and reviewability.
+- Reduces regression risk in a large monolithic HTML script.
+- Aligns with repo policy favoring focused patches.

--- a/PLAYER_FACING_DIALOGUE_AUDIT.txt
+++ b/PLAYER_FACING_DIALOGUE_AUDIT.txt
@@ -1,0 +1,303 @@
+PLAYER-FACING DIALOGUE AUDIT
+Repo: gy8s/evolution-game
+Date: 2026-05-01 (UTC)
+Scope: Full player-facing text-source audit (no gameplay/balance changes in this patch)
+
+Method
+- Audited whole repository text sources with targeted search + direct source inspection.
+- Primary player-facing runtime text is concentrated in `game/play.html`.
+- Searched for emitters (`addLog`, `setNarration`, cue/card render paths) and known anti-pattern templates.
+
+====================================================================
+1) COMBAT / DAMAGE TEXT
+====================================================================
+
+1.1 Generic "Damage: X" templates
+- File: game/play.html
+- Function(s): `resolveLianaBridgeCrossing`, `largeConstrictorCloseInvestigationReaction`, `attack`, predator reaction blocks
+- Current templates (examples):
+  - "The lianas slip under you... Damage: ${damage}." (L2763)
+  - "...reacts to your close attention and coils. Damage: ${damage}." (L9488)
+  - "...but it turns the attack into a coil. Damage: ${damage}." (L10032)
+  - "...but it strikes as you close. Damage: ${damage}." (L10047)
+  - "You fail to kill ... Damage: ${damage}." (L10134)
+- Why bad:
+  - Number-first and mechanism-light.
+  - Mixes UI-stat reporting with narrative channel.
+- Replacement pattern:
+  - Physical mechanism first, numbers in stat UI/debug only.
+  - e.g. constrictor: coil pressure; spider: fangs; wasp: sting; bird: claws/wing buffet; fall: impact.
+
+1.2 Generic kill/fail outcomes
+- File: game/play.html
+- Function: `attack`
+- Current templates:
+  - "You kill the ${target.name}, but take ${damage} damage." (L10110)
+  - "You catch the ${target.name} before it reaches cover. The struggle is brief." (L10114)
+  - "You fail to kill the ${target.name}..." (L10134, L10141)
+  - "Attack failed. The ${target.name} escapes." (L10064)
+- Why bad:
+  - Outcome clarity exists, but repeated skeletal structure remains.
+  - Does not consistently encode causal mechanism of injury.
+- Replacement pattern:
+  - Structured combat narrative builder:
+    1) action intent, 2) contact moment, 3) return harm mechanism, 4) resolution.
+
+1.3 Predator/event damage without mechanism detail
+- File: game/play.html
+- Function(s): water risk, peril checks, pursuit reactions
+- Current templates:
+  - "Drowning risk: fitness -${damage}." (L2924)
+  - "The ${e.name} attacks. Damage: ${damage}." (L8450, L8470)
+- Why bad:
+  - Simulation math surfaced directly in primary channel.
+- Replacement pattern:
+  - Describe physical event (lungs/breath/fall/impact/bite) and leave deltas to UI/debug.
+
+====================================================================
+2) FEEDING / EATING / DRINKING TEXT
+====================================================================
+
+2.1 Numeric feeding templates (energy/hydration deltas)
+- File: game/play.html
+- Function(s): `pickOffSwarmIndividuals`, `concealFocusedFood`, `eat`, `eatCarcass`, `drinkWater`
+- Current templates (examples):
+  - "Energy +${...}, fitness -${...}" (L7163, L7165, L7167, L10428)
+  - "...full benefit... Energy +... Hydration +..." (L7433, L7437)
+  - "You drink ... Energy -${energyLoss}.${hydrationText(gain)}" (L10346, L10365)
+- Why bad:
+  - Numbers dominate prose and create mechanical tone.
+- Replacement pattern:
+  - Narrative-first feeding/drinking line; values shown in status chips / optional compact summary panel.
+
+2.2 Drink verb misuse risk
+- File: game/play.html
+- Function: `eat`
+- Current template:
+  - `eatVerb = hydration > energy ? "drink from" : "eat"` (L10546)
+- Why bad:
+  - Can still produce awkward food wording for high-hydration food items.
+- Replacement pattern:
+  - Action labels and verbs should be source-typed:
+    - water sources => drink,
+    - food/nest/carcass => eat/feed.
+
+2.3 Flat carcass/feed lines
+- File: game/play.html
+- Function: `eatCarcass`
+- Current templates:
+  - "You feed from the ${carcass.name} while keeping watch..." (L10583)
+  - Rot follow-up lines often generic.
+- Why bad:
+  - Better than older text, but still templated and repeated in long runs.
+- Replacement pattern:
+  - Rot stage-specific narration pool + risk continuity without stat deltas.
+
+====================================================================
+3) POISON / ALCOHOL / STATUS TEXT
+====================================================================
+
+3.1 Poison status text still system-like in places
+- File: game/play.html
+- Function(s): `tickPoison`, `applyPoison`
+- Current templates:
+  - "Critical poisoning: ${turns} turns to find a remedy." (L3944)
+  - "Poison worsens: ${severity}." / "Poisoned: ${severity}." (L10740)
+- Why bad:
+  - Exposes severity labels/duration in primary channel.
+- Replacement pattern:
+  - Experience-first progression language; severity/duration in UI chip.
+
+3.2 Alcohol duration/mechanic exposure
+- File: game/play.html
+- Function(s): `tickAlcohol`, status chip text
+- Current templates:
+  - "...still has not passed." (improved prose, L3992)
+  - UI detail: `${turns} turns; senses/reactions down` (L13163)
+- Why bad:
+  - Main narrative mostly improved; UI detail acceptable, but ensure no narrative channel duplication of durations.
+- Replacement pattern:
+  - Keep durations only in UI/status panel; narrative stays sensory.
+
+====================================================================
+4) GROWTH / STAT PROGRESSION TEXT
+====================================================================
+
+4.1 Growth still split between prose and hidden numeric event
+- File: game/play.html
+- Function: turn progression/growth block
+- Current templates:
+  - "You feel growth in your frame..." (L3820)
+  - plus internal numeric size update before narration.
+- Why flagged:
+  - Narrative line is good, but architecture still direct from system block rather than centralized output controller.
+- Replacement pattern:
+  - Route growth event through unified narrative event builder with optional secondary UI stat delta.
+
+====================================================================
+5) PERCEPTION / LOOK / SENSES TEXT
+====================================================================
+
+5.1 Over-certain threat guidance in probabilistic look results
+- File: game/play.html
+- Function: `composeLookNarration`, `lookAround`
+- Current templates:
+  - "Treat this as active risk..." (L12873)
+  - certainty phrases generated from probabilistic checks (L12965-L12969)
+- Why bad:
+  - Better than prior, but certainty language can still over-read stale/moving cues.
+- Replacement pattern:
+  - certainty tiers tied to visibility/reachability/actionability.
+
+5.2 Duplicate cue construction pathways
+- File: game/play.html
+- Function(s): `lookAround`, `renderSenses`, `updateRemoteSenses`
+- Current issue:
+  - Multiple systems can narrate similar signals in same turn (look + ambient + encounter reveal).
+- Why bad:
+  - Can reintroduce duplication and contradictory emphasis.
+- Replacement pattern:
+  - Single turn narrative controller that assembles channel outputs once per turn.
+
+5.3 Repetitive sensory pools still possible
+- File: game/play.html
+- Function(s): `makeClue`, `randomAmbientSound`, `randomAmbientSmell`
+- Current issue:
+  - Variation exists but no de-dup merge by semantic class (e.g., repeated musk/rot cues from multiple dirs).
+- Replacement pattern:
+  - Same-turn semantic dedupe + merge line ("from multiple directions...").
+
+====================================================================
+6) ENCOUNTER CARDS / MULTI-ENCOUNTER UI TEXT
+====================================================================
+
+6.1 Residual system-structure language in encounter stacking
+- File: game/play.html
+- Function: `setTileEncounterStack`
+- Current templates:
+  - "You notice several things at once... is closest." (L7595)
+  - "Several encounters overlap here... is nearest." (L7600)
+- Why bad:
+  - Still narrates list-management rather than ecological scene relation.
+- Replacement pattern:
+  - Relationship narration (e.g., wasp over torn fruit) via pairing/scene synthesis.
+
+6.2 Card/cue duplication risk persists via fallbacks
+- File: game/play.html
+- Function(s): `shortEncounterCue`, `cardDetailForEncounter`, card render
+- Current issue:
+  - Improved, but fallbacks can still collapse into similar lines for under-authored entities.
+- Replacement pattern:
+  - Enforce channel separation: cue short factual, card behavioral detail, narration atmospheric.
+
+====================================================================
+7) GROUP BEHAVIOUR TEXT
+====================================================================
+
+7.1 Group cohesion messaging still centralized but generic
+- File: game/play.html
+- Function: `changeGroupCohesion`
+- Current templates:
+  - "The group hesitates around you; trust thins..." (L5874)
+  - "...moves with you more confidently." (L5875)
+- Why bad:
+  - Better than numeric logs; still low variety across contexts.
+- Replacement pattern:
+  - Context-aware variants based on trigger (food error, failed hunt, repeated risk, abandonment).
+
+7.2 Group injury text improved but not tied to cause-specific mechanism
+- File: game/play.html
+- Function: `stressGroupForRisk`
+- Current template:
+  - "...takes the worst of it and pulls back injured." (L5924)
+- Why bad:
+  - Lacks attacker-specific mechanism and can feel generic.
+- Replacement pattern:
+  - Cause-bound variants (fangs, sting, fall, crush, bite).
+
+====================================================================
+8) RAW DEBUG / CODE LEAK SOURCES
+====================================================================
+
+8.1 Historical raw JS leak vector confirmed
+- File: game/play.html
+- Prior observed leak string: `const actorSize = Number(actor.size || 1);`
+- Root-risk class:
+  - Broken file tail or unresolved merge artifacts can render literal code in DOM.
+- Current mitigation:
+  - Stray tail snippet removed in recent patch; syntax check gate catches parse breaks.
+- Additional recommendation:
+  - Add CI/content guard scanning for forbidden tokens in rendered text payloads.
+
+8.2 Object interpolation leak class
+- File: game/play.html
+- Path(s): narration/cue formatting
+- Risk:
+  - `[object Object]` when non-string interpolated.
+- Current mitigation:
+  - `sanitizeNarrativeText()` now guards addLog/setNarration/formatCueText.
+- Remaining risk:
+  - Any direct template string outside these pathways.
+
+====================================================================
+9) GLOBAL ANTI-PATTERN INVENTORY
+====================================================================
+
+A) Number-first narration (damage/energy/hydration turns/severity).
+B) System labels in prose (encounter structure wording, nearest/closest management text).
+C) Generic kill/fail attack formulas without physical mechanism.
+D) Multi-outcome stacking as separate unrelated lines rather than linked sequence.
+E) Perception certainty mismatch (probabilistic signs narrated too strongly).
+F) Sensory duplication within same turn from independent emitters.
+G) Insufficient encounter-channel contract (event box vs scene vs senses vs card).
+H) Direct string emission from many subsystems (no single narrative controller).
+
+====================================================================
+10) FIX PLAN (STRUCTURAL)
+====================================================================
+
+Priority 1 — Create a single narrative output controller
+- Add central builder in `game/play.html` (or split module in later refactor):
+  - `buildTurnNarrative(events, state)`
+  - `emitPrimaryEvent(text)`
+  - `emitSceneContinuity(text)`
+  - `emitSenseLines({see,hear,smell})`
+  - `emitEncounterCards(encounters)`
+- Enforce one write pass per turn/channel, not ad-hoc `addLog` everywhere.
+
+Priority 2 — Event model standardization
+- Convert core systems to emit structured events:
+  - combat, feeding, conditions, growth, group, perception, hazards.
+- Each event carries:
+  - actor/target/cause/mechanism/certainty/visibility/actionability.
+
+Priority 3 — Narrative builders by domain
+- `buildCombatNarrative(event)` with mechanism dictionaries by species/profile.
+- `buildFeedingNarrative(event)` source-aware (water vs carcass vs fruit vs nest).
+- `buildConditionNarrative(event)` poison/alcohol progression language.
+- `buildGroupNarrative(event)` observed behavior style.
+- `buildPerceptionNarrative(event)` certainty-scaled phrasing.
+
+Priority 4 — De-duplication and suppression
+- `suppressDuplicateNarration(lines)` semantic dedupe by class+direction.
+- Same-turn merge for smell/hear classes.
+- Prevent channel repeats of same sentence root.
+
+Priority 5 — Safe text boundary
+- Keep `sanitizeNarrativeText` as final output gate for all user-visible channels.
+- Add test/check for banned patterns in player text:
+  - `[object Object]`, `Damage:`, `Energy +`, `Hydration +`, `Encounter:` etc.
+
+Priority 6 — What is string replacement vs refactor
+- String-only quick wins:
+  - residual `Damage:` and `Energy +` phrases.
+  - residual structure labels (nearest/closest phrasing).
+- Structural refactor required:
+  - multi-outcome coherence,
+  - certainty scaling,
+  - cross-channel dedupe,
+  - central event-to-text architecture.
+
+Audit completeness note
+- Full repository text-source audit performed.
+- Runtime player-facing sources are overwhelmingly in `game/play.html`.

--- a/game/play.html
+++ b/game/play.html
@@ -807,8 +807,8 @@ const encounters = {
     kind: "forage", name: "ant trail", icon: "🐜", className: "food",
     canInvestigate: true, portions: 1, energy: 4,
     poison: {severity: "mild", rank: 1, toxinType: "irritant", lethal: false, turns: 2, damage: 1, warning: "Biting ants / acid"},
-    seen: "A dark ordinary-ant trail runs in a purposeful line. The workers bite if disturbed, but this is not a giant-ant trail.",
-    investigated: "The trail has a direction, not just a smell. One way leads toward ants; the other way leads toward whatever they are feeding on."
+    seen: "A dark line of ants travels with purpose through the leaf litter. It hints at food nearby, and a swarm of biting bodies if disturbed.",
+    investigated: "The trail runs with intent, not chaos. One direction returns to the colony; the other may lead to fruit, carrion, grubs, or conflict."
   },
 
   antNest: {
@@ -888,6 +888,7 @@ const encounters = {
     canInvestigate: true, portions: 1, energy: 6,
     poison: null,
     seen: "A millipede coils beneath a wet leaf. Slow does not always mean safe.",
+    cardDetail: "It remains tightly coiled, glossy segments catching what little light reaches the forest floor.",
     investigationDetails: ["Its shape and movement are clear, but the important question is chemical defence.", "You look for warning smell, colour, and whether predators have avoided it. The signs suggest risk, but not certainty.", "This millipede type is becoming familiar. Some are defended, some are harmless mimics, and some are worse than they look."],
     investigated: "It is tempting because it is slow, but millipedes can punish a careless mouthful."
   },
@@ -936,6 +937,7 @@ const encounters = {
     canInvestigate: true, portions: 3, energy: 18,
     poison: null,
     seen: "A soft fallen fruit lies among leaves, bruised but rich with sugar.",
+    cardDetail: "The skin is split and damp with sugar scent; insects are already feeding at the torn edge.",
     investigationDetails: [
       "The bruised flesh smells sweet, not rotten. Tiny insects are already feeding in the split skin.",
       "The fruit is soft enough to eat quickly, but the scent will not stay private for long.",
@@ -1250,7 +1252,7 @@ const encounters = {
     dangerProfile: "predator", temperament: "hunter", pursuitType: "air", canInvestigate: true,
     fitness: 95, size: 28, speed: 85, agility: 70, aggression: 75, food: 80,
     poison: null,
-    seen: "A large raptor passes above the canopy, turning its head as it searches for movement."
+    seen: "High above the canopy, a broad-winged raptor turns on warm air, searching for the smallest mistake below."
   },
 
   owl: {
@@ -1258,7 +1260,7 @@ const encounters = {
     dangerProfile: "predator", temperament: "hunter", pursuitType: "air", canInvestigate: true,
     fitness: 80, size: 18, speed: 65, agility: 80, aggression: 65, food: 55,
     poison: null,
-    seen: "An owl shape sits silent against the trunk, eyes fixed and unreadable."
+    seen: "Pressed against the trunk, an owl holds perfectly still. Only the eyes move, measuring the gaps between leaves."
   },
 
   pakicetus: {
@@ -1316,6 +1318,7 @@ const encounters = {
     fitness: 100, size: 55, speed: 45, agility: 25, aggression: 55, food: 160,
     poison: null,
     seen: "A huge flightless bird steps between the trees, heavy beak lowering toward the forest floor.",
+    cardDetail: "Each step is heavy and deliberate. On open ground, hesitation is what this bird is waiting for.",
     investigationDetails: [
       "It is not stalking delicately; it does not need to. On the ground, its reach and mass make the rules simple.",
       "The beak turns side to side as it searches the leaf litter. Small animals survive this by not being on the floor when it arrives.",
@@ -1386,7 +1389,7 @@ const encounters = {
     dangerProfile: "predator", temperament: "hunter", pursuitType: "climber", canInvestigate: true,
     fitness: 90, size: 22, speed: 55, agility: 55, aggression: 65, food: 70,
     poison: null,
-    seen: "A monitor lizard moves with deliberate confidence, tongue tasting the wet air."
+    seen: "A monitor lizard works through the undergrowth with slow confidence, its tongue testing the damp air ahead of it."
   },
 
   iguana: {
@@ -1633,7 +1636,8 @@ const encounters = {
     dangerProfile: "rival", temperament: "defensive", canInvestigate: true,
     fitness: 70, size: 7, speed: 45, agility: 75, aggression: 25, food: 30,
     poison: null,
-    seen: "Another primate-like climber moves through the branches, watching you as much as the forest."
+    seen: "Another primate-like climber moves through the branches, watching you as much as the forest.",
+    cardDetail: "It keeps to cover and tests your reactions before deciding whether to close distance or vanish."
   },
 
   europolemur: {
@@ -1737,8 +1741,8 @@ const encounters = {
   birdNest: {
     kind: "nest", name: "bird nest", icon: "🥚", className: "food",
     canInvestigate: true, eggs: 2,
-    seen: "A small nest sits in a fork of branches. Something pale shows inside.",
-    investigated: "The nest holds eggs. It may be easy food, but the smell and sound of feeding can draw attention."
+    seen: "A small nest rests in the fork of a branch. Pale eggs show through the weave of leaves and twigs.",
+    investigated: "The eggs are easy to reach, but feeding here carries smell and noise farther than you want."
   },
 
   largeGroundNest: {
@@ -1938,13 +1942,13 @@ const encounters = {
     kind: "animal", name: "large constrictor", icon: "🐍", className: "threat",
     dangerProfile: "grapple", temperament: "ambush", canInvestigate: true,
     fitness: 80, size: 11, speed: 35, agility: 50, aggression: 65, food: 35,
-    seen: "A heavy-bodied constrictor is looped across the branch. It is far too large to treat as prey.",
+    seen: "A heavy-bodied constrictor lies looped across the branch, so still it could be mistaken for vine.",
     investigationDetails: [
       "The branch-shape has muscle under it. The stillness is hunting, not rest.",
       "Its head is already angled towards you. If you close badly, it can seize and coil before you can pull free.",
       "It is food only in theory. The practical lesson is distance, height, and not giving it another turn beside you."
     ],
-    investigated: "This is not a food assessment. It is a distance assessment: large constrictor, obvious threat, avoid closing."
+    investigated: "At this size it is not prey; it is a trap with muscle. In branches, one bad approach can become a coil you cannot escape."
   },
   groundCarnivore: {
     kind: "animal", name: "mesonychid-like ground predator", icon: "🐺", className: "predator",
@@ -3342,6 +3346,19 @@ function layerNarrationChoice(layerName) {
  * - Export is capped to prevent unbounded memory growth during long playthroughs.
  */
 // @target [UTILS] Add Log
+function sanitizeNarrativeText(value, fallback = "") {
+  if (value === null || value === undefined) return fallback;
+  if (typeof value === "string") return value.replace(/\[object Object\]/g, fallback || "forest").trim();
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) return sanitizeNarrativeText(value.join(" "), fallback);
+  if (typeof value === "object") {
+    if (typeof value.text === "string") return value.text.trim();
+    if (typeof value.name === "string") return value.name.trim();
+    return fallback;
+  }
+  return fallback;
+}
+
 function addLog(message, cssClass = "minor") {
   const log = document.getElementById("log");
   const p = document.createElement("p");
@@ -3350,12 +3367,13 @@ function addLog(message, cssClass = "minor") {
   // QA/audit format: every event carries the player coordinate and height layer.
   const prefix = `Turn ${player.turn} [X ${player.x}, Y ${player.y}, ${layers[player.z]}]: `;
 
-  if (message.startsWith(`Turn ${player.turn}: `)) {
-    p.textContent = prefix + message.slice(`Turn ${player.turn}: `.length);
-  } else if (message.startsWith("Turn ")) {
-    p.textContent = message;
+  const cleanMessage = sanitizeNarrativeText(message, "You pause, but nothing resolves clearly.");
+  if (cleanMessage.startsWith(`Turn ${player.turn}: `)) {
+    p.textContent = prefix + cleanMessage.slice(`Turn ${player.turn}: `.length);
+  } else if (cleanMessage.startsWith("Turn ")) {
+    p.textContent = cleanMessage;
   } else {
-    p.textContent = prefix + message;
+    p.textContent = prefix + cleanMessage;
   }
 
   const suppressVisibleAfterDeath = player.dead && cssClass !== "death";
@@ -3373,7 +3391,7 @@ function addLog(message, cssClass = "minor") {
     actionKind: lastActionKind,
     cssClass,
     message: p.textContent,
-    rawMessage: String(message)
+    rawMessage: sanitizeNarrativeText(message, "")
   });
 
   if (debugLog.length > 5000) debugLog.length = 5000;
@@ -3407,7 +3425,7 @@ function setNarration(text) {
     return;
   }
 
-  const raw = String(text || "").trim();
+  const raw = sanitizeNarrativeText(text, "").trim();
   const tupleMatch = raw.match(/^([A-Za-z]+),0\.\d+$/);
 
   if (tupleMatch) {
@@ -3416,7 +3434,7 @@ function setNarration(text) {
     return;
   }
 
-  lastNarration = raw;
+  lastNarration = raw || layerNarrationChoice(layers[player.z]);
 }
 
 // @target [UTILS] Escape Html
@@ -3799,7 +3817,7 @@ function startTurn() {
       player.size = Math.round((player.size + 0.1) * 10) / 10;
       player.growthProgress = 0;
       addDebugTrace("state-change", {label: "growth", sizeBefore: oldSize, sizeAfter: player.size, reason: "energy reserves >= 75 for enough turns"});
-      addLog(`Turn ${player.turn}: Good energy reserves support growth. Size increases to ${player.size}.`, "prey");
+      addLog(`Turn ${player.turn}: You feel growth in your frame — more weight, more reach.`, "prey");
       setNarration("With food behind you and energy in your body, growth continues slowly — almost invisibly, but it matters.");
     }
   }
@@ -3904,7 +3922,7 @@ function tickPoison() {
   lastDamageContext = {source: "poison", poison: cloneDebug(poison), fitnessBefore, fitnessAfter: player.fitness, damage: fitnessBefore - player.fitness};
   addDebugTrace("damage-breakdown", lastDamageContext);
 
-  addLog(`Poison damages fitness by ${poison.damage}.`, "poison");
+  addLog(poison.turns >= 4 ? "The sickness lingers, draining your strength again." : (poison.turns <= 1 ? "The worst of the toxin begins to ease." : "The toxin bites again."), "poison");
 
   // If damage itself drops fitness to zero, don't print a misleading remedy countdown.
   if (player.fitness <= 0) {
@@ -3971,7 +3989,7 @@ function applyAlcohol(alcohol, sourceName) {
   if (!player.alcohol || incoming.rank >= (player.alcohol.rank || 1) || incoming.turns > (player.alcohol.turns || 0)) {
     player.alcohol = incoming;
   }
-  addLog(`${capitalise(alcoholSourceName(sourceName))} dulls your senses and slows your reactions.`, "threat");
+  addLog(`After ${alcoholSourceName(sourceName)}, the world feels slightly delayed and your movements lose precision.`, "threat");
   setNarration("The fruit gives quick energy, but the sour-sweet ferment pulls at balance, timing, and judgement.");
 }
 
@@ -3985,7 +4003,7 @@ function tickAlcohol() {
     return;
   }
   if (player.alcohol.turns % 2 === 0) {
-    addLog(`Alcohol dulls senses and reaction time for ${player.alcohol.turns} more turns.`, "threat");
+    addLog("The delayed, unsteady feeling still has not passed.", "threat");
   }
 }
 
@@ -4937,7 +4955,7 @@ function directionLong(dir) {
 
 // @target [TURN] Format Cue Text
 function formatCueText(text) {
-  let out = String(text || "");
+  let out = sanitizeNarrativeText(text, "");
 
   const directionMap = {
     "NE": "North-East",
@@ -5476,7 +5494,11 @@ function makeClue(template, dir, distance, clarity) {
     }
     return {
       sense: "hear",
-      text: `Something flickers or rustles to the ${dirLong}.`,
+      text: choice([
+        `A brief disturbance passes through the leaves to the ${dirLong}, then stops.`,
+        `Something small shifts in cover to the ${dirLong} before the forest settles again.`,
+        `Leaves move once to the ${dirLong}; whatever made it stays hidden.`
+      ]),
       priority,
       narration: `The forest gives you a hint to the ${dirLong}, but not certainty.`
     };
@@ -5593,7 +5615,11 @@ function makeClue(template, dir, distance, clarity) {
   if (template.kind === "forage") {
     return {
       sense: "hear",
-      text: `A clear patch of possible food lies to the ${dirLong}: ${template.name}. It should still be there if you go that way soon.`,
+      text: choice([
+        `A faint sweetness drifts from the ${dirLong} — likely fallen food.`,
+        `The ground to the ${dirLong} looks recently disturbed, as if something edible dropped there.`,
+        `Fresh feeding sign lies to the ${dirLong}, worth checking before it cools or is claimed.`
+      ]),
       priority,
       narration: `To the ${dirLong}, ${template.name} offer a small chance to refill your energy. Plants and fungi do not run.`
     };
@@ -5676,13 +5702,13 @@ function randomAmbientSound() {
 function randomAmbientSmell() {
   if (timeState.sleepTurnsRemaining > 0) return "Sleep dulls even strong scent.";
   if (timeState.phase === "night" && environment.wind === "still") return "Night air holds scent close and heavy.";
-  if (environment.weather === "heavy rain") return "Heavy rain washes scent from the air.";
+  if (environment.weather === "heavy rain") return choice(["Heavy rain washes scent from the air.", "Wet bark and leaf mould dull the scent trail."]);
   if (environment.weather === "mist") return "Mist holds scent low among the leaves.";
-  if (environment.wind === "still") return "The air is still; scent gathers but does not travel far.";
+  if (environment.wind === "still") return choice(["The air is still; scent gathers close to where it began.", "Still air keeps scent low and close; little carries far."]);
   return choice([
     "Wet leaves, bark, and fungal rot fill the air.",
     "The humid forest carries too many scents to trust.",
-    "Rainwater and leaf litter flatten the smells around you.",
+    "Sweet rot carries faintly on the air — fruit, fungus, or something already opened.",
     "The air is warm and green, heavy with plant life."
   ]);
 }
@@ -5858,7 +5884,10 @@ function changeGroupCohesion(delta, reason, opts = {}) {
   addDebugTrace("group-cohesion", {reason, delta, before, after: socialGroup.cohesion, group: cloneDebug(socialGroup), opts: cloneDebug(opts)});
   if (opts.log && before !== socialGroup.cohesion) {
     const direction = delta < 0 ? "falls" : "improves";
-    addLog(`Turn ${player.turn}: Group cohesion ${direction} (${Math.round(before)} → ${Math.round(socialGroup.cohesion)}): ${reason}.`, delta < 0 ? "threat" : "primate");
+    const text = delta < 0
+      ? "The group hesitates around you; trust thins, even if they stay."
+      : "The group settles and moves with you more confidently.";
+    addLog(`Turn ${player.turn}: ${text}`, delta < 0 ? "threat" : "primate");
   }
 }
 
@@ -5906,7 +5935,7 @@ function stressGroupForRisk(reason, severity = 1, opts = {}) {
     return {injured: true, died: true, member: name, damage};
   }
 
-  const injuryMsg = `${(member.name || "A companion")} is hurt after ${reason}. Injury: ${groupDamageLabel(damage)} (${damage}).`;
+  const injuryMsg = `In the struggle, ${(member.name || "a companion")} takes the worst of it and pulls back injured.`;
   addLog(`Turn ${player.turn}: ${injuryMsg}`, "threat");
   setGroupNotice(injuryMsg);
   return {injured: true, died: false, member: member.name, damage};
@@ -7082,9 +7111,7 @@ function isDrinkableEncounter(e) {
   const name = (e.name || "").toLowerCase();
   if (["rainPuddle", "bromeliadPool"].includes(key)) return true;
   if (name.includes("puddle") || name.includes("pool") || name.includes("water")) return true;
-  const hydration = Number(e.hydration || defaultHydrationFor(e) || 0);
-  const energy = Number(e.energy || 0);
-  return e.kind === "forage" && hydration > energy && hydration >= 10;
+  return false;
 }
 
 // @fn consumptionButtonLabel
@@ -7092,7 +7119,13 @@ function consumptionButtonLabel(e) {
   e = normaliseEncounter(e, e && (e.key || e.name) || "unknown");
   if (e.kind === "remedy") return "Consume";
   if (isSwarmEncounter(e)) return "Pick off";
-  if (isDrinkableEncounter(e)) return "Drink";
+  if (isDrinkableEncounter(e)) {
+    const key = e.key || "";
+    if (key === "rainPuddle") return "Drink from puddle";
+    if (key === "bromeliadPool") return "Drink from water pocket";
+    if (isNearWater(player.x, player.y) || terrainAt(player.x, player.y) === "water") return "Drink at water edge";
+    return "Drink from water";
+  }
   return "Eat";
 }
 
@@ -7435,7 +7468,7 @@ function queuedEncounterAction(index, action) {
 // @fn queuedActionButtonsHtml
 function queuedActionButtonsHtml(q, index) {
   q = normaliseEncounter(q, q.key || q.name || "queued");
-  let html = `<button type="button" class="queuedFocusButton investigateButton" data-queued-index="${index}">Focus</button>`;
+  let html = "";
   if (q.canInvestigate) html += `<button type="button" class="queuedInvestigateButton investigateButton" data-queued-index="${index}">Investigate</button>`;
   if (q.kind === "animal") html += `<button type="button" class="queuedAttackButton dangerButton" data-queued-index="${index}">Attack</button>`;
   if (["forage", "nest", "remedy", "carcass"].includes(q.kind)) {
@@ -7467,10 +7500,15 @@ function canActorConsumeSharedResource(actor, victim) {
 
   const actorText = String(`${actor.key || ""} ${actor.name || ""}`).toLowerCase();
   const victimText = String(`${victim.key || ""} ${victim.name || ""} ${victim.kind || ""}`).toLowerCase();
+  const actorSize = Number(actor.size || 1);
+  const victimSize = Number(victim.size || 1);
 
   const victimIsPlantFood = /(fruit|berry|berries|nut|fig|mushroom|fungus)/.test(victimText);
   const victimIsAnimalFood = victim.kind === "animal" || victim.kind === "carcass" || /(insect|hopper|grasshopper|cricket|cicada|beetle|spider|snail|slug|worm|grub|egg|larv|termite|ant|mammal|bird|toad|frog|lizard)/.test(victimText);
   const victimIsNestFood = victim.kind === "nest";
+
+  if (/needle-billed|hummingbird|orchid bee/.test(actorText) && (victim.kind === "animal" || victim.kind === "carcass")) return false;
+  if (/bird/.test(actorText) && actorSize <= 3 && (victim.kind === "animal" || victim.kind === "carcass") && victimSize >= 3) return false;
 
   if (isPredatoryEncounter(actor)) return victimIsAnimalFood || victimIsNestFood;
   if (/centipede|pitviper|spider|tarantula|mantis|dragonfly/.test(actorText)) return victimIsAnimalFood || victimIsNestFood;
@@ -7500,7 +7538,7 @@ function maybeEncounterConsumesOther(encountersHere) {
       if (idx >= 0) arr.splice(idx, 1);
       if (victim.origin && victim.origin.staticTile) { delete staticTileContents[staticKey(victim.origin.x, victim.origin.y, victim.origin.z)]; markWorldRegistryConsumed(victim, "consumed-by-other-encounter"); }
       observeFoodTest(victim, actor);
-      addLog(`The ${actor.name} gets to the ${victim.name} first and feeds. The easy meal is gone.`, actor.className || "threat");
+      addLog(`The ${actor.name} reaches the ${victim.name} first and strips the easy chance before you can act.`, actor.className || "threat");
       setNarration("The tile is not waiting for you. Other animals feed, raid, and interfere with the same chances you are trying to use.");
       break;
     }
@@ -7544,23 +7582,23 @@ function setTileEncounterStack(encountersHere, source, actionText = "notice") {
   tileEncounterQueue = capped;
   if (currentEncounter && ["fatal", "grapple", "predator", "venomous_ambush"].includes(currentEncounter.dangerProfile)) dangerGrace = true;
   addDebugTrace("multi-encounter-stack", {source, actionText, active: cloneDebug(currentEncounter), queued: cloneDebug(tileEncounterQueue), total: 1 + tileEncounterQueue.length});
-  const suffix = tileEncounterQueue.length ? ` Other encounter${tileEncounterQueue.length === 1 ? "" : "s"} present: ${tileEncounterQueue.map(e => e.name).join(", ")}.` : "";
+  const suffix = "";
   const movementAction = String(actionText || "").startsWith("travel ");
   const stackText = movementAction
     ? "notice"
     : (tileEncounterQueue.length ? actionText : (actionText === "come upon several things in the same place" ? "notice" : actionText));
   const dominantThreat = currentEncounter && ["fatal", "grapple", "predator", "venomous_ambush"].includes(currentEncounter.dangerProfile);
   const opener = movementAction
-    ? (tileEncounterQueue.length
+      ? (tileEncounterQueue.length
       ? (dominantThreat
-        ? `Turn ${player.turn}: Immediate danger takes over: ${currentEncounter.name}.${suffix}`
-        : `Turn ${player.turn}: Multiple encounters here. Main threat/opportunity: ${currentEncounter.name}.${suffix}`)
-      : `Turn ${player.turn}: Encounter: ${currentEncounter.name}.`)
+        ? `Turn ${player.turn}: Immediate danger: ${currentEncounter.name}.`
+        : `Turn ${player.turn}: You notice several things at once. ${currentEncounter.name} is closest.`)
+      : `Turn ${player.turn}: ${currentEncounter.name} comes into view.`)
     : (tileEncounterQueue.length
       ? (dominantThreat
-        ? `Turn ${player.turn}: You ${stackText === "come upon several things in the same place" ? "notice movement" : stackText}. Immediate danger takes over: ${currentEncounter.name}.${suffix}`
-        : `Turn ${player.turn}: You ${stackText}. Multiple encounters here. Main threat/opportunity: ${currentEncounter.name}.${suffix}`)
-      : `Turn ${player.turn}: You ${stackText}. Encounter: ${currentEncounter.name}.`);
+        ? `Turn ${player.turn}: You ${stackText === "come upon several things in the same place" ? "notice movement" : stackText}. Immediate danger: ${currentEncounter.name}.`
+        : `Turn ${player.turn}: You ${stackText}. Several encounters overlap here; ${currentEncounter.name} is nearest.`)
+      : `Turn ${player.turn}: You ${stackText}. ${currentEncounter.name} is close.`);
   addLog(opener, currentEncounter.className || "minor");
   setNarration(currentEncounter.key === "antTrail" ? antTrailNarrationText(currentEncounter) : (currentEncounter.seen || `You notice ${article(currentEncounter.name)} ${currentEncounter.name}.`));
   return true;
@@ -7620,7 +7658,7 @@ function layerPerilCheck(actionText) {
   const key = weightedPick(table);
   currentEncounter = normaliseEncounter(cloneEncounter(key), key);
   dangerGrace = ["fatal", "grapple", "predator", "venomous_ambush"].includes(currentEncounter.dangerProfile);
-  addLog(`The ${layerName.toLowerCase()} is not empty. Encounter: ${currentEncounter.name}.`, currentEncounter.className || "threat");
+  addLog(`The ${layerName.toLowerCase()} is not empty. ${currentEncounter.name} is close enough to matter.`, currentEncounter.className || "threat");
   setNarration(currentEncounter.seen);
   return true;
 }
@@ -9111,7 +9149,7 @@ function verticalTransitionHazard(direction) {
       currentEncounter = normaliseEncounter(cloneEncounter(key), key);
       dangerGrace = ["fatal", "grapple", "predator", "venomous_ambush"].includes(currentEncounter.dangerProfile);
 
-      addLog(`Your vertical movement exposes you. Encounter: ${currentEncounter.name}.`, currentEncounter.className || "threat");
+      addLog(`Your vertical movement exposes you. ${currentEncounter.name} is now in reach.`, currentEncounter.className || "threat");
       setNarration(currentEncounter.seen);
 
       // Fatal/large predators should immediately feel dangerous if you blunder
@@ -9468,16 +9506,16 @@ function hiddenSubtypeSuspicionText(e, level) {
   const rank = e.poison ? poisonRank(e.poison) : 0;
   const surface = e.genericName || e.name || "thing";
   if (level <= 1) {
-    if (className === "myriapods") return {log: "uncertain millipede-type; possible chemical defence", narration: "This " + surface + " may be edible, chemically defended, or a mimic. You can read shape and behaviour, not the truth yet.", className: "minor"};
-    if (className === "insects") return {log: "uncertain insect; possible mimic or chemical defence", narration: "This " + surface + " has useful clues, but similar insects can be edible, bitter, or toxic.", className: "minor"};
+    if (className === "myriapods") return {log: "uncertain millipede-type; possible chemical defence", narration: "It could be food — or something that punishes the attempt. The pattern is not enough to be sure.", className: "minor"};
+    if (className === "insects") return {log: "uncertain insect; possible mimic or chemical defence", narration: "You recognise enough to be cautious, not enough to be certain.", className: "minor"};
     if (className === "caterpillars") return {log: "uncertain caterpillar; hairs or toxins possible", narration: "This " + surface + " may be food or may punish a careless mouthful.", className: "minor"};
-    return {log: "uncertain food; more evidence needed", narration: "This " + surface + " has clues, but the true risk is still uncertain.", className: "minor"};
+    return {log: "uncertain food; more evidence needed", narration: "You can read some signs, but not enough to trust them.", className: "minor"};
   }
   if (level < 4) {
-    if (rank >= 4) return {log: "strong warning signs, exact identity uncertain", narration: "The signs now look bad. It may be dangerous, though you have not fully identified it.", className: "threat"};
-    if (rank >= 2) return {log: "probable chemical/toxin risk", narration: "The signs lean risky. It may be chemically defended, though a harmless mimic is still possible.", className: "poison"};
-    if (rank >= 1) return {log: "possible mild toxin or bad taste", narration: "There are weak warning signs. It may only be bitter or mildly irritating.", className: "poison"};
-    return {log: "probably edible, but not certain", narration: "The signs lean safe, but mimicry and hidden toxins mean eating is still the real test.", className: "food"};
+    if (rank >= 4) return {log: "strong warning signs, exact identity uncertain", narration: "The signs are bad: bold warning cues, little fear, and no hurry to escape.", className: "threat"};
+    if (rank >= 2) return {log: "probable chemical/toxin risk", narration: "Slow, exposed prey is often defended. This one deserves care.", className: "poison"};
+    if (rank >= 1) return {log: "possible mild toxin or bad taste", narration: "There are warning hints, but they are weak. Treat it as uncertain, not safe.", className: "poison"};
+    return {log: "probably edible, but not certain", narration: "It looks promising, but certainty only comes with experience and risk.", className: "food"};
   }
   return null;
 }
@@ -10024,7 +10062,8 @@ function attack() {
   if (!debugRoll("attack catch check", catchChance, {playerCatch, targetEscape, target: cloneDebug(target)})) {
     addDebugTrace("failure-reason", {action: "attack", reason: "catch check failed", playerCatch, targetEscape, catchChance, target: cloneDebug(target)});
     addLog(`Turn ${player.turn}: Attack failed. The ${target.name} escapes.`, "threat");
-    setNarration(pressure.note || `You lunge, but the ${target.name} is gone before the strike lands.`);
+    if (isBirdEncounter(target)) setNarration("You lunge into fluttering wings; the bird slips through the leaves before your strike can close.");
+    else setNarration(pressure.note || `You lunge, but the ${target.name} is gone before the strike lands.`);
     clearCurrentEncounterAndPromote("attack missed");
     render();
     return;
@@ -10069,10 +10108,11 @@ function attack() {
 
     if (damage > 0) {
       addLog(`Turn ${player.turn}: You kill the ${target.name}, but take ${damage} damage.`, "prey");
-      setNarration(`The ${target.name} dies fighting. Food remains, but so does pain.`);
+      if (target.dangerProfile === "sting") setNarration(`You crush the ${target.name}, but it stings again before it dies.`);
+      else setNarration(`The ${target.name} dies fighting. Food remains, but so does pain.`);
     } else {
-      addLog(`Turn ${player.turn}: Clean kill. The ${target.name} is dead.`, "prey");
-      setNarration(`You catch and kill the ${target.name}. In this forest, even a small success matters.`);
+      addLog(`Turn ${player.turn}: You catch the ${target.name} before it reaches cover. The struggle is brief.`, "prey");
+      setNarration(`You catch the ${target.name} before it reaches cover. The struggle is brief.`);
     }
 
     render();
@@ -10092,7 +10132,8 @@ function attack() {
   } else {
     if (damage > 0) {
       addLog(`Turn ${player.turn}: You fail to kill the ${target.name}. Damage: ${damage}.`, "threat");
-      setNarration(`The attack goes wrong. The ${target.name} turns your attempt into a wound.`);
+      if (target.dangerProfile === "sting") setNarration(`Already agitated, the ${target.name} bends and drives in another sting.`);
+      else setNarration(`The attack goes wrong. The ${target.name} turns your attempt into a wound.`);
     } else if (target.dangerProfile === "toxic_food") {
       addLog(`Turn ${player.turn}: You fail to catch the ${target.name}. It cannot really hurt you, but its toxins are a risk.`, "poison");
       setNarration(`The ${target.name} flutters away. It is not dangerous as a fighter, but touching or eating it can still make you sick.`);
@@ -10436,7 +10477,7 @@ function eat() {
     e.eggs -= 1;
     const eggEnergy = e.energy || 18;
     const share = addFoodEnergy(eggEnergy, 1);
-    addLog(`Turn ${player.turn}: You eat an egg. Energy +${share.playerEnergy}. Eggs left: ${e.eggs}.${share.shareText}`, "food");
+    addLog(`Turn ${player.turn}: You crack and swallow an egg quickly before the scent spreads.${share.shareText}`, "food");
     setNarration(e.key === "largeGroundNest"
       ? "The large egg is rich, but the nest is exposed. Every bite feels like a signal on the forest floor."
       : "The egg is rich food, swallowed quickly before the parent bird or another hunter notices.");
@@ -10503,7 +10544,7 @@ function eat() {
   }
 
   const eatVerb = (e.hydration || defaultHydrationFor(e)) > (e.energy || 0) ? "drink from" : "eat";
-  addLog(`Turn ${player.turn}: You ${eatVerb} ${e.name}. Energy +${share.playerEnergy}.${hydrationText(share.hydration)}${bonusFoodText}${share.shareText}`, e.poison ? "poison" : "food");
+  addLog(`Turn ${player.turn}: You feed quickly on ${e.name}. The gain is real, but the smell travels.${bonusFoodText}${share.shareText}`, e.poison ? "poison" : "food");
   if (e.alcohol) applyAlcohol(e.alcohol, e.name);
   else setNarration(e.poison ? `The food goes down, but your body soon tells you this was not safe.` : (share.hydration > 12 ? `The moisture matters as much as the calories. For now, thirst loosens its grip.` : `You feed quickly, taking what energy and moisture you can before the forest notices.`));
 
@@ -10539,7 +10580,7 @@ function eatCarcass(options = {}) {
   const share = addFoodEnergy(carcass.energy, 2, carcass.hydration ?? defaultHydrationFor(carcass), carcass.name);
   const age = carcass.carcassAge || 0;
 
-  addLog(`Turn ${player.turn}: You feed from the ${carcass.name}. Energy +${share.playerEnergy}.${hydrationText(share.hydration)} Portions left: ${carcass.portions}.${share.shareText}`, "food");
+  addLog(`Turn ${player.turn}: You feed from the ${carcass.name} while keeping watch. The scent deepens around the kill.${share.shareText}`, "food");
 
   const rotPoison = carcassRotPoison(carcass);
   if (rotPoison) {
@@ -11036,7 +11077,7 @@ function getRandomBotActions() {
 
   if (carcass) add("eat-carcass", `eat ${carcass.name}`, eat, "encounter");
   if (hasGroup() && (carcass || (currentEncounter && ["forage", "nest", "remedy", "carcass"].includes(currentEncounter.kind)))) add("conceal-food", "conceal food", concealFocusedFood, "social");
-  if (canDrinkAtWaterEdge()) add("drink-water", "drink water", drinkWater, "resource");
+  if (canDrinkAtWaterEdge()) add("drink-water", "drink at water edge", drinkWater, "resource");
   add("look", "look around", lookAround, "sense");
   add("call", "call out", callOut, "social");
   add("wait", "wait", waitTurn, "time");
@@ -12814,6 +12855,50 @@ function timeNarrationFragment() {
  * player has created enough safety first.
  */
 
+// Narration tone: restrained natural-history documentary. Sensory, specific, and readable; avoid debug phrasing, melodrama, or hiding critical gameplay information.
+function lookNarrationPick(arr) {
+  return Array.isArray(arr) && arr.length ? arr[Math.floor(Math.random() * arr.length)] : "";
+}
+
+function composeLookNarration(findings, context = {}) {
+  const phase = context.phase || "day";
+  const weather = context.weather || "";
+  const layerName = context.layerName || "forest";
+  const habitatRaw = context.habitat;
+  const habitat = (typeof habitatRaw === "string" && habitatRaw.trim()) ? habitatRaw : ((habitatRaw && typeof habitatRaw.name === "string" && habitatRaw.name.trim()) ? habitatRaw.name : "forest");
+  const lines = [];
+
+  const atmosphere = lookNarrationPick([
+    `You pause in the ${layerName}, listening to the ${habitat}.`,
+    `You hold still and let the ${habitat} settle around you.`,
+    `You stop moving for a breath and read the ${layerName} around you.`
+  ]);
+  const sensory = weather === "heavy rain"
+    ? "Rain drums over leaves and wood, blurring distance."
+    : weather === "mist"
+      ? "Mist softens edges; shapes move before they resolve."
+      : phase === "night"
+        ? "Night keeps most movement hidden, but sound travels cleanly."
+        : phase === "dawn" || phase === "dusk"
+          ? "Low light shifts the trunks into bands of shadow and movement."
+          : "Air, leaf movement, and distant calls sketch out what is active nearby.";
+  lines.push(`${atmosphere} ${sensory}`);
+
+  const threat = findings.find(f => f.cls === "threat");
+  const food = findings.find(f => f.cls === "food");
+  const resource = findings.find(f => /water|puddle|pool|carcass|fruit|berries|mushroom|nest|clay|mussel|crayfish|fig/i.test(f.text || ""));
+  const neutral = findings.find(f => f.cls !== "threat" && f !== food && f !== resource);
+
+  if (threat) {
+    lines.push(`${threat.text} Treat this as active risk, but not a fixed position.`);
+  } else if (food || resource || neutral) {
+    const cueA = food ? food.text : (resource ? resource.text : neutral.text);
+    const cueB = neutral && neutral !== cueA ? neutral.text : (resource && resource !== cueA ? resource.text : "");
+    lines.push(cueB ? `${cueA} ${cueB}` : cueA);
+  }
+  return lines.filter(Boolean).slice(0, 3).join(" ");
+}
+
 function lookAround() {
   if (player.dead) return;
   lastActionKind = "look";
@@ -12896,7 +12981,12 @@ function lookAround() {
         const r = Math.random() * 100;
         const certainty = r < 22 ? "clear" : r < 62 ? "probable" : "uncertain";
         recentPredatorWarning = {key, certainty: certainty === "uncertain" ? "old" : certainty, turn: player.turn, x, y, z, actionKind: "look", context: where};
-        const phrase = certainty === "clear" ? `Clear warning ${where}: ${t.name}.` : certainty === "probable" ? `Probable danger ${where}: movement, shadow, or fresh sign suggests ${article(t.name)} ${t.name}.` : `Uncertain sign ${where}: old marks or shifting shadows could mean ${article(t.name)} ${t.name}.`;
+        const locationHint = where === "above" ? "in the canopy above, not always this exact branch" : where === "below" ? "below, but not pinned to one exact spot" : "nearby";
+        const phrase = certainty === "clear"
+          ? `Strong warning ${where}: sign of ${t.name} ${locationHint}.`
+          : certainty === "probable"
+            ? `Probable danger ${where}: movement, shadow, or fresh sign suggests ${article(t.name)} ${t.name} nearby.`
+            : `Uncertain sign ${where}: old marks or shifting shadows could mean ${article(t.name)} ${t.name}.`;
         addFinding(phrase, "threat");
       }
     }
@@ -12911,7 +13001,7 @@ function lookAround() {
       if (ordinary >= 3) break;
     }
     if (!findings.length) addFinding("Nothing resolves clearly. Either there is nothing obvious nearby, or you failed to read it.", "minor");
-    const text = findings.map(f => f.text).slice(0, 8).join(" ");
+    const text = composeLookNarration(findings, {phase, weather: environment.weather, layerName, habitat});
     lastLookText = text; lastLookTurn = player.turn;
     addLog(`You look carefully. ${text}`, findings.some(f => f.cls === "threat") ? "threat" : "minor");
     setNarration(`You pause to look. ${text}`);
@@ -13291,6 +13381,26 @@ function displayedNarration() {
   return lastNarration;
 }
 
+function sameText(a, b) {
+  const norm = s => String(s || "").toLowerCase().replace(/<[^>]*>/g, "").replace(/[^a-z0-9\s]/g, " ").replace(/\s+/g, " ").trim();
+  return !!norm(a) && norm(a) === norm(b);
+}
+
+function shortEncounterCue(e) {
+  if (!e) return "Something is close, but details are unclear.";
+  if (e.key === "antTrail") return "A narrow ant line crosses the leaf litter nearby.";
+  if (e.key === "gastornis") return "A towering ground bird is close enough to force immediate caution.";
+  if (e.key === "millipede") return "A millipede tucked beneath a wet leaf.";
+  return `You spot ${article(e.name)} ${e.name} nearby.`;
+}
+
+function cardDetailForEncounter(e, cueText) {
+  if (!e) return "";
+  if (e.cardDetail) return e.cardDetail;
+  if (sameText(e.seen, cueText)) return e.investigated || "Its posture and movement offer clues, but no guarantees.";
+  return e.seen || "";
+}
+
 // Renders current scene and encounter cards.
 // This path is fail-safe: if currentEncounter exists, a card should appear.
 // @fn renderSenses
@@ -13341,12 +13451,12 @@ function renderSenses() {
       const e = currentEncounter;
 
       const encounterSeenText = e.key === "antTrail" ? antTrailSeenText(e) : (e.seen || `You notice ${article(e.name)} ${e.name}.`);
-      seeText.innerHTML = formatCueText(e.key === "antTrail" ? antTrailSeeText(e) : encounterSeenText);
+      const seeCueText = e.key === "antTrail" ? antTrailSeeText(e) : shortEncounterCue(e);
+      seeText.innerHTML = formatCueText(seeCueText);
 
       const warning = knownWarning(e);
       const statHtml = encounterStatsHtml(e);
       const actions = encounterActionsHtml(e);
-      const recentLookBox = lastLookText && lastLookTurn >= player.turn - 1 ? `<div class="investigationResult"><strong>Look result:</strong><br>${lastLookText}</div>` : "";
       const currentInvestigationRef = encounterInvestigationRef(e);
       const investigationBelongsToCard = investigationText && (!investigationEncounterRef || investigationEncounterRef === currentInvestigationRef);
       const floatingInvestigationBox = investigationText && !investigationBelongsToCard ? `<div class="investigationResult"><strong>Investigation result:</strong><br>${investigationText}</div>` : "";
@@ -13357,21 +13467,20 @@ function renderSenses() {
           <div class="creatureIcon ${encounterThreatClass(e)}">${e.icon || "?"}</div>
           <div>
             <div class="creatureName">${sexSymbolHtml(e)}<span>${e.name || "unknown encounter"}</span></div>
-            <div class="creatureText">${encounterSeenText || "Something is here, but the game has not described it properly yet."}</div>
-            ${recentLookBox}
+            <div class="creatureText">${cardDetailForEncounter(e, seeCueText) || "Something is here, but the game has not described it properly yet."}</div>
             ${investigationBelongsToCard ? `<div class="investigationResult"><strong>Investigation result:</strong><br>${investigationText}</div>` : ""}
             ${warning ? `<div class="creatureText poison">${warning}</div>` : ""}
             <div class="creatureStats">${statHtml}</div>
             <div class="cardActions">${actions}</div>
-            ${tileEncounterQueue.length ? `<div class="creatureText" style="margin-top:8px"><strong>Also in this tile:</strong> ${tileEncounterQueue.length} other encounter${tileEncounterQueue.length === 1 ? "" : "s"}. These are in the same place, not distant background signs — you can switch focus or act on them directly.</div>` : ""}
+            
           </div>
         </div>
         ${tileEncounterQueue.length ? tileEncounterQueue.map((rawQ, qi) => { const q = normaliseEncounter(rawQ, rawQ.key || rawQ.name || "queued"); return `
           <div class="creatureCard queuedEncounterCard" style="margin-top:8px; opacity:0.94">
             <div class="creatureIcon ${encounterThreatClass(q)}">${q.icon || "?"}</div>
             <div>
-              <div class="creatureName">${sexSymbolHtml(q)}<span>same tile: ${q.name}</span></div>
-              <div class="creatureText">${q.key === "antTrail" ? antTrailSeenText(q) : (q.seen || "It is present in the same patch of forest. You can choose to deal with this instead.")}</div>
+              <div class="creatureName">${sexSymbolHtml(q)}<span>${q.name}</span></div>
+              <div class="creatureText">${cardDetailForEncounter(q, shortEncounterCue(q)) || "It is present in the same patch of forest. You can choose to deal with this instead."}</div>
               ${knownWarning(q) ? `<div class="creatureText poison">${knownWarning(q)}</div>` : ""}
               <div class="creatureStats">${encounterStatsHtml(q)}</div>
               <div class="cardActions">${queuedActionButtonsHtml(q, qi)}</div>
@@ -13415,8 +13524,7 @@ function renderSenses() {
     hearText.innerHTML = formatCueText("water breaks against your body and hides other movement.");
     smellTextEl.innerHTML = formatCueText("wet mineral scent and riverbank rot press close.");
   } else {
-    const recentLook = lastLookText && lastLookTurn >= player.turn - 1 ? ` Last look: ${lastLookText}` : "";
-    seeText.innerHTML = formatCueText("no animal or food source clearly visible." + nearbyWaterText() + staticScarcityCueAt() + recentLook);
+    seeText.innerHTML = formatCueText("no animal or food source clearly visible." + nearbyWaterText() + staticScarcityCueAt());
   }
   if (!lastNarration || isDirectEncounterNarration(lastNarration)) {
     document.getElementById("narration").textContent = weatherNarrationFragment();
@@ -13667,12 +13775,6 @@ function bindCardActionButtons() {
     };
   }
 
-  document.querySelectorAll(".queuedFocusButton").forEach(button => {
-    button.onclick = function(event) {
-      event.preventDefault();
-      focusTileEncounter(Number(button.dataset.queuedIndex), "focus");
-    };
-  });
   document.querySelectorAll(".queuedInvestigateButton").forEach(button => {
     button.onclick = function(event) {
       event.preventDefault();


### PR DESCRIPTION
### Motivation
- Reduce raw debug/mechanical phrasing and accidental code/data leaks in player-facing text by adding a sanitization gate and replacing number-first lines with sensory-first narration.
- Consolidate look/encounter presentation to avoid duplicate or system-label output and make encounter cards and cues more coherent and plausible.
- Provide audit and an agreed implementation plan as documentation to guide staged, low-risk refactors of narrative output.

### Description
- Added two new documents: `PLAYER_FACING_DIALOGUE_AUDIT.txt` (full source audit) and `CONSENSUS_DIALOGUE_PLAN.txt` (comparison of v1–v4 and staged implementation recommendations), and updated `CHANGELOG.txt` with the new entries.
- Introduced `sanitizeNarrativeText()` and wired it into `addLog()`, `setNarration()`, and `formatCueText()` to prevent `[object Object]` and other raw/debug leaks from reaching the UI.
- Reworked look/encounter presentation: added `composeLookNarration()`, `lookNarrationPick()`, `shortEncounterCue()`, `cardDetailForEncounter()`, and `sameText()` to produce sensory-first look output and to separate short cues from card detail; removed system labels like "Encounter:"/"Also in this tile" and reduced number-first log lines across many eat/attack/poison/growth/alert messages.
- Improved consumption labeling and drink logic (more explicit water-source labels), adjusted encounter stacking text, removed duplicate look replay in cards, and applied many curated wording changes in `game/play.html` encounter templates to read as natural-history narration rather than debug output.

### Testing
- Ran the repository syntax checker `node scripts/check_html_js_syntax.mjs` to validate JS/HTML syntax; the check passed.
- No automated browser smoke tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f46762e9a08328ae5da4f0bb67efe4)