### PR TITLE
social-patch-1a: hidden social encounter state foundation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,18 @@
+[2026-05-06 social-patch-1a | Claude]
+Social encounter hidden state foundation (Social Patch 1A). Data and state layer only — no UI overhaul, no group-on-group, no full cue system.
+- SOCIAL_ENGINE_MAX_GROUP = 10 constant added as the engine ceiling for future species. T. belgica groupSizeCap stays at 6, keeping very large groups unavailable for this species.
+- playerSpeciesProfile gains groupSizeCap: 6 field. All group-count draws now use the species cap via socialGroupCountDraw(), not a hardcoded number.
+- socialGroupCountDraw(): T. belgica distribution: lone 70%; multi-member 30% weighted 2-3 (~60%), 4-5 (~30%), 6 (~10%). Groups of 7-10 require a future species with a higher cap.
+- createSameSpeciesEncounter() rewritten. Each member now carries: sex, ageClass (infant/juvenile/youngAdult/adult/old), role (dominant/protective/peripheral/watchful/curious/neutral), temperament (calm/wary/aggressive/tolerant), displayLabel (e.g. "dominant adult female", "watchful adult male", "curious juvenile female", "infant"). First member weighted toward dominant/protective.
+- Hidden encounter attitude added: receptive / disinterested / tense / hostile. Weighted by group size; disinterested is the dominant attitude for lone and small groups. Stored as encounter.social.hiddenAttitude. Dev/debug trace only — not exposed in player UI.
+- harassmentCounter: 0 and escalationState: "calm" added to every new social encounter (encounter.social). escalationState advances through calm / irritated / warning / hostile as harassment accumulates.
+- computeEscalationState(n): pure function mapping counter value to escalation tier.
+- incrementSocialHarassment(encounter): increments counter, recomputes escalationState, escalates disinterested → tense when escalationState reaches "warning". Emits social-harassment-increment debug trace.
+- socialAcceptanceChance() extended with hidden attitude modifier (receptive +15, tense -15, hostile -30, disinterested 0) and escalation modifier (irritated -5, warning -12, hostile -22). Existing flat/binary joining logic preserved as fallback for encounters missing the new fields.
+- Three confirmed-intrusive call sites added for incrementSocialHarassment: (1) failed join/approach in acceptSocialEncounter() failure branch; (2) repeated call directed at active social encounter in callOut() (callStreak > 1 only); (3) groom() while social encounter active and no established rapport (individualSocialState.trust < 1 or no state).
+- Observe, wait, avoidSocialEncounter, backing away, and leaving do NOT increment harassment counter.
+- Syntax check: PASS.
+
 [2026-05-06 patch-death-trace-snapshot | Claude]
 trace.json now focused on death runs only, with encounter and pursuit context per step.
 - buildBotTraceJson() filtered to runs where run.death !== null (death runs only). Survival-run terminal steps were low-value; death steps are where behaviour matters.

--- a/game/play.html
+++ b/game/play.html
@@ -3037,11 +3037,15 @@ let noiseLevel = 0;
 let lastCravingCueTurn = -999;
 let lastRiskMemoryCueTurn = -999;
 
+// Engine ceiling for encountered group size — future species can raise their groupSizeCap toward this.
+const SOCIAL_ENGINE_MAX_GROUP = 10;
+
 const playerSpeciesProfile = {
   species: "tree-climber",
   groupName: "tree-climber band",
   icon: "🐒",
   maxGroupSize: 5,
+  groupSizeCap: 6,       // T. belgica: encountered groups draw up to this ceiling
   baseSocialChance: 6
 };
 
@@ -6105,23 +6109,114 @@ function updateSocialGroupAfterTurn() {
   }
 }
 
+// @target [SOCIAL] Social encounter hidden state helpers
+
+// @fn computeEscalationState
+// Pure function: maps a harassmentCounter value to a named escalation tier.
+function computeEscalationState(n) {
+  if (n >= 6) return "hostile";
+  if (n >= 4) return "warning";
+  if (n >= 2) return "irritated";
+  return "calm";
+}
+
+// @fn incrementSocialHarassment
+// Call this only on confirmed intrusive actions (failed join, repeated call at group,
+// early groom attempt). Do NOT call for observe, wait, back off, or leave.
+function incrementSocialHarassment(encounter) {
+  if (!encounter || !encounter.social) return;
+  encounter.social.harassmentCounter = (encounter.social.harassmentCounter || 0) + 1;
+  const prev = encounter.social.escalationState || "calm";
+  encounter.social.escalationState = computeEscalationState(encounter.social.harassmentCounter);
+  // Disinterested groups become tense once harassment reaches "warning" tier.
+  if (encounter.social.hiddenAttitude === "disinterested" && encounter.social.escalationState === "warning") {
+    encounter.social.hiddenAttitude = "tense";
+  }
+  addDebugTrace("social-harassment-increment", {
+    counter: encounter.social.harassmentCounter,
+    escalationState: encounter.social.escalationState,
+    prevEscalation: prev,
+    hiddenAttitude: encounter.social.hiddenAttitude
+  });
+}
+
 // @target [SOCIAL] Same-species individual generation
