### PR TITLE
Patch 13C: IntelligentBot crisis enforcement (C1–C8)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,17 @@
+[2026-05-03 patch13c | Claude]
+IntelligentBot crisis enforcement — 8 targeted fixes (C1–C8) from post-Patch13B three-run analysis and GPT/Claude joint review. Enforces hard priority under compound crisis. Bot/debug tools change only.
+- C1: P1 water/food conflation fix. In criticalResource, waterDir is now only returned when H<=20 or H<E. Previously, intelligentMoveTowardWater fired even when E was the crisis and H was adequate (e.g. E=5, H=62), sending the bot toward water when it should have been seeking food.
+- C2: H<=5 drink priority over eat. When H<=5 in the criticalResource else-branch, drink-water and intelligentMoveTowardWater are tried before the A4 eat path. Previously A4 (eat at E<=30) could fire before drink even at H=0.
+- C3: Bootstrap grace period. botState.memory.bootTurns increments each turn and resets on run start. In EXPLORE mode, the climb-toward-canopy action is suppressed when bootTurns<=4 and z>=1. Ground→Undergrowth climb is always permitted. Prevents bot climbing straight into aerial predator on fresh resets.
+- C4: Cache water scan direction in criticalResource. After intelligentMoveTowardWater returns a direction, it is stored as a seek_water goal (dirId + turn). If the scan returns null on the next turn (two equidistant water sources causing flip), the cached direction is reused for up to 3 turns. Eliminates water-scan-flip oscillation (E-W loop driven by scanner, not random movement).
+- C5: Position history movement-only push. updateBotMemory() now only appends to positionHistory when player position changed from the previous entry. Non-movement actions (groom, eat, wait) previously inserted duplicate positions, breaking A-B-A-B detection when groom interrupted an oscillation sequence.
+- C6: Groom guard extended. Parasite groom is skipped when E<=0 AND (player.poison OR player.fitness<=10). Previously the guard checked player.poison only, which cleared before the final damage tick of an expiring poison (turns=0), allowing groom to fire at near-death fitness.
+- C7: Aerial escape stickiness. escapeTimer field added to botState.memory. When EMERGENCY_ESCAPE fires against an aerial threat (pursuitType=air), escapeTimer is set to 3. updateBotMemory() decrements it each turn. determineIntelligentBotMode() returns RECOVER instead of EXPLORE while escapeTimer>0 and no active threat. Prevents immediate re-entry to EXPLORE after one aerial escape turn.
+- C8: Hard resource lock. At the top of RECOVER mode, when (E<=10 OR H<=10) and no active pursuit: drink-water or intelligentFindSafeEat is returned immediately before any other action including parasite groom. Priority: drink first when H<=E, eat first otherwise. Enforces resource consumption before movement when a resource is immediately available.
+- CLAUDE.md updated: added explicit prohibition on writing analysis/reports to repo (chat only).
+- game/evolution_game_v66_57.html NOT updated — archived reference version only.
+- Syntax check: PASS.
+
 [2026-05-03 patch13b | Claude]
 IntelligentBot crisis hardening — 10 targeted fixes (B1–B4, P1–P6) from post-Patch13A run analysis (log 20260503-170032) and GPT/Claude joint review. Addresses priority enforcement failure under compound crisis. Bot/debug tools change only.
 - B1: Raise rank-1 poison block threshold from F<=15 to F<=30 in intelligentForageBlocked(). Run 10 confirmed death at F=28 eating rank-1 poison with existing threshold.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,11 @@ You must NOT:
 
 Unless explicitly told.
 
+Analysis, reports, and reviews must NEVER be written to the repository.
+These are always delivered in chat. Repository writes are restricted to
+implementation changes only (game/play.html, CHANGELOG.txt, and explicitly
+authorised log commits). No exceptions without direct instruction from George.
+
 ---
 
 ## 7. SECURITY RULE (CRITICAL)

--- a/game/play.html
+++ b/game/play.html
@@ -10963,7 +10963,9 @@ function newBotMemory() {
     currentGoal: null,    // {type, startTurn, ...} persists until satisfied or cleared
     positionHistory: [],  // [{x, y}] last 6 positions for A-B-A-B oscillation detection (P13A-A3)
     loopBlacklist: [],    // [{x, y, until}] positions blocked to escape local movement loops (P13A-A3)
-    goalStagnantTurns: 0  // consecutive turns goal is active but position spread is minimal (P13B-A6ext)
+    goalStagnantTurns: 0, // consecutive turns goal is active but position spread is minimal (P13B-A6ext)
+    escapeTimer: 0,       // turns remaining of post-aerial-escape RECOVER bias (P13C-C7)
+    bootTurns: 0          // turns elapsed since last reset; suppresses early canopy climb (P13C-C3)
   };
 }
 
