### PR TITLE
Add Fossil Record and Eocene MYA label

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+[2026-05-12 fossil-record-mya-label | Claude]
+Fossil Record and epoch label.
+
+- Fossil Record: on death, the current run is saved to localStorage (key: evolutionGameFossilRecord_v1, capped at 10 entries). Each entry stores turns survived, cause of death, companion count, and date. The death modal now shows a scrollable Fossil Record panel beneath the action buttons listing all past specimens with their turn count, cause, and metadata.
+- Epoch label: a small "Eocene · ~50 MYA" label is displayed beneath the Local forest map heading on the map card. Uses id="epochLabel" for future period updates.
+
 [2026-05-10 field-journal-ui-v2 | Claude]
 Field Journal UI redesign: individual encounter windows, tabbed grouped index, stacked modal behaviour, player titlebar placement.
 

--- a/game/play.html
+++ b/game/play.html
@@ -370,6 +370,15 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
 .deathModalActions button { height: 42px; font-size: 14px; font-weight: bold; }
 #deathModalRestart { background: #7b2424; border-color: #ff8f8f; color: #fff3ee; }
 #deathModalStay { background: #251313; border-color: #8b4a4a; color: #f3c8c0; }
+.epochLabel { font-size: 11px; color: var(--muted); margin-top: 2px; letter-spacing: 0.03em; }
+.fossilRecordPanel { border-top: 1px solid #5a1c1c; margin: 8px 14px 14px; padding-top: 10px; max-height: 200px; overflow-y: auto; }
+.fossilRecordTitle { font-size: 11px; font-weight: bold; text-transform: uppercase; letter-spacing: 0.06em; color: #c08080; margin-bottom: 6px; }
+.fossilEntry { padding: 6px 8px; border-radius: 5px; background: #210d0d; border: 1px solid #4a1c1c; margin-bottom: 5px; font-size: 12px; line-height: 1.45; }
+.fossilEntry:last-child { margin-bottom: 0; }
+.fossilEntryTurns { display: block; color: #f0c0b0; font-weight: bold; }
+.fossilEntryCause { display: block; color: #e89898; }
+.fossilEntryMeta { display: block; color: #a07070; font-size: 11px; margin-top: 1px; }
+.fossilRecordEmpty { color: #7a5050; font-size: 12px; font-style: italic; }
 .nhModal { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; z-index: 10070; padding: 18px; background: rgba(0, 20, 10, 0.82); }
 .nhModal.open { display: flex; }
 .nhModalCard { width: min(94vw, 560px); background: #071209; border: 2px solid #4a9a62; box-shadow: 0 0 0 1px #1a3c22 inset, 0 18px 70px rgba(0,0,0,.75); border-radius: 10px; color: #e8f0d8; overflow: hidden; max-height: 88vh; display: flex; flex-direction: column; }
@@ -669,6 +678,7 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
             <div class="mapToggleWrap">
               <div class="stat mapCard activeMapCard" id="localMapCard">
                 <strong>Local forest map</strong>
+                <div class="epochLabel" id="epochLabel">Eocene · ~50 MYA</div>
                 <div id="map" class="map"></div>
               </div>
 
@@ -814,6 +824,7 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
         <button id="deathModalQABack" type="button" style="display:none">QA Back 1 turn</button>
       </div>
       <div id="deathModalQANote" style="display:none;font-size:0.78em;color:#aaa;margin-top:6px;text-align:center;">God Mode only: restores the state before the fatal action.</div>
+      <div id="fossilRecordPanel" class="fossilRecordPanel"></div>
     </div>
   </div>
 
@@ -4221,6 +4232,8 @@ let qaBackSnapshot = null;
 
 const PROFILE_STORE_KEY = "evolutionGameProfiles_v1";
 const ACTIVE_PROFILE_KEY_STORE = "evolutionGameActiveProfileId_v1";
+const FOSSIL_RECORD_KEY = "evolutionGameFossilRecord_v1";
+const FOSSIL_RECORD_CAP = 10;
 const PROFILE_LOG_CAP = 150;
 const PROFILE_TRACE_CAP = 200;
 
@@ -13616,6 +13629,37 @@ function maybePromptRestartAfterDeath(message) {
 }
 
 // @fn showDeathModal
+function saveFossilRecord(deathMessage) {
+  let records = [];
+  try { records = JSON.parse(localStorage.getItem(FOSSIL_RECORD_KEY) || "[]"); } catch (_) {}
+  if (!Array.isArray(records)) records = [];
+  const companions = (socialGroup && Array.isArray(socialGroup.members)) ? socialGroup.members.length : 0;
+  records.unshift({
+    turns: player.turn || 0,
+    cause: (deathMessage || "Unknown").replace(/^Turn \d+:\s*/i, ""),
+    companions,
+    date: new Date().toLocaleDateString()
+  });
+  if (records.length > FOSSIL_RECORD_CAP) records.length = FOSSIL_RECORD_CAP;
+  try { localStorage.setItem(FOSSIL_RECORD_KEY, JSON.stringify(records)); } catch (_) {}
+  return records;
+}
+
+function renderFossilRecord(records) {
+  if (!records || records.length === 0) {
+    return '<div class="fossilRecordTitle">Fossil Record</div><div class="fossilRecordEmpty">No specimens yet.</div>';
+  }
+  const entries = records.map((r, i) => {
+    const meta = [r.date, r.companions > 0 ? `${r.companions} companion${r.companions !== 1 ? "s" : ""}` : ""].filter(Boolean).join(" · ");
+    return `<div class="fossilEntry">
+      <span class="fossilEntryTurns">Specimen #${records.length - i} &mdash; ${r.turns} turn${r.turns !== 1 ? "s" : ""}</span>
+      <span class="fossilEntryCause">${r.cause}</span>
+      <span class="fossilEntryMeta">${meta}</span>
+    </div>`;
+  }).join("");
+  return `<div class="fossilRecordTitle">Fossil Record &mdash; ${records.length} specimen${records.length !== 1 ? "s" : ""} catalogued</div>${entries}`;
+}
+
 function showDeathModal(message) {
   const modal = document.getElementById("deathModal");
   const messageBox = document.getElementById("deathModalMessage");
@@ -13624,6 +13668,9 @@ function showDeathModal(message) {
     return;
   }
   messageBox.textContent = message || "The run is over.";
+  const fossilRecords = saveFossilRecord(message);
+  const fossilPanel = document.getElementById("fossilRecordPanel");
+  if (fossilPanel) fossilPanel.innerHTML = renderFossilRecord(fossilRecords);
   const qaBackBtn = document.getElementById("deathModalQABack");
   const qaNote = document.getElementById("deathModalQANote");
   const showQA = godModeEnabled && !!qaBackSnapshot;


### PR DESCRIPTION
## Summary

- **Fossil Record**: On death, the run is saved to `localStorage` (capped at 10 entries). Each entry stores turns survived, cause of death, companion count, and date. The death modal shows a scrollable Fossil Record panel beneath the action buttons — up to 10 past specimens listed as `Specimen #N — X turns / cause / date`.
- **Epoch label**: A small `Eocene · ~50 MYA` label sits beneath the Local forest map heading. Uses `id="epochLabel"` so it can be updated programmatically when additional geological periods are added.

## Files changed

- `game/play.html` — CSS (12 lines), map card HTML (1 line), death modal HTML (1 line), localStorage constant (2 lines), two new JS functions `saveFossilRecord` / `renderFossilRecord` (~30 lines), hook in `showDeathModal` (2 lines)
- `CHANGELOG.txt`

## Test plan

- [ ] Play a run and die — death modal should show Fossil Record panel with Specimen #1
- [ ] Die again — Specimen #2 appears at the top, Specimen #1 below
- [ ] Confirm epoch label `Eocene · ~50 MYA` is visible beneath the Local forest map heading
- [ ] Confirm no layout regressions on the map card or death modal
- [ ] Confirm fossil record persists across page refresh (localStorage)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhTucAtYHsYAdX8bKGAjaw)_