+
+// @fn socialGroupCountDraw
+// Draws an encountered group size for the current species profile.
+// T. belgica: lone 70%; multi-member 30% weighted toward 2-3, rare at cap.
+function socialGroupCountDraw() {
+  const cap = clamp(playerSpeciesProfile.groupSizeCap || 6, 1, SOCIAL_ENGINE_MAX_GROUP);
+  if (Math.random() < 0.70) return 1;
+  // Multi-member weights: 2-3 ~60%, 4-5 ~30%, 6 ~10%, 7-10 only reachable if cap > 6
+  const roll = Math.random();
+  if (roll < 0.60) return 2 + Math.floor(Math.random() * 2);   // 2 or 3
+  if (roll < 0.90) return 4 + Math.floor(Math.random() * 2);   // 4 or 5
+  // Remaining 10%: draw from 6..cap (for T. belgica cap=6, always returns 6)
+  return 6 + Math.floor(Math.random() * Math.max(1, cap - 5));
+}
+
+// @fn socialMemberLabel
+// Produces a display label for a group member. "youngAdult" renders as "young".
+function socialMemberLabel(sex, ageClass, role) {
+  if (ageClass === "infant") return "infant";
+  const ageWord = ageClass === "youngAdult" ? "young" : ageClass;
+  return role + " " + ageWord + " " + sex;
+}
+
+// @fn socialHiddenAttitudeForCount
+// Returns a weighted hidden attitude based on encountered group size.
+function socialHiddenAttitudeForCount(count) {
+  // Weights: [receptive, disinterested, tense, hostile]
+  const w = count <= 1  ? [35, 45, 15,  5]
+           : count <= 3 ? [25, 45, 20, 10]
+           : count <= 5 ? [15, 40, 30, 15]
+           :              [ 8, 32, 38, 22];   // 6+ (T. belgica cap)
+  const attitudes = ["receptive", "disinterested", "tense", "hostile"];
+  const total = w.reduce((a, b) => a + b, 0);
+  let r = Math.random() * total;
+  for (let i = 0; i < w.length; i++) { r -= w[i]; if (r <= 0) return attitudes[i]; }
+  return "disinterested";
+}
 
 // @fn createSameSpeciesEncounter
 function createSameSpeciesEncounter() {
-  const count = Math.random() < 0.7 ? 1 : 2 + Math.floor(Math.random() * 3);
+  const count = socialGroupCountDraw();
+  const AGE_CLASSES = ["infant", "juvenile", "youngAdult", "adult", "adult", "adult", "old"];
+  const ROLES = ["dominant", "protective", "peripheral", "watchful", "curious", "neutral"];
+  const TEMPERAMENTS = ["calm", "calm", "wary", "wary", "tolerant", "aggressive"];
   const members = [];
   for (let i = 0; i < count; i++) {
+    const sex = Math.random() < 0.5 ? "female" : "male";
+    const ageClass = AGE_CLASSES[Math.floor(Math.random() * AGE_CLASSES.length)];
+    // First member skewed toward dominant/protective; later members more peripheral
+    const rolePool = i === 0
+      ? ["dominant", "dominant", "protective", "watchful", "neutral"]
+      : ROLES;
+    const role = rolePool[Math.floor(Math.random() * rolePool.length)];
+    const temperament = TEMPERAMENTS[Math.floor(Math.random() * TEMPERAMENTS.length)];
+    const displayLabel = socialMemberLabel(sex, ageClass, role);
     members.push({
       id: "social_" + player.turn + "_" + i + "_" + Math.floor(Math.random() * 9999),
       species: player.species,
-      sex: Math.random() < 0.5 ? "male" : "female",
+      sex,
+      ageClass,
+      role,
+      temperament,
+      displayLabel,
       size: clamp(player.size + (Math.random() * 2 - 1), 3, 8),
-      fitness: clamp(60 + Math.round(Math.random() * 35), 40, 100),
-      temperament: Math.random() < 0.65 ? "cautious" : "assertive"
+      fitness: clamp(60 + Math.round(Math.random() * 35), 40, 100)
     });
   }
   const mixed = members.some(m => m.sex !== members[0].sex);
+  const hiddenAttitude = socialHiddenAttitudeForCount(count);
+  addDebugTrace("social-encounter-created", {
+    count,
+    hiddenAttitude,
+    escalationState: "calm",
+    harassmentCounter: 0,
+    memberLabels: members.map(m => m.displayLabel)
+  });
   return {
     kind: "social",
     key: "sameSpeciesGroup",
@@ -6129,9 +6224,20 @@ function createSameSpeciesEncounter() {
     icon: playerSpeciesProfile.icon,
     className: "primate",
     canInvestigate: true,
-    social: {species: player.species, members, mixed},
-    seen: count === 1 ? "Another " + player.species + " watches from nearby branches." : "A small band of " + player.species + "s moves through the same trees, alert but not immediately hostile.",
-    investigated: mixed ? "The group has a mixed sex balance and seems open to cautious contact. Food pressure will still matter." : "They are your own kind, but their posture is guarded. Same species does not always mean safe."
+    social: {
+      species: player.species,
+      members,
+      mixed,
+      hiddenAttitude,
+      harassmentCounter: 0,
+      escalationState: "calm"
+    },
+    seen: count === 1
+      ? "Another " + player.species + " watches from nearby branches."
+      : "A " + (count <= 3 ? "small" : count <= 5 ? "mid-sized" : "large") + " band of " + player.species + "s moves through the same trees, alert but not immediately hostile.",
+    investigated: mixed
+      ? "The group has a mixed sex balance and seems open to cautious contact. Food pressure will still matter."
+      : "They are your own kind, but their posture is guarded. Same species does not always mean safe."
   };
 }
 
@@ -6187,6 +6293,17 @@ function socialAcceptanceChance(encounter, mode) {
   if (player.energy < 35) chance -= 12;
   if (player.fitness < 45) chance -= 10;
   if (hasGroup()) chance -= socialGroup.members.length * 6;
+  // Hidden attitude modifier (Social Patch 1A)
+  const attitude = encounter && encounter.social && encounter.social.hiddenAttitude;
+  if (attitude === "receptive")  chance += 15;
+  if (attitude === "tense")      chance -= 15;
+  if (attitude === "hostile")    chance -= 30;
+  // disinterested: 0 delta — not joinable by default; other factors decide
+  // Escalation modifier
+  const esc = encounter && encounter.social && encounter.social.escalationState;
+  if (esc === "irritated") chance -= 5;
+  if (esc === "warning")   chance -= 12;
+  if (esc === "hostile")   chance -= 22;
   return clamp(chance, 10, 90);
 }
 
@@ -6367,6 +6484,7 @@ function acceptSocialEncounter(mode) {
   if (!accepted) {
     const tensionDamage = roll(25) ? clamp(Math.round(2 + Math.random() * 8), 2, 10) : 0;
     if (tensionDamage) player.fitness = clamp(player.fitness - tensionDamage, 0, 100);
+    incrementSocialHarassment(encounter);
     addLog("The " + encounter.name + " refuses close contact" + (tensionDamage ? " and snaps at you. Damage: " + tensionDamage + "." : "."), tensionDamage ? "threat" : "minor");
     setNarration("Your own kind can still be competitors. They keep their distance and the chance passes.");
     clearCurrentEncounter("action-cleared-before-render");
@@ -6800,6 +6918,12 @@ function callOut(signalType = "social") {
   if (handleCurrentEncounterCallReaction(signalType)) {
     render();
     return;
+  }
+
+  // Repeated calls directed at an active social encounter count as harassment.
+  // First call does not increment; second+ calls do (callStreak > 1).
+  if (currentEncounter && currentEncounter.kind === "social" && callStreak > 1) {
+    incrementSocialHarassment(currentEncounter);
   }
 
   const h = habitatAt(player.x, player.y);
@@ -7816,6 +7940,13 @@ function groom() {
   lastActionKind = "groom";
   debugLastAction = {kind: "groom", parasiteLoad: player.parasites, groupSize: groupSize()};
   if (!startTurn()) return;
+
+  // Grooming while a social encounter is active and no rapport established counts as
+  // an unsupported/too-early intrusion — the encountered group reads it as presumptuous.
+  if (currentEncounter && currentEncounter.kind === "social" &&
+      (!individualSocialState || (individualSocialState.trust || 0) < 1)) {
+    incrementSocialHarassment(currentEncounter);
+  }
 
   if ((player.parasites || 0) <= 0) {
     addLog("You groom briefly. Nothing obvious comes away.", "minor");

--- a/game/play.html
+++ b/game/play.html
@@ -6148,12 +6148,13 @@ function incrementSocialHarassment(encounter) {
 function socialGroupCountDraw() {
   const cap = clamp(playerSpeciesProfile.groupSizeCap || 6, 1, SOCIAL_ENGINE_MAX_GROUP);
   if (Math.random() < 0.70) return 1;
-  // Multi-member weights: 2-3 ~60%, 4-5 ~30%, 6 ~10%, 7-10 only reachable if cap > 6
+  // Multi-member weights: 2-3 ~60%, 4-5 ~30%, 6 ~10%, 7-10 only reachable if cap > 6.
+  // Each branch is clamped to cap so a low-cap species never produces an oversized encounter.
   const roll = Math.random();
-  if (roll < 0.60) return 2 + Math.floor(Math.random() * 2);   // 2 or 3
-  if (roll < 0.90) return 4 + Math.floor(Math.random() * 2);   // 4 or 5
+  if (roll < 0.60) return Math.min(cap, 2 + Math.floor(Math.random() * 2));   // 2 or 3
+  if (roll < 0.90) return Math.min(cap, 4 + Math.floor(Math.random() * 2));   // 4 or 5
   // Remaining 10%: draw from 6..cap (for T. belgica cap=6, always returns 6)
-  return 6 + Math.floor(Math.random() * Math.max(1, cap - 5));
+  return Math.min(cap, 6 + Math.floor(Math.random() * Math.max(1, cap - 5)));
 }
 
 // @fn socialMemberLabel
@@ -6322,7 +6323,9 @@ function memberCombatStats(member, fallbackName = "tree-climber") {
     size,
     speed: player.speed,
     agility: player.agility,
-    aggression: member.temperament === "assertive" ? 55 : 32,
+    aggression: (member.temperament === "aggressive" || member.temperament === "assertive") ? 55
+               : member.temperament === "wary" ? 38
+               : 28,
     food: Math.max(12, Math.round(size * 6)),
     sex: member.sex || "unknown",
     canInvestigate: true,
@@ -6391,7 +6394,7 @@ function attackSocialEncounter() {
 
   addDebugTrace("same-species-aggression", {encounter: cloneDebug(encounter), target: cloneDebug(target), playerAdv, enemyAdv, playerAllies, enemyGroupSize, outnumbered, sizeGap});
 
-  if (enemyGroupSize === 1 && target.size < player.size * 0.9 && target.temperament !== "assertive" && debugRoll("same species flees aggression", 35, {target: cloneDebug(target)})) {
+  if (enemyGroupSize === 1 && target.size < player.size * 0.9 && target.temperament !== "assertive" && target.temperament !== "aggressive" && debugRoll("same species flees aggression", 35, {target: cloneDebug(target)})) {
     addLog(`Turn ${player.turn}: You lunge at the ${target.name}, but it flees before the fight forms.`, "minor");
     setNarration("Your aggression clears the space. The encounter is over; there is no joining after an attack.");
     clearCurrentEncounter("same-species-fled-aggression");


### PR DESCRIPTION
Lays the data/state layer for Social Patch 1A. No UI overhaul,
no group-on-group, no cue system yet.

- SOCIAL_ENGINE_MAX_GROUP = 10 engine ceiling constant
- playerSpeciesProfile gains groupSizeCap: 6 (T. belgica conservative)
- socialGroupCountDraw(): species-capped weighted distribution
  (lone 70%, 2-3 ~18%, 4-5 ~9%, 6 ~3% for T. belgica)
- createSameSpeciesEncounter() rewritten: each member now carries
  ageClass, role, temperament, displayLabel (e.g. "dominant adult female")
- Hidden attitude per encounter: receptive/disinterested/tense/hostile
  weighted by group size; disinterested dominant for lone/small groups
- harassmentCounter + escalationState (calm/irritated/warning/hostile)
  on every new social encounter
- computeEscalationState() + incrementSocialHarassment() helpers
- socialAcceptanceChance() extended with attitude and escalation modifiers
- Three harassment increment sites: failed join, repeated call at group
  (callStreak > 1), groom before rapport established
- CHANGELOG updated