### PR TITLE
group-mating-fix: hide Court button when no eligible companion

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+[2026-05-09 group-mating-fix | Claude]
+Mobile layout fix: courtCompanion button now hidden (display:none) when no eligible companion is present; shown only when canCourtGroupMember() returns a truthy member. Previously the button was always visible (just disabled), adding an 8th button to the vertical-controls row and breaking the mobile layout. Pattern now matches the encounter-card Court button which only renders when canAttemptMating() is true.
+- Syntax check: PASS.
+
 [2026-05-09 group-mating | Claude]
 Within-group mating — companion courtship path. Complements the existing encounter-mating system. Shares the same matingCount/lastMatingTurn state and goal.
 - canCourtGroupMember(): returns first eligible group companion (opposite sex, youngAdult/adult/old, not matedThisRun) when all gates pass: hasGroup(), isPlayerMature(), matingCount < 5, fitness >= 50, energy >= 40, no activePursuit, 8-turn cooldown clear. Returns null otherwise.

--- a/game/play.html
+++ b/game/play.html
@@ -12774,7 +12774,11 @@ function renderButtons() {
   const leaveButton = document.getElementById("leaveGroup");
   if (leaveButton) leaveButton.disabled = disabled || !hasGroup();
   const courtCompanionButton = document.getElementById("courtCompanion");
-  if (courtCompanionButton) courtCompanionButton.disabled = disabled || !canCourtGroupMember();
+  if (courtCompanionButton) {
+    const eligibleMate = !disabled && canCourtGroupMember();
+    courtCompanionButton.style.display = eligibleMate ? "" : "none";
+    courtCompanionButton.disabled = !eligibleMate;
+  }
   updateBotStatus();
 }
 function renderLayers() {


### PR DESCRIPTION
## Problem

PR #60 added `<button id="courtCompanion">` permanently to the vertical-controls action row. The button was always rendered (just disabled when no eligible companion), adding an 8th button to a row designed for 7. On mobile this broke the layout — "Leave group" wrapped to two lines and the overall row height became inconsistent.

The spec explicitly states: *"Mobile layout must remain stable"* and *"avoid cluttering the main controls unless existing design supports disabled actions."*

## Fix

One-line logic change in `renderButtons()`:

```js
const eligibleMate = !disabled && canCourtGroupMember();
courtCompanionButton.style.display = eligibleMate ? "" : "none";
courtCompanionButton.disabled = !eligibleMate;
```

The Court button is now **hidden** (`display: none`) by default and only revealed when `canCourtGroupMember()` returns a truthy member. This matches the pattern of the encounter-card Court button from PR #59, which also only renders when `canAttemptMating()` is true.

## Files changed
- `game/play.html`
- `CHANGELOG.txt`

---
_Generated by [Claude Code](https://claude.ai/code/session_016sYvnxSRoQp4GcRE6V493Y)_