### PR TITLE
God Mode toggle + QA Back 1 turn death-screen recovery

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,14 @@
+[2026-05-09 god-mode-qa-recovery | Claude]
+God Mode toggle + QA Back 1 turn death-screen recovery. Developer/QA tool only; no effect on normal gameplay unless explicitly toggled on.
+- godModeEnabled (default false) and qaBackSnapshot (default null) added as top-level state variables.
+- takeQABackSnapshot(): called at the top of startTurn() when godModeEnabled is true. Deep-clones (JSON.parse/stringify) the full restorable game state before any turn effects resolve: player, waterState, currentEncounter, tileEncounterQueue, carcass, interruptedFood, nearbyEntities, persistentEntities, worldRegistry, nextRegistryId, exploredTiles (serialised as Array.from), nextEntityId, nextInstanceId, knownMapEntities, staticTileContents, consumedStaticTileKeys, burnedTiles, dangerGrace, recentPredatorWarning, activePursuit, investigationText, investigationEncounterRef, lastLookText, lastLookTurn, lastNarration, groupSceneNotice, heardText, smellText, nearbyRecentSocial, lastActionKind, lastDamageContext, debugLastAction, callStreak, lastCallTurn, socialGroup, noiseLevel, lastCravingCueTurn, lastRiskMemoryCueTurn, individualSocialState, lastHabitatKey, environment, timeState. debugLog and debugTrace are intentionally excluded so death records are preserved.
+- restoreQABackSnapshot(): writes all snapshotted values back; exploredTiles restored via new Set(array); environment/timeState/player restored via Object.assign (all are const objects). Adds qa-back-used debug trace with originalDeathContext, restoredTurn, restoredPosition, godModeEnabled:true. Adds visible log line "QA Back used: restored state before fatal action.". Calls hideDeathModal() then render().
+- HTML: God Mode toggle button (id=godModeToggle) added to Developer / QA Tools below the bot panel. Shows "God Mode: OFF" / "God Mode: ON"; orange outline when on.
+- HTML: deathModalQABack button added to death modal .deathModalActions (display:none by default). deathModalQANote small text note added below actions.
+- showDeathModal(): sets deathModalQABack and deathModalQANote visibility based on godModeEnabled && qaBackSnapshot.
+- Event listeners: deathModalQABack calls restoreQABackSnapshot() guarded by godModeEnabled && qaBackSnapshot. godModeToggle flips godModeEnabled and updates button text/outline.
+- Syntax check: PASS.
+
 [2026-05-09 group-mating-fix | Claude]
 Mobile layout fix: courtCompanion button now hidden (display:none) when no eligible companion is present; shown only when canCourtGroupMember() returns a truthy member. Previously the button was always visible (just disabled), adding an 8th button to the vertical-controls row and breaking the mobile layout. Pattern now matches the encounter-card Court button which only renders when canAttemptMating() is true.
 - Syntax check: PASS.

--- a/game/play.html
+++ b/game/play.html
@@ -695,6 +695,14 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
             </div>
             <div id="botSaveStatus" class="botSaveStatus"></div>
           </div>
+
+        <div class="godModePanel" style="margin-top:10px;padding-top:10px;border-top:1px solid #555;">
+          <strong>God Mode</strong>
+          <div style="margin-top:4px;">
+            <button id="godModeToggle" class="debugButton" type="button">God Mode: OFF</button>
+            <div class="small" style="margin-top:4px;">QA death recovery only. Adds a rollback button on the death screen.</div>
+          </div>
+        </div>
         </div>
       </div>
     </details>
@@ -711,7 +719,9 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
       <div class="deathModalActions">
         <button id="deathModalStay" type="button">Stay on this run</button>
         <button id="deathModalRestart" type="button">Restart</button>
+        <button id="deathModalQABack" type="button" style="display:none">QA Back 1 turn</button>
       </div>
+      <div id="deathModalQANote" style="display:none;font-size:0.78em;color:#aaa;margin-top:6px;text-align:center;">God Mode only: restores the state before the fatal action.</div>
     </div>
   </div>
 
@@ -3036,6 +3046,8 @@ let debugLastAction = null;
 let deathRestartPromptOpen = false;
 let callStreak = 0;
 let lastCallTurn = -999;
