### PR TITLE
Field Journal: restore Fauna/Flora/Misc tabs, stacked entry window, predatorLeftovers fix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,11 @@
 [2026-05-10 field-journal-ui-v2 | Claude]
-Field Journal UI redesign: individual encounter windows, grouped index, main UI placement.
+Field Journal UI redesign: individual encounter windows, tabbed grouped index, stacked modal behaviour, player titlebar placement.
+
+Follow-up fixes after initial review:
+- Restored Fauna / Flora / Misc tabs on the journal index. Each tab shows only the groups belonging to that tab (fauna: predators, snakes, reptiles, birds, primates, mammals, amphibians, insects, arachnids, crustaceans; flora: fruit, flowers, fungi/plants; misc: water/mineral, nests, carcasses, other). Tab filtering uses FJ_TAB_GROUPS + getEncounterGroup so category stored on each entry is irrelevant — predatorLeftovers (kind: "carcass") correctly appears in Misc regardless of its fauna/misc category value.
+- Species entry window (nhModal) now stacks on top of the journal (nhModal z-index raised to 10070; fjModal stays open behind it). nhModal Close button dismisses the entry window only. Clicking outside the entry window (nhModal backdrop) dismisses both windows. Clicking outside the journal index (fjModal backdrop) dismisses the journal only.
+- Tab clicks handled inline in the fjModal click listener; no separate event delegation needed.
+- nhModal._fromJournal flag tracks whether the entry window was opened from the journal, so backdrop click knows whether to also close the journal.
 
 - (i) button on encounter cards now opens a single-creature entry window (showEncounterJournalEntry) via the existing nhModal. Shows the creature's name, investigation count, and all unlocked naturalHistory sections. No longer opens the full journal index.
 - Field Journal index (showFieldJournal) redesigned as a compact scrollable list with sensible biological groupings: Predators / Constrictors & snakes / Reptiles / Birds / Primates & relatives / Other mammals / Amphibians / Insects / Arachnids & myriapods / Freshwater & crustaceans / Fruit & berries / Flowers / Fungi & plants / Water & mineral / Nests / Carcasses / Other. Entries with field notes unlocked are highlighted. Clicking any entry opens the single-creature window.

--- a/game/play.html
+++ b/game/play.html
@@ -370,7 +370,7 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
 .deathModalActions button { height: 42px; font-size: 14px; font-weight: bold; }
 #deathModalRestart { background: #7b2424; border-color: #ff8f8f; color: #fff3ee; }
 #deathModalStay { background: #251313; border-color: #8b4a4a; color: #f3c8c0; }
