### PR TITLE
Predator persistence: fix encounter-state consistency (4 fixes)

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,12 @@
+[2026-05-06 predator-persistence | Claude]
+Predator encounter-state consistency — four fixes ensuring missed, fleeing, and pursuing predators remain visible and detectable. No new systems, no predator behaviour change.
+- fatalPredatorPressure() miss branch: when a ground predator misses and player.z < 2, the encounter card is no longer cleared. dangerGrace is set (giving one free turn before the next attack roll) but the predator remains as currentEncounter. Previously the card vanished even though the predator was still in range.
+- climb(): when the player climbs away from a ground predator and severeThreatRetainsContact() returns false, startPursuit(leaving) is now called before rememberBrokenThreat(). For climber-type predators (miacid, monitor lizard) this routes them into activePursuit instead of only the world registry. activePursuit is checked by sameTileThreats() and exposeCarelessActionToThreat(); rememberBrokenThreat() registry entries are not.
+- descend(): same fix applied symmetrically for predators that remain threatening when the player descends.
+- renderSenses(): activePursuit is now rendered as a visible pursuit card in the encounter area. When activePursuit is set alongside a currentEncounter both are shown; when activePursuit is the only active threat the card is shown alone. Card shows predator name and current distance. Previously activePursuit had no UI representation and the player had no indication a predator was still following.
+- CSS: .pursuitCard, .pursuitIcon, .pursuitName, .pursuitStatus added for the pursuit card display.
+- Syntax check: PASS.
+
 [2026-05-06 social-patch-1b-presentation | Claude]
 Presentation, guardrail, and balance patch based on turn-158 playthrough review. No new systems, no redesign.
 - Fix "0 tree-climbers join you": acceptSocialEncounter() now guards recruits.length > 0 before the join log. Zero-recruit contact shows "The group does not come any closer." instead of a broken count message.
@@ -6,7 +15,7 @@ Presentation, guardrail, and balance patch based on turn-158 playthrough review.
 - Companion poison-testing cost added: when a companion tastes poisonous food, member.poisonExposures increments and member.avoidsTurn is set (3-5 turns). Log message now includes "She/He avoids you for a while." (first exposure) or "The group becomes warier of feeding near you." (repeat). If poisonExposures >= 2 and 40% roll, maybeGroupMemberLeaves fires with "repeated food danger exposure" reason. Companion-assisted learning is preserved intact.
 - GROUP panel UI overhauled: player is now always the first row in the member list. Companion rows are wrapped in .groupMemberScroll (max-height 192px, overflow-y auto, touch-scroll enabled). Header pill shows "N total" instead of "M companions". Summary line reads "Cohesion: X · N total · You + M companions". Solo state shows "Travelling alone." CSS adds .groupMemberScroll, .groupPlayerRow, .groupPlayerIcon, .groupPlayerLabel, .groupPlayerSub. Panel height remains bounded; content scrolls rather than pushing layout.
 - game/evolution_game_v66_57.html NOT updated — archived reference version only.
-- Syntax check: PASS.
+
 
 [2026-05-06 social-patch-1a | Claude]
 Social encounter hidden state foundation (Social Patch 1A). Data and state layer only — no UI overhaul, no group-on-group, no full cue system.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,7 @@ Predator encounter-state consistency — four fixes ensuring missed, fleeing, an
 - descend(): same fix applied symmetrically for predators that remain threatening when the player descends.
 - renderSenses(): activePursuit is now rendered as a visible pursuit card in the encounter area. When activePursuit is set alongside a currentEncounter both are shown; when activePursuit is the only active threat the card is shown alone. Card shows predator name and current distance. Previously activePursuit had no UI representation and the player had no indication a predator was still following.
 - CSS: .pursuitCard, .pursuitIcon, .pursuitName, .pursuitStatus added for the pursuit card display.
