### PR TITLE
patch13a: IntelligentBot recovery sequencing (A1-A6)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,15 @@
+[2026-05-01 patch13a | Claude]
+IntelligentBot recovery sequencing — 6 targeted fixes (A1–A6) from post-Patch12 retrospective and GPT/Claude joint analysis.
+- A1 (CRITICAL): Drink-loop exit. In RECOVER mode's criticalResource block, when H>=65 and E<=10 the bot no longer returns drink-water. Instead it tries safe eat first, sets a seek_food goal, and climbs off Ground toward food-capable layers. Previously the bot could reach H=90+ while starving to death because E=0 triggered the criticalResource drink path on every turn.
+- A2: Water-to-food goal handoff. After a drink action in WATER_PLAN, if E<=30 a seek_food currentGoal is set so subsequent movement is directed toward food recovery rather than random. The seek_food goal also causes the bot to climb off Ground level when active and aerial threats are absent. Goal is cleared when E>=50.
+- A3: Position-based A-B-A-B oscillation breaker. positionHistory (last 6 positions) and loopBlacklist (tiles blocked for 3 turns) added to botState.memory. detectAndBreakOscillation() detects A-B-A-B coordinate loops when E<=15 or H<=15, blacklists both tiles, clears any stale goal, and returns a perpendicular escape move. intelligentFilterMovesAntiLoop() filters blacklisted destination tiles from movement selections. Both applied throughout RECOVER and WATER_PLAN movement paths.
+- A4: Eat before water when both resources critical. In the criticalResource block, when E<=30 a safe eat is tried before the water-move/drink path. Prevents the bot from moving toward water when safe food is immediately available and energy is also dangerously low.
+- A5: Covered structurally by A1+A4 (food or climb chosen over random movement at E=0/H=0) and A3 (no aimless oscillation); no separate code path required.
+- A6: Goal validity timeout. In updateBotMemory(), seek_food goal is cleared when E>=50 (goal achieved) or after 10 turns (staleness). detectAndBreakOscillation() also clears currentGoal when a loop is detected, as an active stale goal likely contributed to the oscillation.
+- Bot/debug tools change only. Gameplay logic, UI/layout, and app-loading behaviour not changed.
+- game/evolution_game_v66_57.html NOT updated — archived reference version only.
+- Syntax check: see PR gate. Browser smoke check not performed by Claude — must be verified before merging.
+
 [2026-05-01 patch12b | Claude]
 IntelligentBot mode telemetry fix — Codex P2 from PR #30.
 - Fixed stale mode in terminalTrace on drowning-escape turns. chooseIntelligentBotAction() now clears botState._lastMode to null at function entry so no early return can leave a previous turn's mode in the step record. The drowning fast-path explicitly sets _lastMode = "EMERGENCY_ESCAPE" before returning the land-escape action.

--- a/game/play.html
+++ b/game/play.html
@@ -10960,7 +10960,9 @@ function newBotMemory() {
     recentThreats: [],    // [{name, x, y, turn, pursuitType, dangerProfile}], capped at 10
     parasiteTurns: 0,     // consecutive turns with parasites >= 1 within this run
     lowHydrationTurns: 0, // consecutive turns with hydration <= 45 within this run
-    currentGoal: null     // {type: string, startTurn: number} persists until satisfied or interrupted
+    currentGoal: null,    // {type, startTurn, ...} persists until satisfied or cleared
+    positionHistory: [],  // [{x, y}] last 6 positions for A-B-A-B oscillation detection (P13A-A3)
+    loopBlacklist: []     // [{x, y, until}] positions blocked to escape local movement loops (P13A-A3)
   };
 }
 
@@ -10983,6 +10985,19 @@ function updateBotMemory() {
   }
   m.parasiteTurns = (player.parasites || 0) >= 1 ? m.parasiteTurns + 1 : 0;
   m.lowHydrationTurns = player.hydration <= 45 ? m.lowHydrationTurns + 1 : 0;