-.nhModal { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; z-index: 10060; padding: 18px; background: rgba(0, 20, 10, 0.82); }
+.nhModal { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; z-index: 10070; padding: 18px; background: rgba(0, 20, 10, 0.82); }
 .nhModal.open { display: flex; }
 .nhModalCard { width: min(94vw, 560px); background: #071209; border: 2px solid #4a9a62; box-shadow: 0 0 0 1px #1a3c22 inset, 0 18px 70px rgba(0,0,0,.75); border-radius: 10px; color: #e8f0d8; overflow: hidden; max-height: 88vh; display: flex; flex-direction: column; }
 .nhModalHeader { display: flex; align-items: center; gap: 10px; background: #1b4a2b; color: #c8f0a0; padding: 12px 14px; font-size: 16px; font-weight: bold; text-transform: uppercase; letter-spacing: .04em; border-bottom: 1px solid #2d6b3e; flex: 0 0 auto; }
@@ -386,7 +386,11 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
 .fjModal { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; z-index: 10060; padding: 18px; background: rgba(0, 20, 10, 0.82); }
 .fjModal.open { display: flex; }
 .fjCard { width: min(96vw, 480px); background: #071209; border: 2px solid #4a9a62; box-shadow: 0 0 0 1px #1a3c22 inset, 0 18px 70px rgba(0,0,0,.75); border-radius: 10px; color: #e8f0d8; overflow: hidden; max-height: 90vh; display: flex; flex-direction: column; }
-.fjHeader { background: #1b4a2b; color: #c8f0a0; padding: 10px 14px; flex: 0 0 auto; border-bottom: 1px solid #2d6b3e; font-size: 15px; font-weight: bold; text-transform: uppercase; letter-spacing: .04em; }
+.fjHeader { background: #1b4a2b; color: #c8f0a0; padding: 10px 14px 0; flex: 0 0 auto; border-bottom: 1px solid #2d6b3e; }
+.fjHeaderTitle { font-size: 15px; font-weight: bold; text-transform: uppercase; letter-spacing: .04em; margin-bottom: 8px; }
+.fjTabs { display: flex; gap: 4px; }
+.fjTab { padding: 5px 14px; font-size: 12px; font-weight: bold; text-transform: uppercase; letter-spacing: .04em; background: transparent; border: 1px solid #2d6b3e; border-bottom: none; color: #6db87a; border-radius: 4px 4px 0 0; cursor: pointer; }
+.fjTab.active { background: #071209; color: #c8f0a0; border-color: #4a9a62; }
 .fjBody { padding: 8px 0; overflow-y: auto; flex: 1 1 auto; }
 .fjGroup { margin-bottom: 2px; }
 .fjGroupHeader { padding: 5px 14px 3px; font-size: 10px; font-weight: bold; text-transform: uppercase; letter-spacing: .08em; color: #4a9a62; }
@@ -864,7 +868,14 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
 
   <div id="fjModal" class="fjModal" aria-hidden="true">
     <div class="fjCard" role="dialog" aria-modal="true" aria-labelledby="fjTitle">
-      <div class="fjHeader" id="fjTitle">Field Journal</div>
+      <div class="fjHeader">
+        <div class="fjHeaderTitle" id="fjTitle">Field Journal</div>
+        <div class="fjTabs">
+          <button type="button" class="fjTab active" data-fjtab="fauna">Fauna</button>
+          <button type="button" class="fjTab" data-fjtab="flora">Flora</button>
+          <button type="button" class="fjTab" data-fjtab="misc">Misc</button>
+        </div>
+      </div>
       <div id="fjBody" class="fjBody"></div>
       <button id="fjClose" class="fjClose" type="button">Close</button>
     </div>
@@ -12225,6 +12236,14 @@ const FJ_GROUPS = [
   "Nests", "Carcasses", "Other"
 ];
 
+const FJ_TAB_GROUPS = {
+  fauna: ["Predators", "Constrictors & snakes", "Reptiles", "Birds",
+          "Primates & relatives", "Other mammals", "Amphibians",
+          "Insects", "Arachnids & myriapods", "Freshwater & crustaceans"],
+  flora: ["Fruit & berries", "Flowers", "Fungi & plants"],
+  misc:  ["Water & mineral", "Nests", "Carcasses", "Other"]
+};
+
 const FJ_GROUP_MAP = {
   groundCarnivore: "Predators", climbingHunter: "Predators", gastornis: "Predators",
   masillaraptor: "Predators", eagle: "Predators", bergisuchus: "Predators",
@@ -12331,30 +12350,35 @@ function showEncounterJournalEntry(typeKey) {
 }
 
 // @target [INVESTIGATION] Show Field Journal (index)
-function showFieldJournal() {
+function showFieldJournal(tab) {
   const modal = document.getElementById("fjModal");
   const body = document.getElementById("fjBody");
   if (!modal || !body) return;
 
+  const activeTab = tab || (modal.querySelector(".fjTab.active") || {}).dataset && modal.querySelector(".fjTab.active").dataset.fjtab || "fauna";
+  modal.querySelectorAll(".fjTab").forEach(t => t.classList.toggle("active", t.dataset.fjtab === activeTab));
+
   const journal = player.knowledgeByEncounterKey || {};
   const entries = Object.values(journal);
+  const tabGroups = FJ_TAB_GROUPS[activeTab] || [];
+  const tabEntries = entries.filter(tk => tabGroups.includes(getEncounterGroup(tk.typeKey)));
 
-  if (!entries.length) {
-    body.innerHTML = `<p style="padding:12px 14px;color:#6db87a;font-style:italic">No encounters recorded yet. Investigate creatures and plants to build your journal.</p>`;
+  if (!tabEntries.length) {
+    body.innerHTML = `<p style="padding:12px 14px;color:#6db87a;font-style:italic">No ${activeTab} entries yet.</p>`;
     modal.classList.add("open");
     modal.setAttribute("aria-hidden", "false");
     return;
   }
 
   const grouped = {};
-  for (const tk of entries) {
+  for (const tk of tabEntries) {
     const g = getEncounterGroup(tk.typeKey);
     if (!grouped[g]) grouped[g] = [];
     grouped[g].push(tk);
   }
 
   const html = FJ_GROUPS
-    .filter(g => grouped[g])
+    .filter(g => tabGroups.includes(g) && grouped[g])
     .map(g => {
       const rows = grouped[g]
         .slice()
@@ -17326,16 +17350,20 @@ if (showWorldMapButton) showWorldMapButton.addEventListener("click", () => setAc
 const mapOverlayClose = document.getElementById("mapOverlayClose");
 if (mapOverlayClose) mapOverlayClose.addEventListener("click", closeMapOverlay);
 const nhModalClose = document.getElementById("nhModalClose");
-if (nhModalClose) nhModalClose.addEventListener("click", () => {
-  const nhModal = document.getElementById("nhModal");
-  if (nhModal) { nhModal.classList.remove("open"); nhModal.setAttribute("aria-hidden", "true"); }
-});
 const nhModal = document.getElementById("nhModal");
+if (nhModalClose) nhModalClose.addEventListener("click", () => {
+  if (nhModal) { nhModal.classList.remove("open"); nhModal.setAttribute("aria-hidden", "true"); nhModal._fromJournal = false; }
+});
 if (nhModal) nhModal.addEventListener("click", event => {
-  if (event.target === nhModal) { nhModal.classList.remove("open"); nhModal.setAttribute("aria-hidden", "true"); }
+  if (event.target === nhModal) {
+    nhModal.classList.remove("open"); nhModal.setAttribute("aria-hidden", "true");
+    if (nhModal._fromJournal && fjModal) { fjModal.classList.remove("open"); fjModal.setAttribute("aria-hidden", "true"); }
+    nhModal._fromJournal = false;
+  }
 });
 document.addEventListener("click", event => {
   if (event.target && event.target.id === "nhInfoBtn" && currentEncounter) {
+    if (nhModal) nhModal._fromJournal = false;
     showEncounterJournalEntry(getEncounterTypeKey(currentEncounter));
   }
 });
@@ -17347,11 +17375,12 @@ if (fjClose) fjClose.addEventListener("click", () => {
   fjModal.setAttribute("aria-hidden", "true");
 });
 if (fjModal) fjModal.addEventListener("click", event => {
-  if (event.target === fjModal) { fjModal.classList.remove("open"); fjModal.setAttribute("aria-hidden", "true"); }
+  if (event.target === fjModal) { fjModal.classList.remove("open"); fjModal.setAttribute("aria-hidden", "true"); return; }
+  const tab = event.target.closest(".fjTab[data-fjtab]");
+  if (tab) { showFieldJournal(tab.dataset.fjtab); return; }
   const row = event.target.closest(".fjEntryRow[data-fjtk]");
   if (row) {
-    fjModal.classList.remove("open");
-    fjModal.setAttribute("aria-hidden", "true");
+    if (nhModal) nhModal._fromJournal = true;
     showEncounterJournalEntry(row.dataset.fjtk);
   }
 });

--- a/game/play.html
+++ b/game/play.html
@@ -380,6 +380,9 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
 .nhModalSection strong { display: block; color: #9bea72; font-size: 11px; text-transform: uppercase; letter-spacing: .04em; margin-bottom: 4px; }
 .nhModalSection p { margin: 0; line-height: 1.5; color: #cfdcba; font-size: 15px; }
 .nhModalClose { margin: 0 14px 14px; width: calc(100% - 28px); height: 38px; font-size: 14px; font-weight: bold; background: #1b4a2b; border-color: #4a9a62; color: #c8f0a0; flex: 0 0 auto; }
+.nhModalFooter { display: flex; gap: 8px; margin: 0 14px 14px; flex: 0 0 auto; }
+.nhModalFooter .nhModalClose { margin: 0; width: auto; flex: 1 1 auto; }
+.nhModalBack { flex: 0 0 auto; height: 38px; padding: 0 14px; font-size: 13px; font-weight: bold; background: transparent; border: 1px solid #2d6b3e; color: #6db87a; border-radius: 4px; cursor: pointer; white-space: nowrap; }
 .nhModalProgress { font-size: 11px; color: #6db87a; font-weight: normal; text-transform: uppercase; letter-spacing: .04em; margin-left: 8px; }
 .nhInfoBtn { font-size: 13px; padding: 2px 7px; background: #1b4a2b; border: 1px solid #4a9a62; color: #9bea72; border-radius: 4px; cursor: pointer; line-height: 1.4; vertical-align: middle; margin-left: 6px; }
 .nhInfoBtn:hover { background: #2d6b3e; }
@@ -862,7 +865,10 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
         <span class="nhModalTitle" id="nhModalTitle">Natural History Unlocked</span>
       </div>
       <div id="nhModalBody" class="nhModalBody"></div>
-      <button id="nhModalClose" class="nhModalClose" type="button">Close</button>
+      <div class="nhModalFooter">
+        <button id="nhModalBack" class="nhModalBack" type="button">← Journal</button>
+        <button id="nhModalClose" class="nhModalClose" type="button">Close</button>
+      </div>
     </div>
   </div>
 
@@ -17353,6 +17359,11 @@ const nhModalClose = document.getElementById("nhModalClose");
 const nhModal = document.getElementById("nhModal");
 if (nhModalClose) nhModalClose.addEventListener("click", () => {
   if (nhModal) { nhModal.classList.remove("open"); nhModal.setAttribute("aria-hidden", "true"); nhModal._fromJournal = false; }
+});
+const nhModalBack = document.getElementById("nhModalBack");
+if (nhModalBack) nhModalBack.addEventListener("click", () => {
+  if (nhModal) { nhModal.classList.remove("open"); nhModal.setAttribute("aria-hidden", "true"); nhModal._fromJournal = false; }
+  showFieldJournal();
 });
 if (nhModal) nhModal.addEventListener("click", event => {
   if (event.target === nhModal) {


### PR DESCRIPTION
## Summary

Follow-up to PR #71. These changes were pushed after that PR was squash-merged and so weren't included.

- **Fauna / Flora / Misc tabs restored** on the journal index. Tab filtering uses `FJ_TAB_GROUPS` keyed by `getEncounterGroup(typeKey)` — not the stored `category` field — so items like `predatorLeftovers` (kind: carcass) always land in Misc regardless of any stored category inconsistency.
- **Stacked modal behaviour**: nhModal z-index raised to 10070 (above fjModal's 10060) so the entry window sits on top of the journal. Journal stays open when a row is clicked. nhModal Close button dismisses the entry window only and returns to the journal. Clicking outside the entry window (nhModal backdrop) dismisses both. `nhModal._fromJournal` flag tracks whether to also close the journal on backdrop click.
- **predatorLeftovers** now correctly appears in Misc → Carcasses tab.
- Tab click events handled inline in the fjModal click listener.

## Test plan

- [ ] Fauna/Flora/Misc tabs visible in Field Journal header
- [ ] Each tab filters correctly (predator leftovers in Misc)
- [ ] Clicking a journal row opens entry window on top of journal (journal visible behind)
- [ ] Entry window Close button dismisses entry only — journal still open
- [ ] Clicking outside entry window (dark backdrop) dismisses both
- [ ] Clicking outside journal (dark backdrop) dismisses journal only


---
_Generated by [Claude Code](https://claude.ai/code/session_01SbndgXZEyjsETvjc19ny1s)_