### PR TITLE
Patch 13B: IntelligentBot crisis hardening (B1–B4, P1–P6, A6ext)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,18 @@
+[2026-05-03 patch13b | Claude]
+IntelligentBot crisis hardening — 10 targeted fixes (B1–B4, P1–P6) from post-Patch13A run analysis (log 20260503-170032) and GPT/Claude joint review. Addresses priority enforcement failure under compound crisis. Bot/debug tools change only.
+- B1: Raise rank-1 poison block threshold from F<=15 to F<=30 in intelligentForageBlocked(). Run 10 confirmed death at F=28 eating rank-1 poison with existing threshold.
+- B2: Compound crisis poison block — any rank-1 poison now blocked when (F<=50 AND H<=20) OR E<=10, regardless of rank-2+ check. Prevents eating marginal food when multiple stats are low.
+- B3: Queued-eat recheck expanded — intelligentFindSafeEat() now returns null immediately if an active predator pursuit is in progress (pursuitType=air or dangerProfile=predator/fatal). Prevents eating while being chased.
+- B4: Desperation exception — if F<=5 and no safe food found, rank-1 non-guardian poison food is allowed as last resort with DESPERATION_EAT QA trace tag.
+- P1: Hard crisis gate — when E<=5 OR H<=5 and movement is the only remaining option in criticalResource block, intelligentMoveTowardWater() is tried before randomBotAction(). Prevents aimless drift at minimum stats (Run 7: 5x move-north at E=0/H=0).
+- P2: Resource anchor — at start of RECOVER mode, if current encounter has portions>=2 and (E<=30 OR H<=15 OR F<=15), eat is returned before any other action including movement. Prevents leaving multi-portion food after one eat (Run 8: ate once, moved away, died).
+- P3: Water→food handoff gap fix — new sub-case in criticalResource: when E=0 AND H>=40 AND poisoned, block drink-water and groom, force seek_food goal and climb. Addresses A1 gap exposed in Run 2 (A1 threshold H>=65 was never reached; bot died at H=52 still drinking). Also: parasite groom is skipped when E=0 and poisoned so the criticalResource block can reach food/water logic.
+- P4: Clay bank filter — intelligentFindSafeEat() now skips clay bank encounters unless player.poison is truthy. Clay provides zero energy; eating it at E=0 wastes turns (Run 9: 3x clay consume at E=0/H=0).
+- P5: Oscillation blacklist duration 3→6 turns + forced perpendicular escape. detectAndBreakOscillation() now blacklists loop tiles for 6 turns. Escape move selection computes loop axis (dx/dy between A and B) and returns a dot-product-zero (perpendicular) move first, falling back to other non-blacklisted moves only if no perpendicular is available.
+- A6ext: Goal stagnancy timeout — goalStagnantTurns counter added to botState.memory. updateBotMemory() increments it when last 4 positions span <=2 Manhattan tiles while a goal is active; clears goal after 3 consecutive stagnant turns. Complements existing 10-turn age timeout.
+- game/evolution_game_v66_57.html NOT updated — archived reference version only.
+- Syntax check: PASS.
+
 [2026-05-01 patch13a | Claude]
 IntelligentBot recovery sequencing — 6 targeted fixes (A1–A6) from post-Patch12 retrospective and GPT/Claude joint analysis.
 - A1 (CRITICAL): Drink-loop exit. In RECOVER mode's criticalResource block, when H>=65 and E<=10 the bot no longer returns drink-water. Instead it tries safe eat first, sets a seek_food goal, and climbs off Ground toward food-capable layers. Previously the bot could reach H=90+ while starving to death because E=0 triggered the criticalResource drink path on every turn.

--- a/game/play.html
+++ b/game/play.html
@@ -10962,7 +10962,8 @@ function newBotMemory() {
     lowHydrationTurns: 0, // consecutive turns with hydration <= 45 within this run
     currentGoal: null,    // {type, startTurn, ...} persists until satisfied or cleared
     positionHistory: [],  // [{x, y}] last 6 positions for A-B-A-B oscillation detection (P13A-A3)
-    loopBlacklist: []     // [{x, y, until}] positions blocked to escape local movement loops (P13A-A3)
+    loopBlacklist: [],    // [{x, y, until}] positions blocked to escape local movement loops (P13A-A3)
+    goalStagnantTurns: 0  // consecutive turns goal is active but position spread is minimal (P13B-A6ext)
   };
 }
 
