### PR TITLE
Patch 13F: final bot hardening — aerial, canopy, stat clamp, H/E crisis

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,15 @@
+[2026-05-04 patch13f | Claude]
+IntelligentBot final hardening — 7 fixes (F1–F7) consolidating original 13C aerial/layer scope and latest-log blockers. This is the v1 QA completion patch. Bot/debug tools change only.
+- F1: Aerial escape direction variation. In threatAwareEscape(), when an aerial threat fires lateral movement, the chosen direction is stored in botState.memory.lastAerialEscapeDir and excluded from the candidate set on the next aerial escape. Eliminates same-key lateral trap where the bot repeatedly moved one direction into the threat.
+- F2: Canopy idle block after recent aerial threat. In the EXPLORE nonAttack filter, look/wait/call/sleep are blocked when player.z>=2 and hasRecentAerialThreat() is true. Prevents idle canopy exposure immediately after an aerial encounter.
+- F3: Weak-state canopy suppression. The EXPLORE climb-toward-canopy return is now gated on player.fitness>40 AND player.energy>30 AND player.hydration>30. Low-stat bot no longer climbs into exposed canopy where aerial predators are disproportionately lethal.
+- F4: Stat underflow clamp (blocker). Wildfire tick used bare `-=` for fitness and hydration; both now use Math.max(0,...). botActionSnapshot() also clamps all three stats defensively. Fixes ERR_STAT_OUT_OF_RANGE x3 and hydration=-1 confirmed in 105455.
+- F5: H<=5 central water priority. Top-level gate added in chooseIntelligentBotAction() before mode dispatch: when H<=5 and no active pursuit, drink-water or intelligentMoveTowardWater is returned immediately. Groom guard extended to also skip when player.hydration<=5 (dehydration kills faster than parasites at this threshold).
+- F6: Drink-loop starvation fix. In determineIntelligentBotMode(), when H>=65 AND E<=30, SAFE_FORAGE is returned instead of WATER_PLAN. Cuts the drink loop at mode level when hydration is recovered but energy is still critical.
+- F7: Resource lock at E<=10 in WATER_PLAN. Mirrors C8: when E<=10 and intelligentFindSafeEat returns an action, eat is returned before any water pursuit. Previously C8 only ran in RECOVER; WATER_PLAN bypassed it even at zero energy.
+- game/evolution_game_v66_57.html NOT updated — archived reference version only.
+- Syntax check: PASS.
+
 [2026-05-04 patch13e | Claude]
 IntelligentBot logging observability — 5 targeted changes (E1–E5) from GPT post-13D log review. Adds decision context to step records and introduces trace.json per run for API-fetchable diagnostics. Bot/debug tools change only; no behaviour change.
 - E1: Decision context capture. In chooseIntelligentBotAction(), after mode is determined, botState._lastContext is populated with: goalType, goalTarget, bootTurns, escapeTimer, drinkAvailable, eatAvailable. Captured once per step at the point where mode routing is resolved.