@@ -10986,10 +10988,19 @@ function updateBotMemory() {
   }
   m.parasiteTurns = (player.parasites || 0) >= 1 ? m.parasiteTurns + 1 : 0;
   m.lowHydrationTurns = player.hydration <= 45 ? m.lowHydrationTurns + 1 : 0;
-  // P13A-A3: Track position history for A-B-A-B oscillation detection
+  // P13C-C3: Count turns since reset for bootstrap grace period
+  if (!('bootTurns' in m)) m.bootTurns = 0;
+  m.bootTurns++;
+  // P13C-C7: Decrement aerial escape stickiness timer
+  if (!('escapeTimer' in m)) m.escapeTimer = 0;
+  if (m.escapeTimer > 0) m.escapeTimer--;
+  // P13A-A3: Track position history — C5: only push when position actually changed
   if (!m.positionHistory) m.positionHistory = [];
-  m.positionHistory.push({ x: player.x, y: player.y });
-  if (m.positionHistory.length > 6) m.positionHistory.shift();
+  const ph = m.positionHistory;
+  if (ph.length === 0 || ph[ph.length-1].x !== player.x || ph[ph.length-1].y !== player.y) {
+    ph.push({ x: player.x, y: player.y });
+  }
+  if (ph.length > 6) ph.shift();
   // Expire loop blacklist entries
   if (!m.loopBlacklist) m.loopBlacklist = [];
   m.loopBlacklist = m.loopBlacklist.filter(b => player.turn < b.until);
@@ -11681,6 +11692,9 @@ function determineIntelligentBotMode(threat) {
   if (player.poison || player.fitness <= 45 || (player.parasites || 0) >= 1) return "RECOVER";
   if (player.hydration <= 50) return "WATER_PLAN";
   if (player.energy <= 60) return "SAFE_FORAGE";
+  // P13C-C7: After aerial escape, hold RECOVER bias instead of returning to EXPLORE
+  const mMode = botState.memory;
+  if (mMode && (mMode.escapeTimer || 0) > 0) return "RECOVER";
   return "EXPLORE";
 }
 