+let godModeEnabled = false;
+let qaBackSnapshot = null;
 
 let socialGroup = {
   members: [],
@@ -3147,6 +3159,121 @@ function diffSnapshots(before, after) {
   if (JSON.stringify(before.encounter) !== JSON.stringify(after.encounter)) deltas.encounter = {before: before.encounter, after: after.encounter};
   if (JSON.stringify(before.activePursuit) !== JSON.stringify(after.activePursuit)) deltas.activePursuit = {before: before.activePursuit, after: after.activePursuit};
   return deltas;
+}
+
+// @target [STATE] God Mode QA Back Snapshot
+function takeQABackSnapshot() {
+  try {
+    qaBackSnapshot = JSON.parse(JSON.stringify({
+      player: player,
+      waterState: waterState,
+      currentEncounter: currentEncounter,
+      tileEncounterQueue: tileEncounterQueue,
+      carcass: carcass,
+      interruptedFood: interruptedFood,
+      nearbyEntities: nearbyEntities,
+      persistentEntities: persistentEntities,
+      worldRegistry: worldRegistry,
+      nextRegistryId: nextRegistryId,
+      exploredTiles: Array.from(exploredTiles),
+      nextEntityId: nextEntityId,
+      nextInstanceId: nextInstanceId,
+      knownMapEntities: knownMapEntities,
+      staticTileContents: staticTileContents,
+      consumedStaticTileKeys: consumedStaticTileKeys,
+      burnedTiles: burnedTiles,
+      dangerGrace: dangerGrace,
+      recentPredatorWarning: recentPredatorWarning,
+      activePursuit: activePursuit,
+      investigationText: investigationText,
+      investigationEncounterRef: investigationEncounterRef,
+      lastLookText: lastLookText,
+      lastLookTurn: lastLookTurn,
+      lastNarration: lastNarration,
+      groupSceneNotice: groupSceneNotice,
+      heardText: heardText,
+      smellText: smellText,
+      nearbyRecentSocial: nearbyRecentSocial,
+      lastActionKind: lastActionKind,
+      lastDamageContext: lastDamageContext,
+      debugLastAction: debugLastAction,
+      callStreak: callStreak,
+      lastCallTurn: lastCallTurn,
+      socialGroup: socialGroup,
+      noiseLevel: noiseLevel,
+      lastCravingCueTurn: lastCravingCueTurn,
+      lastRiskMemoryCueTurn: lastRiskMemoryCueTurn,
+      individualSocialState: individualSocialState,
+      lastHabitatKey: lastHabitatKey,
+      environment: environment,
+      timeState: {phase: timeState.phase, phaseTurn: timeState.phaseTurn, sleepTurnsRemaining: timeState.sleepTurnsRemaining}
+    }));
+  } catch (e) {
+    qaBackSnapshot = null;
+  }
+}
+
+function restoreQABackSnapshot() {
+  if (!qaBackSnapshot) return;
+  const snap = qaBackSnapshot;
+  const originalDeathContext = cloneDebug(player.deathContext);
+
+  Object.assign(player, snap.player);
+  waterState = snap.waterState;
+  currentEncounter = snap.currentEncounter;
+  tileEncounterQueue = snap.tileEncounterQueue;
+  carcass = snap.carcass;
+  interruptedFood = snap.interruptedFood;
+  nearbyEntities = snap.nearbyEntities;
+  persistentEntities = snap.persistentEntities;
+  worldRegistry = snap.worldRegistry;
+  nextRegistryId = snap.nextRegistryId;
+  exploredTiles = new Set(snap.exploredTiles);
+  nextEntityId = snap.nextEntityId;
+  nextInstanceId = snap.nextInstanceId;
+  knownMapEntities = snap.knownMapEntities;
+  staticTileContents = snap.staticTileContents;
+  consumedStaticTileKeys = snap.consumedStaticTileKeys;
+  burnedTiles = snap.burnedTiles;
+  dangerGrace = snap.dangerGrace;
+  recentPredatorWarning = snap.recentPredatorWarning;
+  activePursuit = snap.activePursuit;
+  investigationText = snap.investigationText;
+  investigationEncounterRef = snap.investigationEncounterRef;
+  lastLookText = snap.lastLookText;
+  lastLookTurn = snap.lastLookTurn;
+  lastNarration = snap.lastNarration;
+  groupSceneNotice = snap.groupSceneNotice;
+  heardText = snap.heardText;
+  smellText = snap.smellText;
+  nearbyRecentSocial = snap.nearbyRecentSocial;
+  lastActionKind = snap.lastActionKind;
+  lastDamageContext = snap.lastDamageContext;
+  debugLastAction = snap.debugLastAction;
+  callStreak = snap.callStreak;
+  lastCallTurn = snap.lastCallTurn;
+  socialGroup = snap.socialGroup;
+  noiseLevel = snap.noiseLevel;
+  lastCravingCueTurn = snap.lastCravingCueTurn;
+  lastRiskMemoryCueTurn = snap.lastRiskMemoryCueTurn;
+  individualSocialState = snap.individualSocialState;
+  lastHabitatKey = snap.lastHabitatKey;
+  Object.assign(environment, snap.environment);
+  timeState.phase = snap.timeState.phase;
+  timeState.phaseTurn = snap.timeState.phaseTurn;
+  timeState.sleepTurnsRemaining = snap.timeState.sleepTurnsRemaining;
+
+  addDebugTrace("qa-back-used", {
+    originalDeathContext,
+    restoredTurn: player.turn,
+    restoredPosition: {x: player.x, y: player.y, z: player.z},
+    godModeEnabled: true
+  });
+  addLog(`Turn ${player.turn}: QA Back used: restored state before fatal action.`, "minor");
+
+  hideDeathModal();
+  deathRestartPromptOpen = false;
+  render();
 }
 
 // @target [STATE] Add Turn Delta Trace
@@ -3804,6 +3931,7 @@ function actionMetabolismProfile(actionKind) {
 
 function startTurn() {
   if (player.dead) return false;
+  if (godModeEnabled) takeQABackSnapshot();
 
   const before = importantStateSnapshot();
   addDebugTrace("action-start", {debugLastAction: cloneDebug(debugLastAction), before});
@@ -11329,6 +11457,11 @@ function showDeathModal(message) {
     return;
   }
   messageBox.textContent = message || "The run is over.";
+  const qaBackBtn = document.getElementById("deathModalQABack");
+  const qaNote = document.getElementById("deathModalQANote");
+  const showQA = godModeEnabled && !!qaBackSnapshot;
+  if (qaBackBtn) qaBackBtn.style.display = showQA ? "" : "none";
+  if (qaNote) qaNote.style.display = showQA ? "" : "none";
   modal.classList.add("open");
   modal.setAttribute("aria-hidden", "false");
 }
@@ -15056,6 +15189,16 @@ if (deathModalRestart) deathModalRestart.addEventListener("click", () => {
   resetGameForPlayer("death modal restart");
 });
 if (deathModalStay) deathModalStay.addEventListener("click", hideDeathModal);
+const deathModalQABack = document.getElementById("deathModalQABack");
+if (deathModalQABack) deathModalQABack.addEventListener("click", () => {
+  if (godModeEnabled && qaBackSnapshot) restoreQABackSnapshot();
+});
+const godModeToggle = document.getElementById("godModeToggle");
+if (godModeToggle) godModeToggle.addEventListener("click", () => {
+  godModeEnabled = !godModeEnabled;
+  godModeToggle.textContent = godModeEnabled ? "God Mode: ON" : "God Mode: OFF";
+  godModeToggle.style.outline = godModeEnabled ? "2px solid #f90" : "";
+});
 document.addEventListener("keydown", event => {
   if (event.key === "Escape") { closeMapOverlay(); closeCallChoiceOverlay(); }
 });


### PR DESCRIPTION
## Summary

- Adds a **God Mode** toggle in Developer / QA Tools (default OFF). No effect on normal gameplay unless explicitly switched on.
- When God Mode is ON, `startTurn()` captures a full deep-clone snapshot of all restorable game state before any turn effects resolve.
- If the player dies with God Mode ON, the death modal shows a **"QA Back 1 turn"** button. Clicking it restores the pre-fatal-action snapshot, adds a `qa-back-used` debug trace (preserving the original death context), logs a visible line, and re-renders.
- Death record is intentionally preserved: `debugLog` and `debugTrace` are excluded from the snapshot.

## What is snapshotted

`player`, `waterState`, `currentEncounter`, `tileEncounterQueue`, `carcass`, `interruptedFood`, `nearbyEntities`, `persistentEntities`, `worldRegistry`, `nextRegistryId`, `exploredTiles`, `nextEntityId`, `nextInstanceId`, `knownMapEntities`, `staticTileContents`, `consumedStaticTileKeys`, `burnedTiles`, `dangerGrace`, `recentPredatorWarning`, `activePursuit`, `investigationText`, `investigationEncounterRef`, `lastLookText`, `lastLookTurn`, `lastNarration`, `groupSceneNotice`, `heardText`, `smellText`, `nearbyRecentSocial`, `lastActionKind`, `lastDamageContext`, `debugLastAction`, `callStreak`, `lastCallTurn`, `socialGroup`, `noiseLevel`, `lastCravingCueTurn`, `lastRiskMemoryCueTurn`, `individualSocialState`, `lastHabitatKey`, `environment`, `timeState`.

## Test plan

- [ ] Page load: God Mode toggle reads "God Mode: OFF"; no QA Back button on death modal
- [ ] Toggle on: button reads "God Mode: ON" with orange outline
- [ ] Die with God Mode OFF: death modal shows only "Stay on this run" and "Restart" — no QA Back
- [ ] Die with God Mode ON: death modal shows "QA Back 1 turn" and the small note
- [ ] Click QA Back: player is alive, at pre-fatal position, mating progress and group state restored, predator/pursuit state restored if present before fatal action
- [ ] Debug trace: `qa-back-used` entry present; original death context preserved; `godModeEnabled: true`
- [ ] Visible log line: "QA Back used: restored state before fatal action."
- [ ] Bot mode unaffected: bot runs with God Mode OFF proceed normally
- [ ] Syntax check: PASS

---
_Generated by [Claude Code](https://claude.ai/code/session_01437S16SBFthfNV2QbvvZGT)_