### PR TITLE
Patch 13D: compound crisis mode override and bootstrap nonAttack fix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,10 @@
+[2026-05-03 patch13d | Claude]
+IntelligentBot crisis mode and bootstrap hotfix — 2 surgical fixes (D1–D2) from post-13C three-run analysis. Closes WATER_PLAN bypass gap and completes C3 bootstrap enforcement. Bot/debug tools change only.
+- D1: Compound crisis mode override. In determineIntelligentBotMode(), a new check before WATER_PLAN routes to RECOVER when E<=10 AND H<=10 regardless of fitness. Previously, healthy fitness (>45%) caused WATER_PLAN selection at E=0/H=0, bypassing C8 hard resource lock entirely. 175820 Run 12 confirmed: bot oscillated past safe magnolia flowers in WATER_PLAN at F=69/E=0/H=0.
+- D2: Bootstrap nonAttack filter. In EXPLORE mode nonAttack filter, climb/sleep/call/look are blocked when inBootstrap (bootTurns<=4) and z>=1. C3 suppressed the explicit climb return but randomBotAction(nonAttack) could still return climb or sleep during the grace period. 175503 Runs 10/12/13 confirmed: sleep|Canopy at turn 4 after 3 climbs.
+- game/evolution_game_v66_57.html NOT updated — archived reference version only.
+- Syntax check: PASS.
+
 [2026-05-03 patch13c | Claude]
 IntelligentBot crisis enforcement — 8 targeted fixes (C1–C8) from post-Patch13B three-run analysis and GPT/Claude joint review. Enforces hard priority under compound crisis. Bot/debug tools change only.
 - C1: P1 water/food conflation fix. In criticalResource, waterDir is now only returned when H<=20 or H<E. Previously, intelligentMoveTowardWater fired even when E was the crisis and H was adequate (e.g. E=5, H=62), sending the bot toward water when it should have been seeking food.

--- a/game/play.html
+++ b/game/play.html
@@ -11690,6 +11690,8 @@ function hasRecentGroundThreat() {
 function determineIntelligentBotMode(threat) {
   if (threat.isFatal || activePursuit || threat.isPredatorDanger) return "EMERGENCY_ESCAPE";
   if (player.poison || player.fitness <= 45 || (player.parasites || 0) >= 1) return "RECOVER";
+  // P13D-D1: Compound crisis — E<=10 AND H<=10 routes to RECOVER regardless of fitness
+  if (player.energy <= 10 && player.hydration <= 10) return "RECOVER";
   if (player.hydration <= 50) return "WATER_PLAN";
   if (player.energy <= 60) return "SAFE_FORAGE";
   // P13C-C7: After aerial escape, hold RECOVER bias instead of returning to EXPLORE
@@ -11981,6 +11983,8 @@ function chooseIntelligentBotAction(actions) {
   if (!inBootstrap && !urgentNeedsGround && !hasRecentAerialThreat() && climbAction) return climbAction;
   const nonAttack = actions.filter(a => {
     if (a.id.startsWith("attack") || a.id.startsWith("queued-attack")) return false;
+    // P13D-D2: Bootstrap grace — block climb/sleep/call/look above ground for first 4 turns
+    if (inBootstrap && player.z >= 1 && (a.id === "climb" || a.id === "sleep" || a.id === "call" || a.id === "look")) return false;
     // Only descend when thirsty; WATER_PLAN owns descent for water access, so in EXPLORE/SAFE_FORAGE
     // fallthrough (H always >50 here) descent is almost never justified and risks ground predators
     if (a.id === "descend" && player.hydration > 50) return false;


### PR DESCRIPTION
## Summary

- **D1**: In `determineIntelligentBotMode()`, add compound crisis check (`E<=10 AND H<=10 → RECOVER`) before the `WATER_PLAN` branch. Closes C8 hard resource lock bypass — previously healthy fitness (>45%) routed to WATER_PLAN at E=0/H=0, skipping all RECOVER crisis logic. Proven by 175820 Run 12: bot oscillated past safe magnolia flowers at F=69/E=0/H=0 in WATER_PLAN mode.
- **D2**: In EXPLORE `nonAttack` filter, block `climb/sleep/call/look` when `inBootstrap` (bootTurns<=4) and `z>=1`. Completes C3 — the explicit climb suppression was in place but `randomBotAction(nonAttack)` could still return climb or sleep during the grace period. Proven by 175503 Runs 10/12/13: `sleep|Canopy` at turn 4 after 3 climbs.

## Files changed

- `game/play.html` — 2 one-line insertions in existing functions
- `CHANGELOG.txt` — patch13d entry prepended

---
_Generated by [Claude Code](https://claude.ai/code/session_014dNQz8F3y6rJeuo6TEZSGd)_