+  // P13A-A3: Track position history for A-B-A-B oscillation detection
+  if (!m.positionHistory) m.positionHistory = [];
+  m.positionHistory.push({ x: player.x, y: player.y });
+  if (m.positionHistory.length > 6) m.positionHistory.shift();
+  // Expire loop blacklist entries
+  if (!m.loopBlacklist) m.loopBlacklist = [];
+  m.loopBlacklist = m.loopBlacklist.filter(b => player.turn < b.until);
+  // P13A-A6: Clear seek_food goal when energy recovered; clear any goal after 10 turns
+  if (m.currentGoal) {
+    const goalAge = player.turn - (m.currentGoal.startTurn || player.turn);
+    if (m.currentGoal.type === 'seek_food' && player.energy >= 50) m.currentGoal = null;
+    else if (goalAge > 10) m.currentGoal = null;
+  }
 }
 
 function addQAIssue(code, severity = "warning", detail = {}) {
@@ -11400,6 +11415,63 @@ function intelligentFindSafeEat(actions) {
   return null;
 }
 
+// P13A-A3: Detect A-B-A-B position loop at critical stats; blacklist both tiles and return an escape move.
+function detectAndBreakOscillation(actions) {
+  const m = botState.memory;
+  if (!m) return null;
+  const h = m.positionHistory || [];
+  if (h.length < 4) return null;
+  if (player.energy > 15 && player.hydration > 15) return null;
+  const n = h.length;
+  const p0 = h[n-4], p1 = h[n-3], p2 = h[n-2], p3 = h[n-1];
+  const eq = (a, b) => a.x === b.x && a.y === b.y;
+  if (!eq(p0, p2) || !eq(p1, p3) || eq(p0, p1)) return null;
+  // A-B-A-B confirmed — blacklist both positions for 3 turns
+  m.loopBlacklist = m.loopBlacklist || [];
+  if (!m.loopBlacklist.find(b => b.x === p0.x && b.y === p0.y))
+    m.loopBlacklist.push({ x: p0.x, y: p0.y, until: player.turn + 3 });
+  if (!m.loopBlacklist.find(b => b.x === p1.x && b.y === p1.y))
+    m.loopBlacklist.push({ x: p1.x, y: p1.y, until: player.turn + 3 });
+  if (m.currentGoal) m.currentGoal = null; // A6: stale goal likely contributed to loop
+  const deltas = {
+    "move-northwest":[-1,-1],"move-north":[0,-1],"move-northeast":[1,-1],
+    "move-west":[-1,0],"move-east":[1,0],
+    "move-southwest":[-1,1],"move-south":[0,1],"move-southeast":[1,1]
+  };
+  const byId = Object.fromEntries(actions.map(a => [a.id, a]));
+  const escapeMoves = [];
+  for (const [id, d] of Object.entries(deltas)) {
+    const a = byId[id];
+    if (!a) continue;
+    const nx = player.x + d[0], ny = player.y + d[1];
+    if (m.loopBlacklist.find(b => b.x === nx && b.y === ny)) continue;
+    if (nx >= 0 && ny >= 0 && nx < WORLD_SIZE && ny < WORLD_SIZE && terrainAt(nx, ny) === 'water') continue;
+    escapeMoves.push(a);
+  }
+  if (escapeMoves.length) return randomBotAction(escapeMoves);
+  if (byId["climb"]) return byId["climb"];
+  if (byId["descend"] && !hasRecentGroundThreat()) return byId["descend"];
+  return null;
+}
+
+// P13A-A3: Filter out moves that would land on blacklisted positions; falls back to unfiltered if all blocked.
+function intelligentFilterMovesAntiLoop(moves) {
+  const m = botState.memory;
+  if (!m || !m.loopBlacklist || !m.loopBlacklist.length) return moves;
+  const deltas = {
+    "move-northwest":[-1,-1],"move-north":[0,-1],"move-northeast":[1,-1],
+    "move-west":[-1,0],"move-east":[1,0],
+    "move-southwest":[-1,1],"move-south":[0,1],"move-southeast":[1,1]
+  };
+  const filtered = moves.filter(a => {
+    const d = deltas[a.id];
+    if (!d) return true;
+    const nx = player.x + d[0], ny = player.y + d[1];
+    return !m.loopBlacklist.find(b => b.x === nx && b.y === ny);
+  });
+  return filtered.length ? filtered : moves;
+}
+
 function intelligentMoveTowardWater(actions) {
   let bestDist = Infinity;
   let bestDx = 0, bestDy = 0;
@@ -11616,16 +11688,35 @@ function chooseIntelligentBotAction(actions) {
     // Hard gate: at E<=10 or H<=10 only movement, drink, eat, and groom are permitted
     const criticalResource = player.energy <= 10 || player.hydration <= 10;
     if (criticalResource) {
-      const drinkMove = byId["drink-water"] || intelligentMoveTowardWater(actions);
-      if (drinkMove) return drinkMove;
-      const landMoves = moveActions.filter(a => {
+      const mCrit = botState.memory || (botState.memory = newBotMemory());
+      // P13A-A1: If adequately hydrated but critically starving, eat or climb toward food — don't keep drinking
+      if (player.hydration >= 65 && player.energy <= 10) {
+        const eat = intelligentFindSafeEat(actions);
+        if (eat) return eat;
+        if (!mCrit.currentGoal || mCrit.currentGoal.type !== 'seek_food')
+          mCrit.currentGoal = { type: 'seek_food', startTurn: player.turn };
+        // Climb toward food-capable layer when stuck at ground
+        if (player.z === 0 && byId["climb"] && !hasRecentAerialThreat()) return byId["climb"];
+      } else {
+        // P13A-A4: If E is also low, try an immediately available safe eat before pursuing water
+        if (player.energy <= 30) {
+          const eat = intelligentFindSafeEat(actions);
+          if (eat) return eat;
+        }
+        const drinkMove = byId["drink-water"] || intelligentMoveTowardWater(actions);
+        if (drinkMove) return drinkMove;
+      }
+      // P13A-A3: Break A-B-A-B oscillation before falling back to random movement
+      const oscEscapeCrit = detectAndBreakOscillation(actions);
+      if (oscEscapeCrit) return oscEscapeCrit;
+      const landMoves = intelligentFilterMovesAntiLoop(moveActions.filter(a => {
         const dir = a.id.replace("move-", "");
         const deltas = {"northwest":[-1,-1],"north":[0,-1],"northeast":[1,-1],"west":[-1,0],"east":[1,0],"southwest":[-1,1],"south":[0,1],"southeast":[1,1]};
         const d = deltas[dir]; if (!d) return true;
         return terrainAt(player.x + d[0], player.y + d[1]) !== "water";
-      });
+      }));
       if (landMoves.length) return randomBotAction(landMoves);
-      if (moveActions.length) return randomBotAction(moveActions);
+      if (moveActions.length) return randomBotAction(intelligentFilterMovesAntiLoop(moveActions));
     }
     // Move away from poison/injury — block attack, investigate, call, look, sleep, wait, blacklisted eat
     if (player.poison || player.fitness <= 45) {
@@ -11659,17 +11750,29 @@ function chooseIntelligentBotAction(actions) {
       const eat = intelligentFindSafeEat(actions);
       if (eat) return eat;
     }
-    const landMoves = moveActions.filter(a => {
+    // P13A-A2: Follow food goal — if seek_food goal active and stuck at ground, climb toward food layer
+    const mRec = botState.memory;
+    if (mRec && mRec.currentGoal && mRec.currentGoal.type === 'seek_food' &&
+        player.z === 0 && byId["climb"] && !hasRecentAerialThreat()) {
+      return byId["climb"];
+    }
+    // P13A-A3: Break A-B-A-B oscillation before falling back to random movement
+    const oscEscapeRec = detectAndBreakOscillation(actions);
+    if (oscEscapeRec) return oscEscapeRec;
+    const landMoves = intelligentFilterMovesAntiLoop(moveActions.filter(a => {
       const dir = a.id.replace("move-", "");
       const deltas = {"northwest":[-1,-1],"north":[0,-1],"northeast":[1,-1],"west":[-1,0],"east":[1,0],"southwest":[-1,1],"south":[0,1],"southeast":[1,1]};
       const d = deltas[dir]; if (!d) return true;
       return terrainAt(player.x + d[0], player.y + d[1]) !== "water";
-    });
+    }));
     if (landMoves.length) return randomBotAction(landMoves);
-    if (moveActions.length) return randomBotAction(moveActions);
+    if (moveActions.length) return randomBotAction(intelligentFilterMovesAntiLoop(moveActions));
     // Hard fallback: at E=0 or H=0 never fall through to EXPLORE
     // Guardian-risk and poison food must remain blocked even in desperation
     if (player.energy <= 0 || player.hydration <= 0) {
+      // P13A-A3: Try oscillation escape first
+      const oscEscapeHard = detectAndBreakOscillation(actions);
+      if (oscEscapeHard) return oscEscapeHard;
       const survival = actions.filter(a => {
         if (a.id.startsWith("attack") || a.id.startsWith("queued-attack")) return false;
         if (["look", "call", "sleep", "wait", "investigate"].includes(a.id)) return false;
@@ -11682,14 +11785,15 @@ function chooseIntelligentBotAction(actions) {
         }
         return true;
       });
-      return randomBotAction(survival.length ? survival : actions);
+      return randomBotAction(intelligentFilterMovesAntiLoop(survival.length ? survival : actions));
     }
   }
 
   if (mode === "WATER_PLAN") {
     const m = botState.memory || (botState.memory = newBotMemory());
     if (byId["drink-water"]) {
-      m.currentGoal = null; // goal satisfied
+      // P13A-A2: After drinking, if energy is critically low set a food-seek goal for subsequent turns
+      m.currentGoal = player.energy <= 30 ? { type: 'seek_food', startTurn: player.turn } : null;
       return byId["drink-water"];
     }
     // Climb before approaching water if ground predators were recently nearby
@@ -11709,15 +11813,18 @@ function chooseIntelligentBotAction(actions) {
     m.currentGoal = null;
     // Descend toward ground to unlock drink-water (requires z=0), but only if ground is safe
     if (descendAction && player.z > 0 && !hasRecentGroundThreat()) return descendAction;
+    // P13A-A3: Break A-B-A-B oscillation before lateral movement
+    const oscEscapeW = detectAndBreakOscillation(actions);
+    if (oscEscapeW) return oscEscapeW;
     // Ground is dangerous or already at ground — keep moving laterally
     if (moveActions.length) {
-      const landMoves = moveActions.filter(a => {
+      const landMoves = intelligentFilterMovesAntiLoop(moveActions.filter(a => {
         const dir = a.id.replace("move-", "");
         const deltas = {"northwest":[-1,-1],"north":[0,-1],"northeast":[1,-1],"west":[-1,0],"east":[1,0],"southwest":[-1,1],"south":[0,1],"southeast":[1,1]};
         const d = deltas[dir]; if (!d) return true;
         return terrainAt(player.x + d[0], player.y + d[1]) !== "water";
-      });
-      return randomBotAction(landMoves.length ? landMoves : moveActions);
+      }));
+      return randomBotAction(landMoves.length ? landMoves : intelligentFilterMovesAntiLoop(moveActions));
     }
   }
 


### PR DESCRIPTION
Six targeted fixes for resource triage, drink-loop exit, and oscillation breaking from post-Patch12 joint GPT/Claude analysis.

- A1: Block repeat drinking when H>=65 and E<=10; seek food instead
- A2: Set seek_food goal after drink when E<=30 for directed recovery
- A3: Detect A-B-A-B position loops at critical stats; blacklist both tiles and return a perpendicular escape move
- A4: Try safe eat before water move when E<=30 in criticalResource gate
- A5: Covered structurally by A1+A4 (no separate path required)
- A6: Clear seek_food goal on E>=50 or after 10-turn staleness timeout; also cleared when oscillation loop detected

Bot/debug tools change only. game/evolution_game_v66_57.html unchanged.

## Summary

<!-- Plain-English summary of what changed and why. -->

## Scope check

Tick every area touched by this PR:

- [ ] Gameplay logic / mechanics
- [ ] UI / layout / presentation
- [ ] Bot / debug / QA tools
- [ ] GitHub Pages / app loading / PWA files
- [ ] Documentation / workflow only
- [ ] Other: <!-- describe -->

## Known bug guardrails

Before marking this PR ready, check `docs/bug-guardrails.md` for any previously documented failure mode that may apply.

- [ ] Reviewed `docs/bug-guardrails.md`
- [ ] Any applicable guardrail checks have been completed
- [ ] If this PR fixes a bug/coding error, a new guardrail entry was added or an existing one was updated
- [ ] If no guardrail applies, state why here: <!-- reason -->

**GPT/Claude instruction:** If a patch introduces or fixes a serious bug, do not treat it as fully resolved until the lesson learned is captured in `docs/bug-guardrails.md` or there is a clear reason not to add one.

## Mandatory syntax/render safety check

Required for any PR touching `game/*.html`, `index.html`, `manifest.json`, bot/debug tooling, or app-loading behaviour.

- [ ] `node scripts/check_html_js_syntax.mjs` passed, or equivalent syntax check performed
- [ ] `game/play.html` opened in a browser
- [ ] Game renders without a blank or half-loaded screen
- [ ] Map is visible
- [ ] Player/status UI is visible
- [ ] Core action controls are visible
- [ ] At least one action/turn can be taken
- [ ] Browser console checked for red JavaScript errors
- [ ] If bot/debug tools were touched: bot can start and stop without crashing

If this check was not run, state clearly here:

> Syntax/render safety check not run.

## Mandatory CHANGELOG reminder

- [ ] `CHANGELOG.txt` updated with a timestamped plain-English entry for this PR
- [ ] Entry states who made the change
- [ ] Entry states whether gameplay logic, UI/layout, bot/debug tools, app-loading behaviour, or documentation changed
- [ ] If the changelog was intentionally not updated, explain why here: <!-- reason -->

**GPT/Claude instruction:** Do not describe a PR as complete, safe, or ready to merge unless the changelog status is explicitly addressed.

## Commit message check

- [ ] No `claude.ai/code/session_...` URLs in any commit message on this PR (repo is public)

## Testing / review notes

<!-- List what was actually checked. Do not claim tests were run if they were not. -->

## Reviewer confirmation

Reviewer must explicitly state one of:

- `Bug guardrails reviewed; applicable checks passed.`
- `Bug guardrails not reviewed.`

Reviewer must explicitly state one of:

- `Syntax/render safety check passed.`
- `Syntax/render safety check not run.`

Reviewer must also explicitly state one of:

- `CHANGELOG updated.`
- `CHANGELOG not updated: [reason].`