@@ -11708,7 +11722,10 @@ function chooseIntelligentBotAction(actions) {
   botState._lastMode = mode;
 
   if (mode === "EMERGENCY_ESCAPE") {
+    // P13C-C7: Set escape stickiness timer when aerial threat is present
+    const mEsc = botState.memory || (botState.memory = newBotMemory());
     const escapeThreat = activeThreat || threat;
+    if (escapeThreat && escapeThreat.pursuitType === 'air') mEsc.escapeTimer = 3;
     const escape = threatAwareEscape(actions, escapeThreat);
     if (escape) return escape;
     if (moveActions.length) return randomBotAction(moveActions);
@@ -11723,15 +11740,23 @@ function chooseIntelligentBotAction(actions) {
   }
 
   if (mode === "RECOVER") {
+    // P13C-C8: Hard resource lock — at critical stats, consume available resource before moving
+    if ((player.energy <= 10 || player.hydration <= 10) && !activePursuit) {
+      const critDrink = byId["drink-water"];
+      const critEat = intelligentFindSafeEat(actions);
+      if (player.hydration <= player.energy && critDrink) return critDrink;
+      if (critEat) return critEat;
+      if (critDrink) return critDrink;
+    }
     // P13B-P2: Resource anchor — multi-portion safe food at low stats: eat before moving
     if (currentEncounter && (currentEncounter.portions || 0) >= 2 &&
         (player.energy <= 30 || player.hydration <= 15 || player.fitness <= 15)) {
       const eat = intelligentFindSafeEat(actions);
       if (eat) return eat;
     }
-    // Groom immediately if parasites — skip only when starving and poisoned (P13B-P3)
+    // Groom immediately if parasites — skip when starving+poisoned or near-death (P13B-P3 + P13C-C6)
     if ((player.parasites || 0) >= 1 && byId["groom"] &&
-        !(player.energy <= 0 && player.poison)) return byId["groom"];
+        !(player.energy <= 0 && (player.poison || player.fitness <= 10))) return byId["groom"];
     // Critical hydration — drink immediately
     if (player.hydration <= 20 && byId["drink-water"]) return byId["drink-water"];
     // Critical energy — eat safe food before water-seeking or movement (resource-anchor)
@@ -11759,13 +11784,38 @@ function chooseIntelligentBotAction(actions) {
           mCrit.currentGoal = { type: 'seek_food', startTurn: player.turn };
         if (player.z === 0 && byId["climb"] && !hasRecentAerialThreat()) return byId["climb"];
       } else {
+        // P13C-C2: H<=5 — drink takes absolute priority over eat
+        if (player.hydration <= 5) {
+          const critDrink = byId["drink-water"];
+          if (critDrink) { mCrit.currentGoal = null; return critDrink; }
+          const wDir = intelligentMoveTowardWater(actions);
+          if (wDir) {
+            mCrit.currentGoal = { type: 'seek_water', dirId: wDir.id, turn: player.turn };
+            return wDir;
+          }
+          // C4: Reuse cached water direction if scan fails this turn
+          if (mCrit.currentGoal && mCrit.currentGoal.type === 'seek_water' && mCrit.currentGoal.dirId) {
+            const cached = byId[mCrit.currentGoal.dirId];
+            if (cached && (player.turn - mCrit.currentGoal.turn) <= 3) return cached;
+          }
+        }
         // P13A-A4: If E is also low, try an immediately available safe eat before pursuing water
         if (player.energy <= 30) {
           const eat = intelligentFindSafeEat(actions);
           if (eat) return eat;
         }
-        const drinkMove = byId["drink-water"] || intelligentMoveTowardWater(actions);
-        if (drinkMove) return drinkMove;
+        // P13C-C4: Cache water direction to prevent scan-flip oscillation
+        const drinkAction = byId["drink-water"];
+        if (drinkAction) { mCrit.currentGoal = null; return drinkAction; }
+        const waterDir = intelligentMoveTowardWater(actions);
+        if (waterDir) {
+          mCrit.currentGoal = { type: 'seek_water', dirId: waterDir.id, turn: player.turn };
+          return waterDir;
+        }
+        if (mCrit.currentGoal && mCrit.currentGoal.type === 'seek_water' && mCrit.currentGoal.dirId) {
+          const cached = byId[mCrit.currentGoal.dirId];
+          if (cached && (player.turn - mCrit.currentGoal.turn) <= 3) return cached;
+        }
       }
       // P13A-A3: Break A-B-A-B oscillation before falling back to movement
       const oscEscapeCrit = detectAndBreakOscillation(actions);
@@ -11776,10 +11826,12 @@ function chooseIntelligentBotAction(actions) {
         const d = deltas[dir]; if (!d) return true;
         return terrainAt(player.x + d[0], player.y + d[1]) !== "water";
       }));
-      // P13B-P1: At deepest crisis (E<=5 or H<=5) prefer goal-directed water move over random
+      // P13C-C1: At deepest crisis, water direction only when H is the crisis (not E-only starvation)
       if (player.energy <= 5 || player.hydration <= 5) {
-        const waterDir = intelligentMoveTowardWater(actions);
-        if (waterDir) return waterDir;
+        if (player.hydration <= 20 || player.hydration <= player.energy) {
+          const waterDir = intelligentMoveTowardWater(actions);
+          if (waterDir) return waterDir;
+        }
       }
       if (landMoves.length) return randomBotAction(landMoves);
       if (moveActions.length) return randomBotAction(intelligentFilterMovesAntiLoop(moveActions));
@@ -11911,6 +11963,9 @@ function chooseIntelligentBotAction(actions) {
   }
 
   // EXPLORE (and fallthrough from SAFE_FORAGE when no action found)
+  // P13C-C3: Bootstrap grace — suppress climb above Undergrowth (z=1) for first 4 turns
+  const mExp = botState.memory;
+  const inBootstrap = mExp && (mExp.bootTurns || 0) <= 4;
   // Bootstrap: always climb off ground immediately — ground is most dangerous layer
   if (player.z === 0 && climbAction && !hasRecentAerialThreat()) return climbAction;
   // On the ground floor, never waste a turn on look/call/sleep/wait if climbing or moving is possible