+- Codex P2 fix: downwind-escape narration in the miss branch updated to no longer say contact is broken (it isn't — dangerGrace retains the encounter).
 - Syntax check: PASS.
 
 [2026-05-06 social-patch-1b-presentation | Claude]

--- a/game/play.html
+++ b/game/play.html
@@ -8633,7 +8633,7 @@ function fatalPredatorPressure(e) {
         addLog(`Turn ${player.turn}: The Gastornis misses, then keeps pursuing.`, "predator");
       } else {
         if (relation === "downwind escape") {
-          setNarration(`It had the line for a moment, but your downwind movement breaks the contact.`);
+          setNarration(`It had the line for a moment, but the rush fails. Your position has not changed — it is still close.`);
         } else if (relation === "upwind exposure") {
           setNarration(`Your scent gives it too much information, but the rush still fails this time.`);
         } else {

--- a/game/play.html
+++ b/game/play.html
@@ -31,6 +31,10 @@ body.dead .mapCueIcon { border-color: #814444; background: #210a0a; }
 .cueKeyword { color: #f1f0c4; font-weight: bold; }
 .cueDirection { color: #ffffff; font-weight: bold; }
 .encounterArea { margin-top: 14px; padding-top: 12px; border-top: 1px solid #345d30; }
+.pursuitCard { display: flex; align-items: center; gap: 10px; padding: 8px 10px; border: 1px solid #755b24; border-radius: 6px; background: #1a1208; margin-top: 8px; }
+.pursuitIcon { font-size: 18px; flex: 0 0 auto; color: #f0a83a; }
+.pursuitName { color: #f3e6c4; font-size: 13px; font-weight: bold; }
+.pursuitStatus { color: #c8a878; font-size: 12px; margin-top: 2px; }
 .creatureIcon { width: 84px; height: 70px; border: 2px solid #3df36b; background: #0d1a0f; display: flex; align-items: center; justify-content: center; font-size: 38px; }
 .investigationResult { background: #142b35; border: 1px solid #65a7c4; color: #d8f3ff; border-radius: 6px; padding: 8px; margin: 8px 0; font-size: 14px; line-height: 1.35; }
 .twoCol { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
@@ -8635,7 +8639,10 @@ function fatalPredatorPressure(e) {
         } else {
           setNarration(`For a moment, the predator is too close. You escape through cover, but only just.`);
         }
-        clearCurrentEncounter("predator-escaped");
+        // Predator missed but player.z < 2 means it is still in reach.
+        // Retain as current encounter so the card stays visible; dangerGrace
+        // gives one turn before the next attack roll.
+        dangerGrace = true;
       }
     } else {
       setNarration(`For a moment, the predator is too close. Survival now depends on reaching branches it cannot use.`);
@@ -9440,7 +9447,12 @@ function climb() {
     } else {
       const retained = severeThreatRetainsContact(leaving, "climb");
       if (retained) currentEncounter = leaving;
-      else rememberBrokenThreat(leaving, player.x, player.y, oldZ, "climb-contact-broken");
+      else {
+        // Climber predators that break visual contact enter pursuit rather than
+        // vanishing into the world registry. startPursuit no-ops for non-climbers.
+        if (!activePursuit) startPursuit(leaving);
+        rememberBrokenThreat(leaving, player.x, player.y, oldZ, "climb-contact-broken");
+      }
     }
 
     leaveWaterIfNeeded();
@@ -9489,6 +9501,9 @@ function descend() {
     if (retained) {
       currentEncounter = leaving;
     } else {
+      // Climber predators that break visual contact enter pursuit rather than
+      // vanishing into the world registry. startPursuit no-ops for non-climbers.
+      if (!activePursuit) startPursuit(leaving);
       rememberBrokenThreat(leaving, player.x, player.y, oldZ, "descend-contact-broken");
     }
 
@@ -14089,6 +14104,16 @@ function renderSenses() {
       `;
     }
 
+    // Append pursuit card below the main encounter when both are active.
+    if (activePursuit && activePursuit.name) {
+      html += `<div class="pursuitCard">
+        <div class="pursuitIcon">⚠</div>
+        <div class="pursuitInfo">
+          <div class="pursuitName">${escapeHtml(activePursuit.name)}</div>
+          <div class="pursuitStatus">following · distance ${activePursuit.distance !== undefined ? Number(activePursuit.distance).toFixed(1) : "close"}</div>
+        </div>
+      </div>`;
+    }
     encounterArea.innerHTML = html;
     return;
   }
@@ -14102,6 +14127,17 @@ function renderSenses() {
   }
   if (!lastNarration || isDirectEncounterNarration(lastNarration)) {
     document.getElementById("narration").textContent = weatherNarrationFragment();
+  }
+  // Show pursuit card alone when there is no current encounter or carcass.
+  if (activePursuit && activePursuit.name) {
+    encounterArea.innerHTML = `<div class="pursuitCard">
+      <div class="pursuitIcon">⚠</div>
+      <div class="pursuitInfo">
+        <div class="pursuitName">${escapeHtml(activePursuit.name)}</div>
+        <div class="pursuitStatus">following · distance ${activePursuit.distance !== undefined ? Number(activePursuit.distance).toFixed(1) : "close"}</div>
+      </div>
+    </div>`;
+    return;
   }
   encounterArea.innerHTML = "";
 }


### PR DESCRIPTION
## Summary

Four encounter-state consistency fixes. No new systems, no predator behaviour changes.

**Fix 1 — Ground predator miss no longer clears the encounter card**
`fatalPredatorPressure()`: when a ground predator misses and the player is still on a reachable layer (`player.z < 2`), `clearCurrentEncounter("predator-escaped")` is replaced with `dangerGrace = true`. The predator stays as `currentEncounter`; `dangerGrace` gives one free turn before the next attack roll. Previously the card vanished even though the predator was still in range.

**Fix 2 — Miacid/monitor lizard no longer disappear on layer change**
`climb()` and `descend()`: when `severeThreatRetainsContact()` returns false for a climber-type predator, `startPursuit(leaving)` is now called before `rememberBrokenThreat()`. Climbers (miacid, monitor lizard) enter `activePursuit` rather than only the world registry. `activePursuit` is checked by `sameTileThreats()` and `exposeCarelessActionToThreat()`; registry entries are not — so without this fix the predator became effectively invisible to the threat system.

**Fix 3 — activePursuit now has a visible UI card**
`renderSenses()`: `activePursuit` is rendered as a pursuit card in the encounter area. Shown alongside `currentEncounter` when both are active; shown alone when there is no current encounter or carcass. Card displays predator name and distance.

**Fix 4 (side-effect of Fix 2) — Eagle + climber dual-threat preserved across layer change**
The encounter queue is wiped on layer change. By routing climbers to `activePursuit` (which survives `clearCurrentEncounter`), a concurrent eagle threat in `currentEncounter` and a climbing predator both remain tracked after the player changes layer.

## Files changed
- `game/play.html` — four JS fixes + pursuit card CSS
- `CHANGELOG.txt` — entry prepended

---
_Generated by [Claude Code](https://claude.ai/code/session_016sYvnxSRoQp4GcRE6V493Y)_