### PR TITLE
Progressive field notes (i) button — investigation knowledge popup

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,29 @@
+[2026-05-10 nh-progressive-reveal | Claude]
+Investigation knowledge popup redesigned as progressive field notes system.
+
+Field notes (i) button:
+- Appears on encounter cards once investigations >= 10 (KNOWLEDGE_INFO_UNLOCK). Only shown if the encounter has naturalHistory content.
+- Button label: ⓘ with tooltip "Field Notes (N/5 sections unlocked)".
+- Positioned inline in the creature name row.
+- Clicking opens the Field Notes popup showing only unlocked sections.
+
+Progressive section unlock (KNOWLEDGE_NH_THRESHOLDS = [10, 14, 18, 22, 26]):
+- 10 investigations: Field Note unlocked. Log message: "Field notes on the X are now accessible. Tap ⓘ to read them."
+- 14 investigations: Behaviour unlocked. Log: "Your field notes on the X have expanded."
+- 18 investigations: Ecology unlocked. Same log.
+- 22 investigations: Danger to you (gameplayInsight) unlocked. Same log.
+- 26 investigations: Science note unlocked. Same log.
+- Sections not yet unlocked are simply absent from the popup — no placeholder text.
+
+Popup changes:
+- Title changed from "Natural History Unlocked: X" to "Field Notes: X" with inline progress badge "N/5 sections".
+- Auto-trigger at KNOWLEDGE_MAX (30) removed — popup is now player-initiated only via the (i) button.
+- showNaturalHistoryPopup() reads current investigation count from player.knowledgeByEncounterKey to determine which sections to render.
+
+New constants: KNOWLEDGE_INFO_UNLOCK = 10, KNOWLEDGE_NH_THRESHOLDS = [10, 14, 18, 22, 26].
+New CSS: .nhInfoBtn, .nhModalProgress.
+Debug trace: "natural-history-popup" (replaces "natural-history-unlocked").
+
 [2026-05-10 quick-fixes-v2 | Claude]
 Four small correctness fixes.
 