@@ -11922,8 +11977,8 @@ function chooseIntelligentBotAction(actions) {
   if (enc && (threat.isDangerous || threat.isThreatClass) && moveActions.length) {
     return threatAwareEscape(actions, threat) || randomBotAction(moveActions);
   }
-  // Climb toward canopy when safe — no aerial threat in recent memory, not urgently needed on ground
-  if (!urgentNeedsGround && !hasRecentAerialThreat() && climbAction) return climbAction;
+  // Climb toward canopy when safe — suppressed during bootstrap grace (C3) and aerial threat memory
+  if (!inBootstrap && !urgentNeedsGround && !hasRecentAerialThreat() && climbAction) return climbAction;
   const nonAttack = actions.filter(a => {
     if (a.id.startsWith("attack") || a.id.startsWith("queued-attack")) return false;
     // Only descend when thirsty; WATER_PLAN owns descent for water access, so in EXPLORE/SAFE_FORAGE


### PR DESCRIPTION
## Summary

Patch 13C enforces hard decision priority under compound crisis. Post-13B analysis identified that behaviour was conditionally correct but not reliably enforced. These 8 fixes make survival actions mandatory, not preferred.

Validated against logs 20260503-173017, 20260503-173217, 20260503-173412.

---

### C1 — P1 water/food conflation fix
`criticalResource` block: `intelligentMoveTowardWater` now only fires when `H <= 20 OR H <= E`. Previously returned waterDir even when `E=5, H=62` — bot moved toward water while starving with adequate hydration.

### C2 — H<=5 drink priority over eat
`criticalResource` else-branch: when `H <= 5`, drink-water and water direction are tried before the A4 eat path. Previously A4 (eat at E<=30) fired before drink even at H=0, causing eat-before-water inversion at critical hydration.

### C3 — Bootstrap grace period
`botState.memory.bootTurns` increments each turn, resets on run start. In EXPLORE mode, the climb-toward-canopy action is suppressed when `bootTurns <= 4` and `z >= 1`. Ground→Undergrowth climb always permitted. Prevents bot climbing straight into aerial predators on fresh resets (4 such deaths in a single run in 173217).

### C4 — Cache water scan direction
`criticalResource`: after `intelligentMoveTowardWater` returns, direction is stored as `seek_water` goal (`dirId + turn`). If the scan returns null next turn (two equidistant water sources flipping), cached direction reused for up to 3 turns. Eliminates water-scan-flip E-W oscillation confirmed in multiple death traces.

### C5 — Position history movement-only push
`updateBotMemory()`: only appends to `positionHistory` when position actually changed. Non-movement actions (groom, eat) previously inserted duplicate coordinates, breaking A-B-A-B detection when a groom action appeared mid-oscillation sequence (confirmed in 173217 Run 15 ant trail loop).

### C6 — Groom guard extended
Parasite groom skipped when `E <= 0 AND (player.poison OR player.fitness <= 10)`. Previously checked `player.poison` only — which clears before the final tick of expiring poison (`turns=0`), allowing groom to fire at near-death fitness while still taking poison damage.

### C7 — Aerial escape stickiness
`escapeTimer` field added to memory. On EMERGENCY_ESCAPE against aerial threat (`pursuitType=air`), `escapeTimer = 3`. `updateBotMemory()` decrements each turn. `determineIntelligentBotMode()` returns RECOVER instead of EXPLORE while `escapeTimer > 0` and no active threat. Prevents single-turn escape followed by immediate re-entry to EXPLORE.

### C8 — Hard resource lock
At the top of RECOVER mode, before parasite groom: when `(E <= 10 OR H <= 10)` and no active pursuit, drink-water or `intelligentFindSafeEat` is returned immediately. Priority: drink first when `H <= E`, eat first otherwise. Enforces resource consumption over movement when a resource is available on the current tile.

---

### Also in this PR
- `CLAUDE.md` updated: explicit prohibition on writing analysis/reports to repository (chat only, per process correction).

### Files changed
- `game/play.html` — bot logic only
- `CHANGELOG.txt` — Patch 13C entry prepended
- `CLAUDE.md` — reporting rule clarification

### Scope
Strictly C1–C8. No new modes. No new architecture. No changes outside the three files above.

---
_Generated by [Claude Code](https://claude.ai/code/session_014dNQz8F3y6rJeuo6TEZSGd)_