### PR TITLE
Patch 13E: logging observability — decision context in steps and trace.json

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,13 @@
+[2026-05-04 patch13e | Claude]
+IntelligentBot logging observability — 5 targeted changes (E1–E5) from GPT post-13D log review. Adds decision context to step records and introduces trace.json per run for API-fetchable diagnostics. Bot/debug tools change only; no behaviour change.
+- E1: Decision context capture. In chooseIntelligentBotAction(), after mode is determined, botState._lastContext is populated with: goalType, goalTarget, bootTurns, escapeTimer, drinkAvailable, eatAvailable. Captured once per step at the point where mode routing is resolved.
+- E2: Step record extended. Each entry in botState.steps now includes: mode, goalType, goalTarget, bootTurns, escapeTimer, drinkAvailable, eatAvailable. These fields flow into full.txt JSON and trace.json. Allows reviewers to see what goal was active and whether resources were available at every decision point.
+- E3: trace.json added per run. buildBotTraceJson() produces a compact JSON file containing the last 10 steps per run with full decision-context fields. File stays well under 1MB, making it fetchable via the GitHub contents API. Included in pushBotRunToGitHub() alongside meta.json, compact.txt, full.txt.
+- E4: hasFullReport truthfulness fix. buildBotMetaJson() previously hardcoded hasFullReport: true. Now set to report.stepsRun > 0, so meta.json correctly reflects whether step data was actually captured.
+- E5: trace.json documents mode routing, goal state, and resource availability at each terminal step — directly answering the diagnostic questions raised in the post-13D GPT review (was drink available? was a goal active? what was bootTurns/escapeTimer?).
+- game/evolution_game_v66_57.html NOT updated — archived reference version only.
+- Syntax check: PASS.
+
 [2026-05-03 patch13d | Claude]
 IntelligentBot crisis mode and bootstrap hotfix — 2 surgical fixes (D1–D2) from post-13C three-run analysis. Closes WATER_PLAN bypass gap and completes C3 bootstrap enforcement. Bot/debug tools change only.
 - D1: Compound crisis mode override. In determineIntelligentBotMode(), a new check before WATER_PLAN routes to RECOVER when E<=10 AND H<=10 regardless of fitness. Previously, healthy fitness (>45%) caused WATER_PLAN selection at E=0/H=0, bypassing C8 hard resource lock entirely. 175820 Run 12 confirmed: bot oscillated past safe magnolia flowers in WATER_PLAN at F=69/E=0/H=0.