--- a/game/play.html
+++ b/game/play.html
@@ -380,6 +380,9 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
 .nhModalSection strong { display: block; color: #9bea72; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; margin-bottom: 4px; }
 .nhModalSection p { margin: 0; line-height: 1.5; color: #cfdcba; font-size: 15px; }
 .nhModalClose { margin: 0 14px 14px; width: calc(100% - 28px); height: 38px; font-size: 14px; font-weight: bold; background: #1b4a2b; border-color: #4a9a62; color: #c8f0a0; flex: 0 0 auto; }
+.nhModalProgress { font-size: 11px; color: #6db87a; font-weight: normal; text-transform: uppercase; letter-spacing: .04em; margin-left: 8px; }
+.nhInfoBtn { font-size: 13px; padding: 2px 7px; background: #1b4a2b; border: 1px solid #4a9a62; color: #9bea72; border-radius: 4px; cursor: pointer; line-height: 1.4; vertical-align: middle; margin-left: 6px; }
+.nhInfoBtn:hover { background: #2d6b3e; }
 .knowledge { color: #9bea72; }
 .knowledge-tier { color: #d9c747; font-weight: bold; }
 /* === MOBILE: @media (max-width: 980px) === */
@@ -4738,6 +4741,8 @@ function initGame(resumeChoice) {
 
 const KNOWLEDGE_MAX = 30;
 const KNOWLEDGE_PER_ENTITY_CAP = 2;
+const KNOWLEDGE_INFO_UNLOCK = 10;
+const KNOWLEDGE_NH_THRESHOLDS = [10, 14, 18, 22, 26];
 const KNOWLEDGE_TIERS = [
   { threshold: 0,  tier: 0, label: "unknown" },
   { threshold: 1,  tier: 1, label: "noticed" },
@@ -12076,7 +12081,10 @@ function showNaturalHistoryPopup(e) {
 
   const nh = e.naturalHistory || {};
   const name = nh.title || e.name || "creature";
-  titleEl.textContent = `Natural History Unlocked: ${name}`;
+
+  const typeKey = getEncounterTypeKey(e);
+  const tk = player.knowledgeByEncounterKey ? player.knowledgeByEncounterKey[typeKey] : null;
+  const count = tk ? tk.investigations : KNOWLEDGE_MAX;
 
   const sections = [
     { label: "Field Note", key: "fieldNote" },
@@ -12086,18 +12094,24 @@ function showNaturalHistoryPopup(e) {
     { label: "Science note", key: "scienceNote" }
   ];
 
+  const unlockedCount = KNOWLEDGE_NH_THRESHOLDS.filter(t => count >= t).length;
+  const progressLabel = unlockedCount < sections.length
+    ? `<span class="nhModalProgress">${unlockedCount}/${sections.length} sections</span>`
+    : "";
+  titleEl.innerHTML = `Field Notes: ${name}${progressLabel}`;
+
   const rendered = sections
-    .filter(s => nh[s.key])
+    .filter((s, i) => count >= KNOWLEDGE_NH_THRESHOLDS[i] && nh[s.key])
     .map(s => `<div class="nhModalSection"><strong>${s.label}</strong><p>${nh[s.key]}</p></div>`)
     .join("");
 
-  body.innerHTML = rendered || `<div class="nhModalSection"><p>Your sustained observation of the <em>${name}</em> over many encounters has built a detailed understanding of its place in this world.</p></div>`;
+  body.innerHTML = rendered || `<div class="nhModalSection"><p>Continue investigating to expand your field notes.</p></div>`;
 
   modal.classList.add("open");
   modal.setAttribute("aria-hidden", "false");
 
-  addDebugTrace("natural-history-unlocked", {
-    encounterKey: getEncounterTypeKey(e), name: e.name, naturalHistory: cloneDebug(nh)
+  addDebugTrace("natural-history-popup", {
+    encounterKey: typeKey, name: e.name, count, unlockedCount
   });
 }
 
@@ -12380,8 +12394,10 @@ function investigate() {
       const tierText = investigationKnowledgeTierText(e, knowledgeResult.tierUnlocked);
       if (tierText) addLog(tierText, "knowledge-tier");
     }
-    if (kCount >= KNOWLEDGE_MAX) {
-      showNaturalHistoryPopup(e);
+    if (kCount === KNOWLEDGE_INFO_UNLOCK && e.naturalHistory) {
+      addLog(`Field notes on the ${eName} are now accessible. Tap ⓘ on the encounter card to read them.`, "knowledge-tier");
+    } else if ([14, 18, 22, 26].includes(kCount) && e.naturalHistory) {
+      addLog(`Your field notes on the ${eName} have expanded.`, "knowledge");
     }
   }
 
@@ -16378,18 +16394,24 @@ function renderSenses() {
       const cleanInvestigationText = safeNarrativeText(investigationText, "");
       const floatingInvestigationBox = cleanInvestigationText && !investigationBelongsToCard ? `<div class="investigationResult"><strong>Investigation result:</strong><br>${cleanInvestigationText}</div>` : "";
 
+      const nhTypeKey = getEncounterTypeKey(e);
+      const nhTk = player.knowledgeByEncounterKey ? player.knowledgeByEncounterKey[nhTypeKey] : null;
+      const nhBtnHtml = (e.naturalHistory && nhTk && nhTk.investigations >= KNOWLEDGE_INFO_UNLOCK)
+        ? `<button type="button" id="nhInfoBtn" class="nhInfoBtn" title="Field Notes (${KNOWLEDGE_NH_THRESHOLDS.filter(t => nhTk.investigations >= t).length}/${KNOWLEDGE_NH_THRESHOLDS.length} sections unlocked)">ⓘ</button>`
+        : "";
+
       html += `
         ${floatingInvestigationBox}
         <div class="creatureCard">
           <div class="creatureIcon ${encounterThreatClass(e)}">${e.icon || "?"}</div>
           <div>
-            <div class="creatureName">${sexSymbolHtml(e)}<span>${e.name || "unknown encounter"}</span></div>
+            <div class="creatureName">${sexSymbolHtml(e)}<span>${e.name || "unknown encounter"}</span>${nhBtnHtml}</div>
             <div class="creatureText">${cardDetailForEncounter(e, seeCueText) || "Something is here, but the game has not described it properly yet."}</div>
             ${investigationBelongsToCard ? `<div class="investigationResult"><strong>Investigation result:</strong><br>${cleanInvestigationText}</div>` : ""}
             ${warning ? `<div class="creatureText poison">${warning}</div>` : ""}
             <div class="creatureStats">${statHtml}</div>
             <div class="cardActions">${actions}</div>
-            
+
           </div>
         </div>
         ${tileEncounterQueue.length ? tileEncounterQueue.map((rawQ, qi) => { const q = normaliseEncounter(rawQ, rawQ.key || rawQ.name || "queued"); return `
@@ -17041,6 +17063,11 @@ if (nhModalClose) nhModalClose.addEventListener("click", () => {
 const nhModal = document.getElementById("nhModal");
 if (nhModal) nhModal.addEventListener("click", event => {
   if (event.target === nhModal) { nhModal.classList.remove("open"); nhModal.setAttribute("aria-hidden", "true"); }
+});
+document.addEventListener("click", event => {
+  if (event.target && event.target.id === "nhInfoBtn" && currentEncounter) {
+    showNaturalHistoryPopup(currentEncounter);
+  }
 });
 const mapOverlay = document.getElementById("mapOverlay");
 if (mapOverlay) {

--- a/game/play.html
+++ b/game/play.html
@@ -12095,10 +12095,13 @@ function showNaturalHistoryPopup(e) {
   ];
 
   const unlockedCount = KNOWLEDGE_NH_THRESHOLDS.filter(t => count >= t).length;
-  const progressLabel = unlockedCount < sections.length
-    ? `<span class="nhModalProgress">${unlockedCount}/${sections.length} sections</span>`
-    : "";
-  titleEl.innerHTML = `Field Notes: ${name}${progressLabel}`;
+  titleEl.textContent = `Field Notes: ${name}`;
+  if (unlockedCount < sections.length) {
+    const badge = document.createElement("span");
+    badge.className = "nhModalProgress";
+    badge.textContent = `${unlockedCount}/${sections.length} sections`;
+    titleEl.appendChild(badge);
+  }
 
   const rendered = sections
     .filter((s, i) => count >= KNOWLEDGE_NH_THRESHOLDS[i] && nh[s.key])


### PR DESCRIPTION
## Summary

Investigation knowledge popup redesigned as a progressive field notes system unlocked by repeated investigation.

## How it works

- At **10 investigations**, an ⓘ button appears on the encounter card (inline with the creature name). A log line fires: *"Field notes on the X are now accessible. Tap ⓘ to read them."*
- Clicking ⓘ opens the **Field Notes** popup showing only unlocked sections
- One new section unlocks every 4 investigations after that:

| Investigations | Section unlocked |
|---|---|
| 10 | Field Note |
| 14 | Behaviour |
| 18 | Ecology |
| 22 | Danger to you |
| 26 | Science note |

- Sections not yet unlocked are **absent** from the popup — no placeholder text
- Popup title shows **"Field Notes: X"** with an inline **N/5 sections** progress badge
- The old auto-trigger at 30 investigations is removed — popup is now always player-initiated

## Files changed

- `game/play.html` — new constants, CSS, button, popup logic, log messages, event listener
- `CHANGELOG.txt` — entry added

## New constants

- `KNOWLEDGE_INFO_UNLOCK = 10`
- `KNOWLEDGE_NH_THRESHOLDS = [10, 14, 18, 22, 26]`

## Test plan

- [ ] Investigate an encounter 10 times — ⓘ button should appear and log message should fire
- [ ] Open ⓘ — only Field Note section should be visible
- [ ] Investigate to 14 — reopen ⓘ — Behaviour section should now appear
- [ ] Continue to 26 — all 5 sections visible
- [ ] Encounter with no `naturalHistory` — no ⓘ button at any count (note: after PR #67 all encounters have naturalHistory)
- [ ] ⓘ button absent below 10 investigations

**Note:** Requires PR #67 (`natural-history-all-encounters`) for all encounters to have naturalHistory content. Can be reviewed and merged independently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbndgXZEyjsETvjc19ny1s)_