### PR TITLE
Social persist: movement feedback + 4-turn tile hold on social encounter departure

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,10 +1,18 @@
+[2026-05-06 social-persist | Claude]
+Social encounter short-duration tile hold and movement feedback. No new encounter generation, no balance change.
+- nearbyRecentSocial: new module-level variable {encounter, x, y, z, expiresAfterTurn}. Null-safe; cleared on resetGameForPlayer() and resetGameForBot().
+- move(): when movement clears a social encounter, a log line is now emitted ("The [group/lone species] falls behind as you move away. The contact passes."). The encounter is stored in nearbyRecentSocial with a 4-turn expiry. Previously the encounter vanished silently with no player feedback.
+- move(): after the player arrives at the new tile, if no encounter is active and nearbyRecentSocial targets the same x/y/z and has not expired, the social encounter is restored as currentEncounter and a log line is emitted ("The [name] is still nearby. You have another chance."). The social group has not moved; the player returned to them. This gives 4 turns to reconsider without permanently pinning the group to a tile.
+- The 4-turn window is intentional — enough to take one detour and return, not enough to keep an encounter open indefinitely. On expiry the slot is not restored; the encounter is simply gone.
+- Syntax check: PASS.
+
 [2026-05-06 fire-sensory | Claude]
 Fire hazard directional sensory cues. No new system — extends the existing wildfire state and sensory rendering pipeline.
 - wildfireDirection(dx, dy): new helper that maps fire-to-player delta into a compass string (North, South-East, etc.) or null when fire is directly adjacent.
 - applyWildfireProximityEffects(): inner zone (dist <= radius) log now reads "Flames move through the undergrowth to the [direction]." Edge zone (dist <= r+3) reads "The air grows hot. Animals move away from the [direction]." Outer zone (dist <= r+6) reads "Smoke hangs faintly from the [direction]." All log messages are suppressed after the first per turn using environment.wildfire._lastLogTurn to prevent the repeated identical-line problem seen in the turn-399 log.
 - renderSenses(): fire sensory cues injected after the normal heardText/smellText render. Inner zone overrides both HEAR ("Dry wood cracks to [direction]. The fire is here.") and SMELL ("Scorched bark and ash from [direction]."). Edge zone overrides SMELL only ("Smoke drifts from [direction]."). Outer zone sets a faint SMELL cue ("Faint smoke from [direction]."). The injection happens after updateRemoteSenses so fire dominates when the player is genuinely in danger from the inner zone.
 - No encounter card added. No fire logic change. Game version string not updated.
-- Syntax check: PASS.
+
 
 [2026-05-06 predator-persistence | Claude]
 Predator encounter-state consistency — four fixes ensuring missed, fleeing, and pursuing predators remain visible and detectable. No new systems, no predator behaviour change.

--- a/game/play.html
+++ b/game/play.html
@@ -3024,6 +3024,7 @@ let lastNarration = "In a warm forest of tangled branches and dripping leaves, s
 let groupSceneNotice = null;
 let heardText = "The forest is never silent. Small things move beyond sight.";
 let smellText = "The wet forest air is thick with leaf rot, bark, and your own scent.";
+let nearbyRecentSocial = null;
 let lastActionKind = "wait";
 let debugLog = [];
 let debugTrace = [];
@@ -9039,6 +9040,13 @@ function move(dx, dy, actionText) {
     const leaving = currentEncounter;
     if (carcass && carcass.portions > 0) persistCarcassAt(oldX, oldY, oldZ, carcass);
     restoreUnconsumedPersistentEncounter(leaving);
+
+    if (leaving && leaving.kind === "social") {
+      const groupDesc = leaving.social && leaving.social.members && leaving.social.members.length > 1 ? leaving.name : "lone " + player.species;
+      addLog(`The ${groupDesc} falls behind as you move away. The contact passes.`, "minor");
+      nearbyRecentSocial = {encounter: leaving, x: oldX, y: oldY, z: oldZ, expiresAfterTurn: player.turn + 4};
+    }
+
     clearCurrentEncounter("move-to-new-tile", {clearQueue: true});
     carcass = null;
 
@@ -9047,6 +9055,13 @@ function move(dx, dy, actionText) {
       currentEncounter = leaving;
     } else {
       rememberBrokenThreat(leaving, oldX, oldY, oldZ, "move-contact-broken");
+    }
+
+    if (!currentEncounter && nearbyRecentSocial && nearbyRecentSocial.expiresAfterTurn >= player.turn &&
+        player.x === nearbyRecentSocial.x && player.y === nearbyRecentSocial.y && player.z === nearbyRecentSocial.z) {
+      currentEncounter = nearbyRecentSocial.encounter;
+      nearbyRecentSocial = null;
+      addLog(`The ${currentEncounter.name} is still nearby. You have another chance.`, "minor");
     }
 
     if (player.dead) { render(); return; }
@@ -11076,6 +11091,7 @@ function clearRunLogsForNewGame() {
 
 // @fn resetGameForPlayer
 function resetGameForPlayer(reason = "manual restart") {
+  nearbyRecentSocial = null;
   clearRunLogsForNewGame();
   Object.assign(player, {
     x: 50,
@@ -11476,6 +11492,7 @@ function summariseCurrentBotRun(reason) {
 }
 
 function resetGameForBot(reason = "bot auto-reset") {
+  nearbyRecentSocial = null;
   botState.resets += 1;
   clearRunLogsForNewGame();
   Object.assign(player, {


### PR DESCRIPTION
## Summary

Addresses two social encounter problems from the turn-399 log: (1) no feedback when the player moves away from an active social encounter; (2) no opportunity to return within a few turns if the player changed their mind.

**Root cause confirmed:** in `move()`, `restoreUnconsumedPersistentEncounter()` excludes social encounters, `severeThreatRetainsContact()` returns false for non-animal kinds, and `rememberBrokenThreat()` also returns false. Social encounters silently vanished on movement with zero log output and no recovery path.

**`nearbyRecentSocial`** — new module-level variable `{encounter, x, y, z, expiresAfterTurn}`. Cleared on `resetGameForPlayer()` and `resetGameForBot()`.

**`move()` — departure:**
When movement clears a social encounter, one log line is emitted:
`"The tree-climber band falls behind as you move away. The contact passes."`
The encounter is stored in `nearbyRecentSocial` with a 4-turn expiry.

**`move()` — return:**
After the player arrives at the new tile, if `currentEncounter` is null and `nearbyRecentSocial` targets the same x/y/z and has not expired, the encounter is restored and logged:
`"The tree-climber band is still nearby. You have another chance."`

The 4-turn window is intentional — long enough for one short detour, not long enough to keep the slot open indefinitely. Expiry silently discards the cached encounter; the group simply moved on.

## Files changed
- `game/play.html` — `nearbyRecentSocial` variable, departure and return logic in `move()`, resets in both game-reset functions
- `CHANGELOG.txt` — entry prepended

---
_Generated by [Claude Code](https://claude.ai/code/session_016sYvnxSRoQp4GcRE6V493Y)_