### PR TITLE
Move Fossil Record into Field Journal as Fossils tab [superseded by #75]

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+[2026-05-12 fossil-record-mya-label | Claude]
+Fossil Record and epoch label.
+
+- Fossil Record: on death, the current run is saved to localStorage (key: evolutionGameFossilRecord_v1, capped at 10 entries). Each entry stores turns survived, cause of death, companion count, and date. The death modal now shows a scrollable Fossil Record panel beneath the action buttons listing all past specimens with their turn count, cause, and metadata.
+- Epoch label: a small "Eocene · ~50 MYA" label is displayed beneath the Local forest map heading on the map card. Uses id="epochLabel" for future period updates.
+
 [2026-05-10 field-journal-ui-v2 | Claude]
 Field Journal UI redesign: individual encounter windows, tabbed grouped index, stacked modal behaviour, player titlebar placement.
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,7 @@ Fossil Record and epoch label.
 
 - Fossil Record: on death, the current run is saved to localStorage (key: evolutionGameFossilRecord_v1, capped at 10 entries). Each entry stores turns survived, cause of death, companion count, and date. The death modal now shows a scrollable Fossil Record panel beneath the action buttons listing all past specimens with their turn count, cause, and metadata.
 - Epoch label: a small "Eocene · ~50 MYA" label is displayed beneath the Local forest map heading on the map card. Uses id="epochLabel" for future period updates.
+- Security: r.cause and r.date are now passed through escapeHtml before innerHTML injection in renderFossilRecord, closing a potential XSS vector via tampered localStorage.
 
 [2026-05-10 field-journal-ui-v2 | Claude]
 Field Journal UI redesign: individual encounter windows, tabbed grouped index, stacked modal behaviour, player titlebar placement.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,10 @@
+[2026-05-12 fossil-record-journal-tab | Claude]
+Fossil Record moved into Field Journal as Fossils tab.
+
+- Added "Fossils" tab to the Field Journal (fjModal). Clicking it renders the full run history from localStorage via renderFossilRecord(), accessible at any time during a run — not only on death.
+- Death modal simplified: the scrolling fossil panel is replaced with a one-line summary ("N specimens in Fossil Record") and a "View in Journal" button that closes the death modal and opens the journal to the Fossils tab.
+- CSS: replaced .fossilRecordPanel (scroll container) with .fossilRecordSummary / .fossilRecordSummaryText / .fossilRecordSummaryBtn for the death modal summary line.
+
 [2026-05-12 fossil-record-mya-label | Claude]
 Fossil Record and epoch label.
 

--- a/game/play.html
+++ b/game/play.html
@@ -370,6 +370,15 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
 .deathModalActions button { height: 42px; font-size: 14px; font-weight: bold; }
 #deathModalRestart { background: #7b2424; border-color: #ff8f8f; color: #fff3ee; }
 #deathModalStay { background: #251313; border-color: #8b4a4a; color: #f3c8c0; }
+.epochLabel { font-size: 11px; color: var(--muted); margin-top: 2px; letter-spacing: 0.03em; }
+.fossilRecordPanel { border-top: 1px solid #5a1c1c; margin: 8px 14px 14px; padding-top: 10px; max-height: 200px; overflow-y: auto; }
+.fossilRecordTitle { font-size: 11px; font-weight: bold; text-transform: uppercase; letter-spacing: 0.06em; color: #c08080; margin-bottom: 6px; }
+.fossilEntry { padding: 6px 8px; border-radius: 5px; background: #210d0d; border: 1px solid #4a1c1c; margin-bottom: 5px; font-size: 12px; line-height: 1.45; }
+.fossilEntry:last-child { margin-bottom: 0; }
+.fossilEntryTurns { display: block; color: #f0c0b0; font-weight: bold; }
+.fossilEntryCause { display: block; color: #e89898; }
+.fossilEntryMeta { display: block; color: #a07070; font-size: 11px; margin-top: 1px; }
+.fossilRecordEmpty { color: #7a5050; font-size: 12px; font-style: italic; }
 .nhModal { position: fixed; inset: 0; display: none; align-items: center; justify-content: center; z-index: 10070; padding: 18px; background: rgba(0, 20, 10, 0.82); }
 .nhModal.open { display: flex; }
 .nhModalCard { width: min(94vw, 560px); background: #071209; border: 2px solid #4a9a62; box-shadow: 0 0 0 1px #1a3c22 inset, 0 18px 70px rgba(0,0,0,.75); border-radius: 10px; color: #e8f0d8; overflow: hidden; max-height: 88vh; display: flex; flex-direction: column; }
@@ -669,6 +678,7 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
             <div class="mapToggleWrap">
               <div class="stat mapCard activeMapCard" id="localMapCard">
                 <strong>Local forest map</strong>
+                <div class="epochLabel" id="epochLabel">Eocene · ~50 MYA</div>
                 <div id="map" class="map"></div>
               </div>
 
@@ -814,6 +824,7 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
         <button id="deathModalQABack" type="button" style="display:none">QA Back 1 turn</button>
       </div>
       <div id="deathModalQANote" style="display:none;font-size:0.78em;color:#aaa;margin-top:6px;text-align:center;">God Mode only: restores the state before the fatal action.</div>
+      <div id="fossilRecordPanel" class="fossilRecordPanel"></div>
     </div>
   </div>
 
@@ -4221,6 +4232,8 @@ let qaBackSnapshot = null;
 
 const PROFILE_STORE_KEY = "evolutionGameProfiles_v1";
 const ACTIVE_PROFILE_KEY_STORE = "evolutionGameActiveProfileId_v1";
+const FOSSIL_RECORD_KEY = "evolutionGameFossilRecord_v1";
+const FOSSIL_RECORD_CAP = 10;
 const PROFILE_LOG_CAP = 150;
 const PROFILE_TRACE_CAP = 200;
 
@@ -13616,6 +13629,37 @@ function maybePromptRestartAfterDeath(message) {
 }
 
 // @fn showDeathModal
+function saveFossilRecord(deathMessage) {
+  let records = [];
+  try { records = JSON.parse(localStorage.getItem(FOSSIL_RECORD_KEY) || "[]"); } catch (_) {}
+  if (!Array.isArray(records)) records = [];
+  const companions = (socialGroup && Array.isArray(socialGroup.members)) ? socialGroup.members.length : 0;
+  records.unshift({
+    turns: player.turn || 0,
+    cause: (deathMessage || "Unknown").replace(/^Turn \d+:\s*/i, ""),
+    companions,
+    date: new Date().toLocaleDateString()
+  });
+  if (records.length > FOSSIL_RECORD_CAP) records.length = FOSSIL_RECORD_CAP;
+  try { localStorage.setItem(FOSSIL_RECORD_KEY, JSON.stringify(records)); } catch (_) {}
+  return records;
+}
+
+function renderFossilRecord(records) {
+  if (!records || records.length === 0) {
+    return '<div class="fossilRecordTitle">Fossil Record</div><div class="fossilRecordEmpty">No specimens yet.</div>';
+  }
+  const entries = records.map((r, i) => {
+    const meta = [r.date, r.companions > 0 ? `${r.companions} companion${r.companions !== 1 ? "s" : ""}` : ""].filter(Boolean).join(" · ");
+    return `<div class="fossilEntry">
+      <span class="fossilEntryTurns">Specimen #${records.length - i} &mdash; ${r.turns} turn${r.turns !== 1 ? "s" : ""}</span>
+      <span class="fossilEntryCause">${r.cause}</span>
+      <span class="fossilEntryMeta">${meta}</span>
+    </div>`;
+  }).join("");
+  return `<div class="fossilRecordTitle">Fossil Record &mdash; ${records.length} specimen${records.length !== 1 ? "s" : ""} catalogued</div>${entries}`;
+}
+
 function showDeathModal(message) {
   const modal = document.getElementById("deathModal");
   const messageBox = document.getElementById("deathModalMessage");
@@ -13624,6 +13668,9 @@ function showDeathModal(message) {
     return;
   }
   messageBox.textContent = message || "The run is over.";
+  const fossilRecords = saveFossilRecord(message);
+  const fossilPanel = document.getElementById("fossilRecordPanel");
+  if (fossilPanel) fossilPanel.innerHTML = renderFossilRecord(fossilRecords);
   const qaBackBtn = document.getElementById("deathModalQABack");
   const qaNote = document.getElementById("deathModalQANote");
   const showQA = godModeEnabled && !!qaBackSnapshot;

--- a/game/play.html
+++ b/game/play.html
@@ -13650,10 +13650,10 @@ function renderFossilRecord(records) {
     return '<div class="fossilRecordTitle">Fossil Record</div><div class="fossilRecordEmpty">No specimens yet.</div>';
   }
   const entries = records.map((r, i) => {
-    const meta = [r.date, r.companions > 0 ? `${r.companions} companion${r.companions !== 1 ? "s" : ""}` : ""].filter(Boolean).join(" · ");
+    const meta = [escapeHtml(r.date), r.companions > 0 ? `${r.companions} companion${r.companions !== 1 ? "s" : ""}` : ""].filter(Boolean).join(" · ");
     return `<div class="fossilEntry">
       <span class="fossilEntryTurns">Specimen #${records.length - i} &mdash; ${r.turns} turn${r.turns !== 1 ? "s" : ""}</span>
-      <span class="fossilEntryCause">${r.cause}</span>
+      <span class="fossilEntryCause">${escapeHtml(r.cause)}</span>
       <span class="fossilEntryMeta">${meta}</span>
     </div>`;
   }).join("");

--- a/game/play.html
+++ b/game/play.html
@@ -371,7 +371,9 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
 #deathModalRestart { background: #7b2424; border-color: #ff8f8f; color: #fff3ee; }
 #deathModalStay { background: #251313; border-color: #8b4a4a; color: #f3c8c0; }
 .epochLabel { font-size: 11px; color: var(--muted); margin-top: 2px; letter-spacing: 0.03em; }
-.fossilRecordPanel { border-top: 1px solid #5a1c1c; margin: 8px 14px 14px; padding-top: 10px; max-height: 200px; overflow-y: auto; }
+.fossilRecordSummary { display: flex; align-items: center; justify-content: space-between; gap: 8px; border-top: 1px solid #5a1c1c; padding: 10px 14px 14px; }
+.fossilRecordSummaryText { font-size: 12px; color: #c08080; }
+.fossilRecordSummaryBtn { font-size: 12px; font-weight: bold; padding: 4px 10px; background: #251313; border: 1px solid #8b4a4a; color: #f3c8c0; border-radius: 4px; cursor: pointer; white-space: nowrap; }
 .fossilRecordTitle { font-size: 11px; font-weight: bold; text-transform: uppercase; letter-spacing: 0.06em; color: #c08080; margin-bottom: 6px; }
 .fossilEntry { padding: 6px 8px; border-radius: 5px; background: #210d0d; border: 1px solid #4a1c1c; margin-bottom: 5px; font-size: 12px; line-height: 1.45; }
 .fossilEntry:last-child { margin-bottom: 0; }
@@ -824,7 +826,7 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
         <button id="deathModalQABack" type="button" style="display:none">QA Back 1 turn</button>
       </div>
       <div id="deathModalQANote" style="display:none;font-size:0.78em;color:#aaa;margin-top:6px;text-align:center;">God Mode only: restores the state before the fatal action.</div>
-      <div id="fossilRecordPanel" class="fossilRecordPanel"></div>
+      <div id="fossilRecordSummary" class="fossilRecordSummary"></div>
     </div>
   </div>
 
@@ -891,6 +893,7 @@ button { background: #153d1b; color: #e7f1d2; border: 1px solid #4a8741; border-
           <button type="button" class="fjTab active" data-fjtab="fauna">Fauna</button>
           <button type="button" class="fjTab" data-fjtab="flora">Flora</button>
           <button type="button" class="fjTab" data-fjtab="misc">Misc</button>
+          <button type="button" class="fjTab" data-fjtab="fossil">Fossils</button>
         </div>
       </div>
       <div id="fjBody" class="fjBody"></div>
@@ -12377,6 +12380,16 @@ function showFieldJournal(tab) {
   const activeTab = tab || (modal.querySelector(".fjTab.active") || {}).dataset && modal.querySelector(".fjTab.active").dataset.fjtab || "fauna";
   modal.querySelectorAll(".fjTab").forEach(t => t.classList.toggle("active", t.dataset.fjtab === activeTab));
 
+  if (activeTab === "fossil") {
+    let records = [];
+    try { records = JSON.parse(localStorage.getItem(FOSSIL_RECORD_KEY) || "[]"); } catch (_) {}
+    if (!Array.isArray(records)) records = [];
+    body.innerHTML = `<div style="padding:10px 14px;">${renderFossilRecord(records)}</div>`;
+    modal.classList.add("open");
+    modal.setAttribute("aria-hidden", "false");
+    return;
+  }
+
   const journal = player.knowledgeByEncounterKey || {};
   const entries = Object.values(journal);
   const tabGroups = FJ_TAB_GROUPS[activeTab] || [];
@@ -13669,8 +13682,15 @@ function showDeathModal(message) {
   }
   messageBox.textContent = message || "The run is over.";
   const fossilRecords = saveFossilRecord(message);
-  const fossilPanel = document.getElementById("fossilRecordPanel");
-  if (fossilPanel) fossilPanel.innerHTML = renderFossilRecord(fossilRecords);
+  const fossilSummary = document.getElementById("fossilRecordSummary");
+  if (fossilSummary) {
+    const count = fossilRecords.length;
+    fossilSummary.innerHTML = count > 0
+      ? `<span class="fossilRecordSummaryText">${count} specimen${count !== 1 ? "s" : ""} in Fossil Record</span><button class="fossilRecordSummaryBtn" type="button" id="fossilRecordViewBtn">View in Journal</button>`
+      : `<span class="fossilRecordSummaryText">Fossil Record is empty</span>`;
+    const viewBtn = fossilSummary.querySelector("#fossilRecordViewBtn");
+    if (viewBtn) viewBtn.addEventListener("click", () => { hideDeathModal(); showFieldJournal("fossil"); });
+  }
   const qaBackBtn = document.getElementById("deathModalQABack");
   const qaNote = document.getElementById("deathModalQANote");
   const showQA = godModeEnabled && !!qaBackSnapshot;


### PR DESCRIPTION
## Summary

- **Fossils tab**: Field Journal now has a fourth tab — "Fossils". Clicking it renders the full run history from `localStorage` via `renderFossilRecord()`, accessible at any time during a run, not only on death.
- **Death modal simplified**: the scrolling fossil panel is replaced with a single summary line ("N specimens in Fossil Record") and a "View in Journal" button. The button closes the death modal and opens the journal directly to the Fossils tab.
- **CSS**: `.fossilRecordPanel` (scroll container, death-modal-specific) replaced with `.fossilRecordSummary` / `.fossilRecordSummaryText` / `.fossilRecordSummaryBtn` for the summary line layout.

> **Note:** This PR is based on `feature/fossil-record-mya-label` (PR #73). It includes that branch's commits plus this change. Merge PR #73 first, or squash — whichever George prefers.

## Files changed

- `game/play.html` — fjModal HTML (+1 tab button), `showFieldJournal()` (+fossil branch), death modal HTML (panel → summary div), `showDeathModal()` (summary render + button listener), CSS (3 lines replaced)
- `CHANGELOG.txt`

## Test plan

- [ ] Open Field Journal during a live run — "Fossils" tab is visible
- [ ] Click Fossils tab with no prior deaths — shows "No specimens yet."
- [ ] Die once — death modal shows "1 specimen in Fossil Record" + "View in Journal" button
- [ ] Click "View in Journal" — death modal closes, journal opens to Fossils tab showing Specimen #1
- [ ] Die again — count increments; most recent run is at the top
- [ ] Fauna/Flora/Misc tabs unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhTucAtYHsYAdX8bKGAjaw)_