--- a/game/play.html
+++ b/game/play.html
@@ -11707,7 +11707,8 @@ function chooseIntelligentBotAction(actions) {
   const descendAction = byId["descend"] || null;
   const urgentNeedsGround = player.hydration <= 30 || player.energy <= 25;
 
-  botState._lastMode = null; // clear stale mode before any early return
+  botState._lastMode = null;    // clear stale mode before any early return
+  botState._lastContext = null; // P13E Codex: clear stale context before any early return
 
   const enc = currentEncounter;
   const threat = classifyThreat(enc);
@@ -11722,6 +11723,16 @@ function chooseIntelligentBotAction(actions) {
 
   const mode = determineIntelligentBotMode(threat);
   botState._lastMode = mode;
+  // P13E: Capture decision context for step recording
+  const _mem = botState.memory;
+  botState._lastContext = {
+    goalType: (_mem && _mem.currentGoal) ? _mem.currentGoal.type : null,
+    goalTarget: (_mem && _mem.currentGoal) ? _mem.currentGoal.target : null,
+    bootTurns: _mem ? (_mem.bootTurns || 0) : 0,
+    escapeTimer: _mem ? (_mem.escapeTimer || 0) : 0,
+    drinkAvailable: !!byId["drink-water"],
+    eatAvailable: actions.some(a => a.id === "eat" || a.id.startsWith("queued-eat-"))
+  };
 
   if (mode === "EMERGENCY_ESCAPE") {
     // P13C-C7: Set escape stickiness timer when aerial threat is present
@@ -12026,7 +12037,8 @@ function stepIntelligentBot() {
     addDebugFlag("Intelligent bot action threw an error", {action: action.id, error});
   }
   const after = botActionSnapshot();
-  const step = {botStep: botState.steps.length + 1, runIndex: botState.runIndex, actionId: action.id, actionLabel: action.label, actionCategory: action.category, availableActionsBefore: actionList, before, after, error, mode: botState._lastMode || null};
+  const _ctx = botState._lastContext || {};
+  const step = {botStep: botState.steps.length + 1, runIndex: botState.runIndex, actionId: action.id, actionLabel: action.label, actionCategory: action.category, availableActionsBefore: actionList, before, after, error, mode: botState._lastMode || null, goalType: _ctx.goalType || null, goalTarget: _ctx.goalTarget || null, bootTurns: _ctx.bootTurns ?? null, escapeTimer: _ctx.escapeTimer ?? null, drinkAvailable: _ctx.drinkAvailable ?? null, eatAvailable: _ctx.eatAvailable ?? null};
   botState.steps.push(step);
   botValidateStep(step);
   if (error) { stopRandomBot("action error"); render(); return; }
@@ -12130,6 +12142,41 @@ function buildBotFullText(report) {
     "--- JSON BOT DATA ---",
     JSON.stringify(report, null, 2)
   ].join("\n");
+}
+
+// P13E: Compact per-run terminal trace with decision context — stays under 1MB for API fetching
+function buildBotTraceJson(report) {
+  const runs = report.runs.map(run => {
+    const runSteps = report.actions.filter(s => s.runIndex === run.runIndex);
+    const terminalSteps = runSteps.slice(-10).map(s => ({
+      botStep: s.botStep,
+      turn: s.before ? s.before.turn : null,
+      action: s.actionId,
+      mode: s.mode || null,
+      goalType: s.goalType || null,
+      goalTarget: s.goalTarget || null,
+      bootTurns: s.bootTurns ?? null,
+      escapeTimer: s.escapeTimer ?? null,
+      drinkAvailable: s.drinkAvailable ?? null,
+      eatAvailable: s.eatAvailable ?? null,
+      before: s.before ? {x: s.before.x, y: s.before.y, z: s.before.z, layer: s.before.layer, fitness: s.before.fitness, energy: s.before.energy, hydration: s.before.hydration} : null,
+      after: s.after ? {fitness: s.after.fitness, energy: s.after.energy, hydration: s.after.hydration, dead: s.after.dead} : null
+    }));
+    return {
+      runIndex: run.runIndex,
+      reason: run.reason,
+      turns: run.endTurn,
+      issues: run.issues ? run.issues.length : 0,
+      finalState: run.finalState ? {fitness: run.finalState.fitness, energy: run.finalState.energy, hydration: run.finalState.hydration, dead: run.finalState.dead} : null,
+      terminalSteps
+    };
+  });
+  return JSON.stringify({
+    runId: report.startedAt || "",
+    gameVersion: typeof GAME_VERSION !== "undefined" ? GAME_VERSION : "",
+    deaths: report.deaths,
+    runs
+  }, null, 2);
 }
 
 function downloadBotReport() {
@@ -12890,7 +12937,7 @@ function buildBotMetaJson(runId, shortVersion, report) {
     botActions: `${report.stepsRun}/${report.maxSteps}`,
     runsRecorded: String(report.runsCompletedOrRecorded),
     deaths: String(report.deaths),
-    hasFullReport: true,
+    hasFullReport: report.stepsRun > 0,
     savedAt: new Date().toISOString()
   }, null, 2);
 }
@@ -12921,7 +12968,8 @@ async function pushBotRunToGitHub() {
   const files = [
     { path: `${prefix}/meta.json`,   content: buildBotMetaJson(runId, shortVersion, report) },
     { path: `${prefix}/compact.txt`, content: buildBotCompactLines(report).join("\n") },
-    { path: `${prefix}/full.txt`,    content: buildBotFullText(report) }
+    { path: `${prefix}/full.txt`,    content: buildBotFullText(report) },
+    { path: `${prefix}/trace.json`,  content: buildBotTraceJson(report) }
   ];
 
   const base = "https://api.github.com/repos/gy8s/evolution-game";


### PR DESCRIPTION
## Summary

- **E1–E2**: `botState._lastContext` captured in `chooseIntelligentBotAction()` after mode is resolved. Fields: `goalType`, `goalTarget`, `bootTurns`, `escapeTimer`, `drinkAvailable`, `eatAvailable`. All merged into each step record in `botState.steps`, flowing into `full.txt` JSON.
- **E3**: `buildBotTraceJson()` — new function producing last-10-steps per run with full decision-context fields. Output stays well under 1MB, making it fetchable via the GitHub contents API. Added as `trace.json` in `pushBotRunToGitHub()`.
- **E4**: `hasFullReport` in `meta.json` was hardcoded `true`. Now `report.stepsRun > 0` — truthfully reflects whether step data was captured.

## What this unblocks

GPT's post-13D review identified that "every review is partly inference" because logs lacked: mode at decision time, active goal, whether drink/eat was available, bootTurns/escapeTimer state. `trace.json` directly answers all of those for the terminal steps of each run.

## Files changed

- `game/play.html` — 3 additions in existing functions + 1 new function (`buildBotTraceJson`)
- `CHANGELOG.txt` — patch13e entry prepended

---
_Generated by [Claude Code](https://claude.ai/code/session_014dNQz8F3y6rJeuo6TEZSGd)_