@@ -10992,11 +10993,31 @@ function updateBotMemory() {
   // Expire loop blacklist entries
   if (!m.loopBlacklist) m.loopBlacklist = [];
   m.loopBlacklist = m.loopBlacklist.filter(b => player.turn < b.until);
-  // P13A-A6: Clear seek_food goal when energy recovered; clear any goal after 10 turns
+  // P13A-A6 + P13B-A6ext: Clear goal when energy recovered, age exceeded, or position stagnant
+  if (!('goalStagnantTurns' in m)) m.goalStagnantTurns = 0;
   if (m.currentGoal) {
     const goalAge = player.turn - (m.currentGoal.startTurn ?? player.turn);
-    if (m.currentGoal.type === 'seek_food' && player.energy >= 50) m.currentGoal = null;
-    else if (goalAge > 10) m.currentGoal = null;
+    if (m.currentGoal.type === 'seek_food' && player.energy >= 50) {
+      m.currentGoal = null; m.goalStagnantTurns = 0;
+    } else if (goalAge > 10) {
+      m.currentGoal = null; m.goalStagnantTurns = 0;
+    } else {
+      // Stagnation check: if last 4 positions span <= 2 tiles, goal is making no progress
+      const ph = m.positionHistory || [];
+      if (ph.length >= 4) {
+        const recent = ph.slice(-4);
+        const spread = (Math.max(...recent.map(p => p.x)) - Math.min(...recent.map(p => p.x))) +
+                       (Math.max(...recent.map(p => p.y)) - Math.min(...recent.map(p => p.y)));
+        if (spread <= 2) {
+          m.goalStagnantTurns++;
+          if (m.goalStagnantTurns >= 3) { m.currentGoal = null; m.goalStagnantTurns = 0; }
+        } else {
+          m.goalStagnantTurns = 0;
+        }
+      }
+    }
+  } else {
+    m.goalStagnantTurns = 0;
   }
 }
 
