### PR TITLE
Fix wildfire outer-zone smell masking predator scent cues

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,6 @@
 [2026-05-10 wildfire-smell-priority | Claude]
 Wildfire outer-zone smell no longer masks predator or threat scents.
-Previously, entering the outer wildfire ring (wdist <= radius + 6) unconditionally overwrote the smell display with "Faint smoke from …", overriding any predator, rival, or other scent already set this render. Now the outer-zone smoke cue is only applied when smellText is the neutral default ("The wet forest air is thick with leaf rot, bark, and your own scent."). Inner-zone and core-fire smoke cues are unchanged and still override as before, since those represent immediate danger.
+Previously, entering the outer wildfire ring (wdist <= radius + 6) unconditionally overwrote the smell display with "Faint smoke from …", overriding any predator, rival, or other scent already set this render. Now uses smellIsAmbientText() which checks against all 11 possible randomAmbientSmell() outputs (not just the single old default string), so the outer-zone smoke cue fires correctly for every ambient condition including rain, mist, still air, and night. Also adds AMBIENT_SMELL_STRINGS constant for maintainability. Inner-zone and core-fire smoke cues are unchanged and still override as before, since those represent immediate danger.
 
 [2026-05-10 roguelike-profile-saves-fix2 | Claude]
 Fix mid-run profile switch not resetting run-tracking globals.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+[2026-05-10 wildfire-smell-priority | Claude]
+Wildfire outer-zone smell no longer masks predator or threat scents.
+Previously, entering the outer wildfire ring (wdist <= radius + 6) unconditionally overwrote the smell display with "Faint smoke from …", overriding any predator, rival, or other scent already set this render. Now the outer-zone smoke cue is only applied when smellText is the neutral default ("The wet forest air is thick with leaf rot, bark, and your own scent."). Inner-zone and core-fire smoke cues are unchanged and still override as before, since those represent immediate danger.
+
 [2026-05-10 roguelike-profile-saves-fix2 | Claude]
 Fix mid-run profile switch not resetting run-tracking globals.
 

--- a/game/play.html
+++ b/game/play.html
@@ -16387,7 +16387,10 @@ function renderSenses() {
     } else if (wdist <= wr + 3) {
       smellTextEl.innerHTML = formatCueText(`Smoke drifts from ${wdirStr}. Something burns nearby.`);
     } else if (wdist <= wr + 6) {
-      smellTextEl.innerHTML = formatCueText(`Faint smoke from ${wdirStr}.`);
+      const defaultSmell = "The wet forest air is thick with leaf rot, bark, and your own scent.";
+      if (!smellText || smellText === defaultSmell) {
+        smellTextEl.innerHTML = formatCueText(`Faint smoke from ${wdirStr}.`);
+      }
     }
   }
 

--- a/game/play.html
+++ b/game/play.html
@@ -7613,6 +7613,24 @@ function randomAmbientSmell() {
   ]);
 }
 
+const AMBIENT_SMELL_STRINGS = new Set([
+  "Sleep dulls even strong scent.",
+  "Night air holds scent close and heavy.",
+  "Heavy rain washes scent from the air.",
+  "Wet bark and leaf mould dull the scent trail.",
+  "Mist holds scent low among the leaves.",
+  "The air is still; scent gathers close to where it began.",
+  "Still air keeps scent low and close; little carries far.",
+  "Wet leaves, bark, and fungal rot fill the air.",
+  "The humid forest carries too many scents to trust.",
+  "Sweet rot carries faintly on the air — fruit, fungus, or something already opened.",
+  "The air is warm and green, heavy with plant life."
+]);
+
+function smellIsAmbientText(text) {
+  return AMBIENT_SMELL_STRINGS.has(text);
+}
+
 // Checks the exact current tile.
 // Static tile contents are checked first so persistent resources are not lost.
 /**
@@ -16387,8 +16405,7 @@ function renderSenses() {
     } else if (wdist <= wr + 3) {
       smellTextEl.innerHTML = formatCueText(`Smoke drifts from ${wdirStr}. Something burns nearby.`);
     } else if (wdist <= wr + 6) {
-      const defaultSmell = "The wet forest air is thick with leaf rot, bark, and your own scent.";
-      if (!smellText || smellText === defaultSmell) {
+      if (!smellText || smellIsAmbientText(smellText)) {
         smellTextEl.innerHTML = formatCueText(`Faint smoke from ${wdirStr}.`);
       }
     }


### PR DESCRIPTION
## Summary

- The outer wildfire ring (`wdist <= radius + 6`) was unconditionally overwriting the smell display with "Faint smoke from …", hiding any predator, rival, or other threat scent already set this render frame
- Fix: adds `AMBIENT_SMELL_STRINGS` (a Set of all 11 strings `randomAmbientSmell()` can return) and `smellIsAmbientText()` helper — the outer-zone guard now uses that instead of a single hard-coded default string
- Covers all ambient conditions: rain, mist, still air, night, and 4 general variants
- Inner-zone (`wdist <= radius + 3`) and core-fire cues are unchanged; those represent immediate danger and should still override

## Files changed

- `game/play.html` — `AMBIENT_SMELL_STRINGS` constant + `smellIsAmbientText()` helper added; outer wildfire smell guard updated to use it
- `CHANGELOG.txt` — entry added

## Test plan

- [ ] Walk near (but not in) a wildfire while a predator is tracking you — predator scent should remain visible in the smell cue
- [ ] Walk into the outer ring with no predator present — faint smoke cue should appear as before
- [ ] Walk into the inner ring or core — smoke/ash cues should still override regardless of other scents
- [ ] Trigger outer ring during heavy rain, mist, still air, and night — faint smoke should show in all ambient conditions

Addresses Codex P2 on PR #66.