### PR TITLE
Patch 12b: fix stale mode telemetry on drowning escape fast-path

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,10 @@
+[2026-05-01 patch12b | Claude]
+IntelligentBot mode telemetry fix — Codex P2 from PR #30.
+- Fixed stale mode in terminalTrace on drowning-escape turns. chooseIntelligentBotAction() now clears botState._lastMode to null at function entry so no early return can leave a previous turn's mode in the step record. The drowning fast-path explicitly sets _lastMode = "EMERGENCY_ESCAPE" before returning the land-escape action.
+- Bot/debug tools change only. Gameplay logic, UI/layout, and app-loading behaviour not changed.
+- game/evolution_game_v66_57.html NOT updated — archived reference version only.
+- Syntax check: PASS. Browser smoke check not performed by Claude — must be verified before merging.
+
 [2026-05-01 00:20 UTC | GPT-5.3-Codex]
 - Verified deployment entrypoint: `index.html` meta-refresh serves `game/play.html` for GitHub Pages root.
 - Performed repository-wide tracked-file searches for bleed literals and confirmed runtime logic occurrences remain only inside intended script code (plus audit documentation text), with no out-of-script HTML leak fragment.

--- a/game/play.html
+++ b/game/play.html
@@ -11572,6 +11572,8 @@ function chooseIntelligentBotAction(actions) {
   const descendAction = byId["descend"] || null;
   const urgentNeedsGround = player.hydration <= 30 || player.energy <= 25;
 
+  botState._lastMode = null; // clear stale mode before any early return
+
   const enc = currentEncounter;
   const threat = classifyThreat(enc);
   const pursuitThreat = activePursuit ? classifyThreat(activePursuit) : null;
@@ -11580,7 +11582,7 @@ function chooseIntelligentBotAction(actions) {
   // Drowning: escape water before anything else
   if (waterState && waterState.inWater && moveActions.length) {
     const landEscape = intelligentEscapeWater(actions);
-    if (landEscape) return landEscape;
+    if (landEscape) { botState._lastMode = "EMERGENCY_ESCAPE"; return landEscape; }
   }
 
   const mode = determineIntelligentBotMode(threat);


### PR DESCRIPTION
## Summary

Codex P2 fix from PR #30 review — not included in the merged Patch 12 commit.

`chooseIntelligentBotAction()` had an early return in the drowning escape path that fired before `botState._lastMode` was set. On any turn where the bot escaped water, the step record inherited the previous turn's mode, making the terminalTrace mode label incorrect for those turns.

Two-line fix:
- `botState._lastMode = null` at function entry — clears any stale value before any early return can exit
- `botState._lastMode = "EMERGENCY_ESCAPE"` set explicitly in the drowning fast-path before returning the land-escape action

## Scope check

- [x] Bot / debug / QA tools
- [ ] Gameplay logic / mechanics
- [ ] UI / layout / presentation
- [ ] GitHub Pages / app loading / PWA files
- [ ] Documentation / workflow only

## Known bug guardrails

- [x] Reviewed `docs/bug-guardrails.md`
- [x] Any applicable guardrail checks have been completed
- [ ] If this PR fixes a bug/coding error, a new guardrail entry was added or an existing one was updated
- [x] If no guardrail applies, state why here: telemetry-only fix, no gameplay impact

## Mandatory syntax/render safety check

- [x] `node scripts/check_html_js_syntax.mjs` passed
- [ ] `game/play.html` opened in a browser — not performed by Claude; must be verified before merging

> Syntax/render safety check not run by Claude.

## Mandatory CHANGELOG reminder

- [x] `CHANGELOG.txt` updated with a timestamped plain-English entry
- [x] Entry states who made the change (Claude)
- [x] Entry states that bot/debug tools changed

## Commit message check

- [x] No `claude.ai/code/session_...` URLs in any commit message

## Reviewer confirmation

- `Bug guardrails reviewed; applicable checks passed.`
- `Syntax/render safety check not run.`
- `CHANGELOG updated.`

---
_Generated by [Claude Code](https://claude.ai/code/session_012aEczbJSq5g6AKhBCwDCQd)_