@@ -11386,18 +11407,26 @@ function intelligentForageBlocked(e) {
   if (FORAGE_BLACKLIST.has(String(e.name || "").toLowerCase())) return true;
   // Block any forage whose encounter object already exposes a moderate-or-worse poison
   if (e.poison && e.poison.rank >= 2) return true;
-  // Any poison is dangerous when fitness is critically low — mild poison can be fatal at F<=15
-  if (e.poison && e.poison.rank >= 1 && (player.fitness || 0) <= 15) return true;
+  // P13B-B1: Mild poison fatal risk raised — block rank-1 when fitness <= 30
+  if (e.poison && e.poison.rank >= 1 && (player.fitness || 0) <= 30) return true;
+  // P13B-B2: Compound crisis block — any poison when (F<=50 AND H<=20) OR E<=10
+  if (e.poison && e.poison.rank >= 1 &&
+      ((player.fitness <= 50 && player.hydration <= 20) || player.energy <= 10)) return true;
   // Block anything with a guardian spawn mechanic
   if (e.guardianKey || e.guardianChance) return true;
   return false;
 }
 
 function intelligentFindSafeEat(actions) {
+  // P13B-B3: Don't eat while being actively pursued by a predator
+  if (activePursuit && (activePursuit.pursuitType === 'air' ||
+      activePursuit.dangerProfile === 'predator' || activePursuit.dangerProfile === 'fatal')) return null;
   for (const a of actions) {
     if (a.id === "eat" && currentEncounter) {
       const e = currentEncounter;
       if (intelligentForageBlocked(e)) continue;
+      // P13B-P4: Clay is a remedy only — block when not poisoned
+      if (e.remedy && e.remedy.type === 'clay' && !player.poison) continue;
       const known = player.knownFoods[variantKeyFor(e)];
       if (known && known.severity !== "safe") continue;
       if (["forage", "nest", "remedy", "carcass"].includes(e.kind)) return a;
@@ -11409,6 +11438,19 @@ function intelligentFindSafeEat(actions) {
       if (q && !intelligentForageBlocked(q)) {
         const known = player.knownFoods[variantKeyFor(q)];
         if (!known || known.severity === "safe") return a;
+      }
+    }
+  }
+  // P13B-B4: Desperation — F<=5 with no safe food, allow rank-1 poison as last resort
+  if ((player.fitness || 0) <= 5) {
+    for (const a of actions) {
+      if (a.id === "eat" && currentEncounter) {
+        const e = currentEncounter;
+        if (e.poison && e.poison.rank === 1 && !e.guardianKey && !e.guardianChance &&
+            e.dangerProfile !== "toxic_food" && !FORAGE_BLACKLIST.has(String(e.name || "").toLowerCase())) {
+          addQAIssue("DESPERATION_EAT", "info", { encounter: e.name, fitness: player.fitness });
+          return a;
+        }
       }
     }
   }
@@ -11426,29 +11468,34 @@ function detectAndBreakOscillation(actions) {
   const p0 = h[n-4], p1 = h[n-3], p2 = h[n-2], p3 = h[n-1];
   const eq = (a, b) => a.x === b.x && a.y === b.y;
   if (!eq(p0, p2) || !eq(p1, p3) || eq(p0, p1)) return null;
-  // A-B-A-B confirmed — blacklist both positions for 3 turns
+  // A-B-A-B confirmed — blacklist both positions for 6 turns (P13B-P5: increased from 3)
   m.loopBlacklist = m.loopBlacklist || [];
   if (!m.loopBlacklist.find(b => b.x === p0.x && b.y === p0.y))
-    m.loopBlacklist.push({ x: p0.x, y: p0.y, until: player.turn + 3 });
+    m.loopBlacklist.push({ x: p0.x, y: p0.y, until: player.turn + 6 });
   if (!m.loopBlacklist.find(b => b.x === p1.x && b.y === p1.y))
-    m.loopBlacklist.push({ x: p1.x, y: p1.y, until: player.turn + 3 });
-  if (m.currentGoal) m.currentGoal = null; // A6: stale goal likely contributed to loop
+    m.loopBlacklist.push({ x: p1.x, y: p1.y, until: player.turn + 6 });
+  if (m.currentGoal) { m.currentGoal = null; m.goalStagnantTurns = 0; } // A6: stale goal contributed to loop
   const deltas = {
     "move-northwest":[-1,-1],"move-north":[0,-1],"move-northeast":[1,-1],
     "move-west":[-1,0],"move-east":[1,0],
     "move-southwest":[-1,1],"move-south":[0,1],"move-southeast":[1,1]
   };
   const byId = Object.fromEntries(actions.map(a => [a.id, a]));
-  const escapeMoves = [];
+  // P13B-P5: Force perpendicular escape — compute loop axis and prefer cross-axis directions
+  const loopDx = p1.x - p0.x, loopDy = p1.y - p0.y;
+  const perpMoves = [], otherMoves = [];
   for (const [id, d] of Object.entries(deltas)) {
     const a = byId[id];
     if (!a) continue;
     const nx = player.x + d[0], ny = player.y + d[1];
     if (m.loopBlacklist.find(b => b.x === nx && b.y === ny)) continue;
     if (nx >= 0 && ny >= 0 && nx < WORLD_SIZE && ny < WORLD_SIZE && terrainAt(nx, ny) === 'water') continue;
-    escapeMoves.push(a);
+    // A move is perpendicular if its dot product with the loop direction is zero
+    const dot = d[0] * loopDx + d[1] * loopDy;
+    if (dot === 0) perpMoves.push(a); else otherMoves.push(a);
   }
-  if (escapeMoves.length) return randomBotAction(escapeMoves);
+  if (perpMoves.length) return randomBotAction(perpMoves);
+  if (otherMoves.length) return randomBotAction(otherMoves);
   if (byId["climb"]) return byId["climb"];
   if (byId["descend"] && !hasRecentGroundThreat()) return byId["descend"];
   return null;
@@ -11676,8 +11723,15 @@ function chooseIntelligentBotAction(actions) {
   }
 
   if (mode === "RECOVER") {
-    // Groom immediately if parasites — now that groom is in the action list this will fire
-    if ((player.parasites || 0) >= 1 && byId["groom"]) return byId["groom"];
+    // P13B-P2: Resource anchor — multi-portion safe food at low stats: eat before moving
+    if (currentEncounter && (currentEncounter.portions || 0) >= 2 &&
+        (player.energy <= 30 || player.hydration <= 15 || player.fitness <= 15)) {
+      const eat = intelligentFindSafeEat(actions);
+      if (eat) return eat;
+    }
+    // Groom immediately if parasites — skip only when starving and poisoned (P13B-P3)
+    if ((player.parasites || 0) >= 1 && byId["groom"] &&
+        !(player.energy <= 0 && player.poison)) return byId["groom"];
     // Critical hydration — drink immediately
     if (player.hydration <= 20 && byId["drink-water"]) return byId["drink-water"];
     // Critical energy — eat safe food before water-seeking or movement (resource-anchor)
@@ -11689,13 +11743,20 @@ function chooseIntelligentBotAction(actions) {
     const criticalResource = player.energy <= 10 || player.hydration <= 10;
     if (criticalResource) {
       const mCrit = botState.memory || (botState.memory = newBotMemory());
-      // P13A-A1: If adequately hydrated but critically starving, eat or climb toward food — don't keep drinking
-      if (player.hydration >= 65 && player.energy <= 10) {
+      // P13B-P3: Poisoned + E=0 + H sufficient — block drink/groom, force food seek
+      if (player.energy <= 0 && player.hydration >= 40 && player.poison) {
         const eat = intelligentFindSafeEat(actions);
         if (eat) return eat;
         if (!mCrit.currentGoal || mCrit.currentGoal.type !== 'seek_food')
           mCrit.currentGoal = { type: 'seek_food', startTurn: player.turn };
-        // Climb toward food-capable layer when stuck at ground
+        if (player.z === 0 && byId["climb"] && !hasRecentAerialThreat()) return byId["climb"];
+        // fall through to movement — drink-water and groom deliberately skipped
+      } else if (player.hydration >= 65 && player.energy <= 10) {
+        // P13A-A1: Adequately hydrated but starving — eat or seek food, don't keep drinking
+        const eat = intelligentFindSafeEat(actions);
+        if (eat) return eat;
+        if (!mCrit.currentGoal || mCrit.currentGoal.type !== 'seek_food')
+          mCrit.currentGoal = { type: 'seek_food', startTurn: player.turn };
         if (player.z === 0 && byId["climb"] && !hasRecentAerialThreat()) return byId["climb"];
       } else {
         // P13A-A4: If E is also low, try an immediately available safe eat before pursuing water
@@ -11706,7 +11767,7 @@ function chooseIntelligentBotAction(actions) {
         const drinkMove = byId["drink-water"] || intelligentMoveTowardWater(actions);
         if (drinkMove) return drinkMove;
       }
-      // P13A-A3: Break A-B-A-B oscillation before falling back to random movement
+      // P13A-A3: Break A-B-A-B oscillation before falling back to movement
       const oscEscapeCrit = detectAndBreakOscillation(actions);
       if (oscEscapeCrit) return oscEscapeCrit;
       const landMoves = intelligentFilterMovesAntiLoop(moveActions.filter(a => {
@@ -11715,6 +11776,11 @@ function chooseIntelligentBotAction(actions) {
         const d = deltas[dir]; if (!d) return true;
         return terrainAt(player.x + d[0], player.y + d[1]) !== "water";
       }));
+      // P13B-P1: At deepest crisis (E<=5 or H<=5) prefer goal-directed water move over random
+      if (player.energy <= 5 || player.hydration <= 5) {
+        const waterDir = intelligentMoveTowardWater(actions);
+        if (waterDir) return waterDir;
+      }
       if (landMoves.length) return randomBotAction(landMoves);
       if (moveActions.length) return randomBotAction(intelligentFilterMovesAntiLoop(moveActions));
     }


### PR DESCRIPTION
## Summary

Patch 13B hardens priority enforcement under compound crisis. The core diagnosis from post-13A run analysis: the bot does not commit under crisis — it evaluates options per-turn but does not lock into a recovery strategy. These fixes make survival decisions mandatory, not preferred.

Validated against log `20260503-170032` (11 deaths, median 78, mean 87, longest 270).

---

### B1 — Raise rank-1 poison block threshold (Run 10)
`intelligentForageBlocked()`: rank-1 poison now blocked when `F <= 30` (was `F <= 15`). Run 10 ate rank-1 berries at F=28 and died carrying poison load 3.

### B2 — Compound crisis poison block (Runs 1, 2, 6)
`intelligentForageBlocked()`: any rank-1 poison additionally blocked when `(F <= 50 AND H <= 20) OR E <= 10`. Prevents eating marginal food when multiple stats are simultaneously low.

### B3 — Pursuit-active eat block (B3 recheck expanded)
`intelligentFindSafeEat()`: returns `null` immediately if `activePursuit` is a predator (`pursuitType=air` or `dangerProfile=predator/fatal`). Prevents wasting an escape turn on eating while being chased.

### B4 — Desperation exception (F<=5)
`intelligentFindSafeEat()`: if F<=5 and no safe food is found in the main loop, allows rank-1 non-guardian poison food as last resort. Tags the action with `DESPERATION_EAT` QA issue for tracing.

### P1 — Hard crisis water direction (Runs 7, 9)
In `criticalResource` block: when `E <= 5 OR H <= 5` and only movement remains, `intelligentMoveTowardWater()` is tried before `randomBotAction()`. Prevents aimless movement at minimum stats (Run 7: 5x move-north at E=0/H=0).

### P2 — Resource anchor (Run 8)
At top of RECOVER mode: if current encounter has `portions >= 2` and `(E <= 30 OR H <= 15 OR F <= 15)`, eat is returned before movement or any other non-parasite action. Run 8: bot ate fallen nuts once, moved away with 1 portion remaining, died dehydrated.

### P3 — Water→food handoff gap fix (Run 2 — A1 gap)
New sub-case in `criticalResource`: when `E <= 0 AND H >= 40 AND player.poison`, block drink-water and groom, force `seek_food` goal. The existing A1 threshold of `H >= 65` was never reached in Run 2 (bot died at H=52 still drinking). Also: parasite groom now skipped when `E <= 0 AND poisoned` so the criticalResource block reaches food/water logic instead.

### P4 — Clay bank filter (Run 9)
`intelligentFindSafeEat()`: clay bank encounters skipped unless `player.poison` is truthy. Clay provides zero energy; Run 9 consumed clay 3 times at E=0/H=0 with no poison present.

### P5 — Oscillation blacklist 3→6 turns + forced perpendicular (Runs 6, 8, 9)
`detectAndBreakOscillation()`: blacklist duration increased from 3 to 6 turns. Escape direction now computed from loop axis (dx/dy between A and B positions); perpendicular moves (dot product = 0 with loop vector) are preferred first. Falls back to other non-blacklisted moves if no perpendicular available.

### A6ext — Goal stagnancy timeout
`newBotMemory()`: adds `goalStagnantTurns: 0`. `updateBotMemory()`: increments counter when last 4 positions span ≤ 2 Manhattan tiles while a goal is active; clears goal after 3 consecutive stagnant turns. Complements the existing 10-turn age timeout.

---

### Files changed
- `game/play.html` — bot logic only
- `CHANGELOG.txt` — Patch 13B entry prepended

### Scope
Strictly the 10 items listed. No new modes, no pathfinding, no map memory, no files outside the two above.

---
_Generated by [Claude Code](https://claude.ai/code/session_014dNQz8F3y6rJeuo6TEZSGd)_