### PR TITLE
patch-death-trace-snapshot: focus trace.json on death runs with encounter context

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,13 @@
+[2026-05-06 patch-death-trace-snapshot | Claude]
+trace.json now focused on death runs only, with encounter and pursuit context per step.
+- buildBotTraceJson() filtered to runs where run.death !== null (death runs only). Survival-run terminal steps were low-value; death steps are where behaviour matters.
+- Window increased from last 10 to last 15 steps per death run.
+- Each step's before snapshot now includes encounter: {name, dangerProfile, pursuitType} and pursuit: {name, dangerProfile, pursuitType} (both null-safe). These were already present in botActionSnapshot() but not forwarded to trace.json.
+- Each run record now includes deathTurn (the turn the player died) and deathContext (the death cause string from player.deathContext).
+- Top-level trace.json object now includes deathRunsRecorded count.
+- No bot logic change. No change to botActionSnapshot(), compact.txt, or meta.json.
+- Syntax check: PASS.
+
 [2026-05-04 autosave-reliability | Claude]
 GitHub auto-save reliability fix. Bot run data no longer lost when full.txt upload fails. No bot logic change.
 - Essential files (meta.json, compact.txt, trace.json) uploaded first and unconditionally; full.txt attempted separately and skipped on failure.

--- a/game/play.html
+++ b/game/play.html
@@ -12173,9 +12173,10 @@ function buildBotFullText(report) {
 
 // P13E: Compact per-run terminal trace with decision context — stays under 1MB for API fetching
 function buildBotTraceJson(report) {
-  const runs = report.runs.map(run => {
+  const deathRuns = report.runs.filter(run => run.death !== null);
+  const runs = deathRuns.map(run => {
     const runSteps = report.actions.filter(s => s.runIndex === run.runIndex);
-    const terminalSteps = runSteps.slice(-10).map(s => ({
+    const terminalSteps = runSteps.slice(-15).map(s => ({
       botStep: s.botStep,
       turn: s.before ? s.before.turn : null,
       action: s.actionId,
@@ -12186,13 +12187,28 @@ function buildBotTraceJson(report) {
       escapeTimer: s.escapeTimer ?? null,
       drinkAvailable: s.drinkAvailable ?? null,
       eatAvailable: s.eatAvailable ?? null,
-      before: s.before ? {x: s.before.x, y: s.before.y, z: s.before.z, layer: s.before.layer, fitness: s.before.fitness, energy: s.before.energy, hydration: s.before.hydration} : null,
+      before: s.before ? {
+        x: s.before.x, y: s.before.y, z: s.before.z, layer: s.before.layer,
+        fitness: s.before.fitness, energy: s.before.energy, hydration: s.before.hydration,
+        encounter: s.before.encounter ? {
+          name: s.before.encounter.name,
+          dangerProfile: s.before.encounter.dangerProfile || null,
+          pursuitType: s.before.encounter.pursuitType || null
+        } : null,
+        pursuit: s.before.activePursuit ? {
+          name: s.before.activePursuit.name,
+          dangerProfile: s.before.activePursuit.dangerProfile || null,
+          pursuitType: s.before.activePursuit.pursuitType || null
+        } : null
+      } : null,
       after: s.after ? {fitness: s.after.fitness, energy: s.after.energy, hydration: s.after.hydration, dead: s.after.dead} : null
     }));
     return {
       runIndex: run.runIndex,
       reason: run.reason,
       turns: run.endTurn,
+      deathTurn: run.death ? run.death.turn : null,
+      deathContext: run.finalState ? run.finalState.deathContext : null,
       issues: run.issues ? run.issues.length : 0,
       finalState: run.finalState ? {fitness: run.finalState.fitness, energy: run.finalState.energy, hydration: run.finalState.hydration, dead: run.finalState.dead} : null,
       terminalSteps
@@ -12202,6 +12218,7 @@ function buildBotTraceJson(report) {
     runId: report.startedAt || "",
     gameVersion: typeof GAME_VERSION !== "undefined" ? GAME_VERSION : "",
     deaths: report.deaths,
+    deathRunsRecorded: deathRuns.length,
     runs
   }, null, 2);
 }


### PR DESCRIPTION
## Summary
- `buildBotTraceJson()` now filtered to death runs only (`run.death !== null`) — survival-run terminal steps were low-value
- Window expanded from last 10 to last 15 steps per death run
- Each step's `before` snapshot now includes `encounter: {name, dangerProfile, pursuitType}` and `pursuit: {name, dangerProfile, pursuitType}` — provides the context needed to audit whether the bot's mode and action choice were correct given the actual threat
- Each run record now includes `deathTurn` and `deathContext` (the death cause string)
- Top-level `deathRunsRecorded` count added

## What doesn't change
- No bot logic change
- `botActionSnapshot()` unchanged — encounter/pursuit were already captured there, just not forwarded to trace output
- `compact.txt` and `meta.json` unchanged

## Test plan
- [ ] Run IntelligentBot for 1000 turns
- [ ] Auto-save to GitHub
- [ ] Confirm `trace.json` contains only runs where `death` occurred
- [ ] Confirm each step includes `encounter` and `pursuit` fields
- [ ] Confirm each run includes `deathTurn` and `deathContext`

---
_Generated by [Claude Code](https://claude.ai/code/session_014dNQz8F3y6rJeuo6TEZSGd)_