--- a/game/play.html
+++ b/game/play.html
@@ -8047,10 +8047,10 @@ function applyWildfireProximityEffects() {
   const r = environment.wildfire.radius;
 
   if (dist <= r) {
-    player.fitness -= (2 + environment.wildfire.intensity);
+    player.fitness = Math.max(0, player.fitness - (2 + environment.wildfire.intensity));
     addLog("Flames move through the undergrowth nearby.", "threat");
   } else if (dist <= r + 3) {
-    player.hydration -= 1;
+    player.hydration = Math.max(0, player.hydration - 1);
     addLog("The air grows hot. Animals are moving in the same direction.", "minor");
   } else if (dist <= r + 6) {
     if (player.turn % 3 === 0) addLog("Smoke hangs faintly in the air.", "minor");
@@ -10964,8 +10964,9 @@ function newBotMemory() {
     positionHistory: [],  // [{x, y}] last 6 positions for A-B-A-B oscillation detection (P13A-A3)
     loopBlacklist: [],    // [{x, y, until}] positions blocked to escape local movement loops (P13A-A3)
     goalStagnantTurns: 0, // consecutive turns goal is active but position spread is minimal (P13B-A6ext)
-    escapeTimer: 0,       // turns remaining of post-aerial-escape RECOVER bias (P13C-C7)
-    bootTurns: 0          // turns elapsed since last reset; suppresses early canopy climb (P13C-C3)
+    escapeTimer: 0,           // turns remaining of post-aerial-escape RECOVER bias (P13C-C7)
+    bootTurns: 0,             // turns elapsed since last reset; suppresses early canopy climb (P13C-C3)
+    lastAerialEscapeDir: null // last lateral direction used when escaping aerial threat (P13F-F1)
   };
 }
 
@@ -11094,9 +11095,9 @@ function botActionSnapshot() {
     layer: layers[player.z],
     terrain: terrainAt(player.x, player.y),
     habitatKey: habitatKeyAt(player.x, player.y),
-    fitness: Math.round(player.fitness),
-    energy: Math.round(player.energy),
-    hydration: Math.round(player.hydration),
+    fitness: Math.max(0, Math.round(player.fitness)),
+    energy: Math.max(0, Math.round(player.energy)),
+    hydration: Math.max(0, Math.round(player.hydration)),
     dead: player.dead,
     deathContext: cloneDebug(player.deathContext || null),
     encounter: currentEncounter ? {
@@ -11646,7 +11647,13 @@ function threatAwareEscape(actions, threat) {
   // Aerial threats (raptor/owl): descend only if ground is not recently dangerous; otherwise lateral
   if (threat.isGrapple || threat.isAerial) {
     if (descendAction && player.z > 0 && !hasRecentGroundThreat()) return descendAction;
-    return moveActions.length ? randomBotAction(moveActions) : null;
+    // P13F-F1: Vary lateral escape direction — avoid repeating same direction as last aerial escape
+    const mEscAer = botState.memory;
+    const lastAerDir = mEscAer ? mEscAer.lastAerialEscapeDir : null;
+    const variedMoves = lastAerDir ? moveActions.filter(a => a.id !== lastAerDir) : moveActions;
+    const aerMove = randomBotAction(variedMoves.length ? variedMoves : moveActions);
+    if (aerMove && mEscAer) mEscAer.lastAerialEscapeDir = aerMove.id;
+    return aerMove || null;
   }
   // Climber threats (miacid etc): pursues through all layers — lateral movement only, never vertical
   if (threat.isClimber) {
@@ -11692,6 +11699,8 @@ function determineIntelligentBotMode(threat) {
   if (player.poison || player.fitness <= 45 || (player.parasites || 0) >= 1) return "RECOVER";
   // P13D-D1: Compound crisis — E<=10 AND H<=10 routes to RECOVER regardless of fitness
   if (player.energy <= 10 && player.hydration <= 10) return "RECOVER";
+  // P13F-F6: H recovered but E critical — exit drink loop, seek food
+  if (player.hydration >= 65 && player.energy <= 30) return "SAFE_FORAGE";
   if (player.hydration <= 50) return "WATER_PLAN";
   if (player.energy <= 60) return "SAFE_FORAGE";
   // P13C-C7: After aerial escape, hold RECOVER bias instead of returning to EXPLORE
@@ -11719,6 +11728,14 @@ function chooseIntelligentBotAction(actions) {
   if (waterState && waterState.inWater && moveActions.length) {
     const landEscape = intelligentEscapeWater(actions);
     if (landEscape) { botState._lastMode = "EMERGENCY_ESCAPE"; return landEscape; }
+  }
+
+  // P13F-F5: H<=5 central gate — drink or move toward water before any mode logic fires
+  if (player.hydration <= 5 && !activePursuit) {
+    const h5drink = byId["drink-water"];
+    if (h5drink) { botState._lastMode = "RECOVER"; return h5drink; }
+    const h5water = intelligentMoveTowardWater(actions);
+    if (h5water) { botState._lastMode = "RECOVER"; return h5water; }
   }
 
   const mode = determineIntelligentBotMode(threat);
@@ -11767,9 +11784,10 @@ function chooseIntelligentBotAction(actions) {
       const eat = intelligentFindSafeEat(actions);
       if (eat) return eat;
     }
-    // Groom immediately if parasites — skip when starving+poisoned or near-death (P13B-P3 + P13C-C6)
+    // Groom if parasites — skip when starving+poisoned, near-death, or dehydration is lethal (P13B-P3+P13C-C6+P13F-F5)
     if ((player.parasites || 0) >= 1 && byId["groom"] &&
-        !(player.energy <= 0 && (player.poison || player.fitness <= 10))) return byId["groom"];
+        !(player.energy <= 0 && (player.poison || player.fitness <= 10)) &&
+        player.hydration > 5) return byId["groom"];
     // Critical hydration — drink immediately
     if (player.hydration <= 20 && byId["drink-water"]) return byId["drink-water"];
     // Critical energy — eat safe food before water-seeking or movement (resource-anchor)
@@ -11922,6 +11940,11 @@ function chooseIntelligentBotAction(actions) {
 
   if (mode === "WATER_PLAN") {
     const m = botState.memory || (botState.memory = newBotMemory());
+    // P13F-F7: Mirror C8 in WATER_PLAN — E<=10 eats safe food before pursuing water
+    if (player.energy <= 10 && !activePursuit) {
+      const wpEat = intelligentFindSafeEat(actions);
+      if (wpEat) return wpEat;
+    }
     if (byId["drink-water"]) {
       // P13A-A2: After drinking, if energy is critically low set a food-seek goal for subsequent turns
       m.currentGoal = player.energy <= 30 ? { type: 'seek_food', startTurn: player.turn } : null;
@@ -11990,12 +12013,15 @@ function chooseIntelligentBotAction(actions) {
   if (enc && (threat.isDangerous || threat.isThreatClass) && moveActions.length) {
     return threatAwareEscape(actions, threat) || randomBotAction(moveActions);
   }
-  // Climb toward canopy when safe — suppressed during bootstrap grace (C3) and aerial threat memory
-  if (!inBootstrap && !urgentNeedsGround && !hasRecentAerialThreat() && climbAction) return climbAction;
+  // Climb toward canopy when safe — suppressed during bootstrap, aerial threat, or weak stats (P13C-C3, P13F-F3)
+  if (!inBootstrap && !urgentNeedsGround && !hasRecentAerialThreat() && climbAction &&
+      player.fitness > 40 && player.energy > 30 && player.hydration > 30) return climbAction;
   const nonAttack = actions.filter(a => {
     if (a.id.startsWith("attack") || a.id.startsWith("queued-attack")) return false;
     // P13D-D2: Bootstrap grace — block climb/sleep/call/look above ground for first 4 turns
     if (inBootstrap && player.z >= 1 && (a.id === "climb" || a.id === "sleep" || a.id === "call" || a.id === "look")) return false;
+    // P13F-F2: Block idle actions in canopy after recent aerial threat
+    if (player.z >= 2 && hasRecentAerialThreat() && (a.id === "look" || a.id === "wait" || a.id === "call" || a.id === "sleep")) return false;
     // Only descend when thirsty; WATER_PLAN owns descent for water access, so in EXPLORE/SAFE_FORAGE
     // fallthrough (H always >50 here) descent is almost never justified and risks ground predators
     if (a.id === "descend" && player.hydration > 50) return false;

--- a/game/play.html
+++ b/game/play.html
@@ -11731,7 +11731,8 @@ function chooseIntelligentBotAction(actions) {
   }
 
   // P13F-F5: H<=5 central gate — drink or move toward water before any mode logic fires
-  if (player.hydration <= 5 && !activePursuit) {
+  // Codex P1: skip gate when encounter is dangerous (threat check guards activePursuit=null case)
+  if (player.hydration <= 5 && !activePursuit && !threat.isDangerous && !threat.isFatal && !threat.isPredatorDanger) {
     const h5drink = byId["drink-water"];
     if (h5drink) { botState._lastMode = "RECOVER"; return h5drink; }
     const h5water = intelligentMoveTowardWater(actions);


### PR DESCRIPTION
## Summary

Consolidated final bot patch (v1 QA completion). Two groups of fixes:

**Aerial / Layer (original scope)**
- **F1**: Aerial escape direction variation — `lastAerialEscapeDir` stored in memory, excluded from candidate set on next aerial escape. Eliminates same-key lateral trap.
- **F2**: Canopy idle block after recent aerial threat — `look/wait/call/sleep` blocked at `z>=2` when `hasRecentAerialThreat()` is true.
- **F3**: Weak-state canopy suppression — `climbAction` in EXPLORE now gated on `fitness>40 AND energy>30 AND hydration>30`.

**Latest-log blockers**
- **F4**: Stat underflow clamp — wildfire tick used bare `-=` for fitness and hydration; both clamped with `Math.max(0,...)`. `botActionSnapshot()` also clamps defensively. Fixes `ERR_STAT_OUT_OF_RANGE` and `hydration=-1` from run 105455.
- **F5**: H<=5 central water gate — fires before mode dispatch; groom guard extended to skip at `H<=5`.
- **F6**: Drink-loop exit at mode level — `H>=65 AND E<=30` returns `SAFE_FORAGE` instead of `WATER_PLAN`.
- **F7**: E<=10 eat-first mirrored into WATER_PLAN block (was RECOVER-only via C8).

## Files changed
- `game/play.html` — 7 targeted edits across existing functions
- `CHANGELOG.txt` — patch13f entry prepended

---
_Generated by [Claude Code](https://claude.ai/code/session_014dNQz8F3y6rJeuo6TEZSGd)_