### PR TITLE
Phase 1 documentation repair: repair existing docs, add current-game-…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -51,6 +51,34 @@ If this check was not run, state clearly here:
 
 **GPT/Claude instruction:** Do not describe a PR as complete, safe, or ready to merge unless the changelog status is explicitly addressed.
 
+## Mandatory documentation gate
+
+Check `docs/documentation-map.md` to identify which documentation files apply to this PR.
+
+Tick every document checked:
+
+- [ ] `CHANGELOG.txt`
+- [ ] `README.md`
+- [ ] `docs/current-game-structure.md`
+- [ ] `docs/architecture-notes.md`
+- [ ] `docs/project-plan.md`
+- [ ] `docs/bug-guardrails.md`
+- [ ] `docs/release-checklist.md`
+- [ ] `.github/pull_request_template.md`
+- [ ] `CLAUDE.md`
+
+This PR body must include one of the following statements — no exceptions:
+
+> `Documentation updated: [list files updated]`
+
+or
+
+> `Documentation checked; no wider docs required because: [specific reason]`
+
+Silence on documentation impact is a process failure. A vague answer ("checked, none needed") does not count.
+
+**GPT/Claude instruction:** Do not describe a PR as complete, safe, or ready to merge unless one of these two statements is present in the PR body.
+
 ## Commit message check
 
 - [ ] No `claude.ai/code/session_...` URLs in any commit message on this PR (repo is public)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,17 @@
+[2026-06-03 phase1-documentation-repair | Claude]
+Documentation repair and enforcement — Phase 1 of controlled rebuild.
+
+- Created docs/current-game-structure.md: owner-facing description of every current game system (turn flow, encounter lifecycle, save/profile flow, ecology, bot/QA tooling, render lifecycle, Field Journal, Fossil Record, Achievements, group system) with six Mermaid diagrams and accurate line ranges for game/play.html (~18,400 lines).
+- Created docs/documentation-map.md: single-page guide to what each documentation file covers, when to update it, and a quick-reference update table.
+- Repaired docs/architecture-notes.md: updated line ranges from stale ~13,400 to current ~18,400; added profiles/saves, Field Journal, Fossil Record, Achievements, and natural-history system to key areas; added knowledge-store fragile area and profile save/resume to do-not-touch list.
+- Repaired docs/project-plan.md: updated current phase from early ecology expansion to Phase 1 of controlled rebuild; added three-phase rebuild plan; parked ecology expansion work clearly for later resumption.
+- Repaired docs/bug-guardrails.md: added BG-004 (documentation drift — docs not updated alongside code changes, causing architectural misalignment and reviewer confusion).
+- Repaired docs/release-checklist.md: replaced single documentation section with a full documentation gate checklist covering all affected doc files and the required gate statement.
+- Repaired .github/pull_request_template.md: added mandatory documentation gate section with per-file tick list and required gate statement; reviewers must confirm statement is present before approving merge.
+- Repaired README.md: updated repository layout table to include all current docs, scripts, and CLAUDE.md; added controlled rebuild plan section.
+- No code changes. No changes to game/play.html.
+- Documentation changed; no gameplay, UI, bot, or app-loading changes.
+
 [2026-05-12 eocene-plant-encounters | Claude]
 Eight new Eocene-grounded plant encounters covering toxic and edible flora.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ These systems are still evolving. Many are deliberately lightweight at this stag
 evolution-game/
 ├── README.md                         Project overview and workflow
 ├── CHANGELOG.txt                     Reverse-chronological change record
+├── CLAUDE.md                         Operating rules for AI assistants
 ├── AI_REVIEW_DIALOGUE.txt            GPT/Claude review coordination notes
 ├── manifest.json                     PWA/home-screen metadata
 ├── index.html                        GitHub Pages entry point; redirects to game/play.html
@@ -89,17 +90,41 @@ evolution-game/
 │   ├── play.html                     Stable playable build used by public link/PWA
 │   └── evolution_game_v66_57.html    Versioned playable build
 ├── docs/
-│   ├── patch8-short-eco-cycles.txt   Detailed notes for Patch 8 ecology cycle work
+│   ├── current-game-structure.md     How the game works now: systems, flows, line ranges
+│   ├── documentation-map.md          What each doc covers and when to update it
+│   ├── architecture-notes.md         Internal file layout and do-not-touch warnings
 │   ├── bug-guardrails.md             Known repeated failure modes and prevention checks
-│   └── project-plan.md               Non-code design plan, priorities, and idea log
+│   ├── project-plan.md               Non-code design plan, priorities, and idea log
+│   ├── release-checklist.md          Step-by-step checklist for each release
+│   ├── design-decisions.md           Record of significant design choices
+│   ├── testing-protocol.md           QA and bot testing guidance
+│   └── patch8-short-eco-cycles.txt   Detailed notes for Patch 8 ecology cycle work
 ├── logs/
 │   ├── bot-runs/                     Raw bot run outputs when intentionally saved
 │   └── consolidated/                 AI-reviewed summaries and bug reports
 ├── scripts/
+│   ├── check_html_js_syntax.mjs      JavaScript syntax checker for game HTML files
 │   └── ingest_bot_report.sh          Helper for manually ingesting downloaded bot logs
 └── .github/
     └── pull_request_template.md      Required PR checklist
 ```
+
+---
+
+## Controlled rebuild plan
+
+The game has grown to ~18,400 lines in a single HTML file. It still works, but the structure is now too fragile to maintain safely. The plan is to restructure it in three phases while keeping the playable build stable throughout.
+
+**Phase 1 — Documentation repair and enforcement** *(current)*  
+Repair all documentation to accurately describe the current game. Create `docs/current-game-structure.md` and `docs/documentation-map.md`. Make documentation checks mandatory in every PR.
+
+**Phase 2 — Architecture plan** *(next)*  
+Agree a proposed modular structure before any code is moved. No extraction begins until George approves the plan.
+
+**Phase 3 — Safe extraction** *(after Phase 2 is approved)*  
+Extract code in small PRs in a defined order, keeping the playable build working at every step.
+
+The rebuild is not a rewrite, not a framework migration, and not a gameplay redesign. See `docs/project-plan.md` for full detail.
 
 ---
 

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -6,7 +6,7 @@ This document is a map of how the game HTML file is organised. Read this before 
 
 ## The single-file structure
 
-The entire game lives in one large HTML file (`game/play.html`, ~13,400 lines). There is no build step, no bundler, and no separate JavaScript files. Everything — CSS, HTML structure, and all JavaScript — is in one file.
+The entire game lives in one large HTML file (`game/play.html`, ~18,400 lines). There is no build step, no bundler, and no separate JavaScript files. Everything — CSS, HTML structure, and all JavaScript — is in one file.
 
 `game/evolution_game_v66_57.html` is the versioned archive of the same build. `game/play.html` is the stable public-facing copy that gets replaced on each release.
 
@@ -18,38 +18,51 @@ The entire game lives in one large HTML file (`game/play.html`, ~13,400 lines). 
 
 | Lines | Area |
 |-------|------|
-| 1–700 | HTML head, CSS styles, HTML body structure (UI panels, buttons, modals) |
-| 700–780 | Game constants (`GAME_VERSION`, world size, layer names, etc.) |
-| 780–2050 | Static data: encounter definitions, spawn tables |
-| 2050–2860 | World generation: habitat, altitude, terrain, water, clay deposits |
-| 2860–3340 | Game state helpers: water tiles, habitat change, debug logging infrastructure |
-| 3340–5000 | Player actions: movement, drinking, grooming, climbing, waiting |
-| 5000–8000 | Encounter system: active encounters, pursuit, resolution, combat |
-| 8000–10000 | Group/social system, ecology, world tick, spawning |
-| 10000–10900 | Bot infrastructure: `botState` object, QA issue tracking, run summaries |
-| 10900–11250 | Bot execution: `runRandomBot`, `stepRandomBot`, `stopRandomBot` |
-| 11250–12120 | Bot reporting and GitHub auto-save |
-| 12120–13200 | Rendering: map, UI panels, status bars, button state |
-| 13200–13400 | Event listener setup and game initialisation |
+| 1–990 | HTML head, CSS styles, HTML body structure (UI panels, buttons, modals) |
+| 990–1020 | Game version constant (`GAME_VERSION`) |
+| 1021–3413 | Static data: encounter definitions (~100+ encounters with spawn, poison, natural-history blocks) |
+| 3414–3630 | Spawn tables: layer-based encounter probability lists |
+| 3631–4252 | World generation: terrain, habitats, altitude, water, clay deposits |
+| 4253–4791 | Player state object and dynamic world state (waterState, socialGroup, nearbyEntities) |
+| 4792–5829 | Achievements (50 defs), profiles, save/load, Field Journal, Fossil Record |
+| 5830–6281 | Core utilities: logging, clamping, cloning, debug tracing, invariant checks |
+| 6282–7612 | Turn flow: `startTurn`, `endTurn`, metabolism, time of day, ecology tick |
+| 7613–8429 | Nearby entity simulation: spawning, persistence, world registry |
+| 8430–11327 | Social system, same-species encounters, group management, calls |
+| 11328–11826 | Threat and predator logic: pursuit, escalation, flee/fight resolution |
+| 11827–12523 | Player action handlers: move, eat, drink, climb, wait, groom, look, etc. |
+| 12524–14471 | Investigation system, carcass interactions, encounter resolution helpers, Field Journal render |
+| 14472–15839 | Bot/QA: `botState`, strategy, step execution, goal planner, loop detection |
+| 15840–16687 | Debug helpers: compact/full report generation, GitHub API push, debug downloads |
+| 16688–17140 | Rendering helpers: encounter card HTML builder, button state logic |
+| 17141–18434 | Main `render()` function, event listeners, game initialisation call, tag extension pass |
 
 ---
 
 ## Key areas explained
 
 ### Game state
-The player state is a single object (`player`) with fields for position, fitness, energy, hydration, death status, and current layer. World state is stored in flat arrays indexed by tile coordinates.
+The player state is a single object (`player`) with fields for position, fitness, energy, hydration, growth, poison, alcohol, parasites, knowledge, and run tracking. World state is stored in flat arrays indexed by tile coordinates. The two must be treated separately: world state is not saved between runs; player knowledge and profile data are.
 
 ### World/map generation
-The world is generated once at startup. It is a fixed grid (`WORLD_SIZE` × `WORLD_SIZE`). Habitats, altitude, terrain, and water are all generated procedurally. There is no save/load of world state.
+The world is generated once at startup. It is a fixed grid (`WORLD_SIZE` × `WORLD_SIZE`). Habitats, altitude, terrain, and water are all generated procedurally. There is no save/load of world state between runs.
 
 ### Encounters
-Encounters are defined in a static data table. An active encounter is tracked in a separate object. Encounters can be: passive (observation), social, predator, prey, or environmental. Each has its own resolution logic.
+Encounters are defined in a static data table (~100+ entries). An active encounter is tracked in `currentEncounter`. Encounters have a `dangerProfile`, `temperament`, `persistence` type, and optional `naturalHistory` blocks. The investigation system builds per-encounter knowledge that feeds the Field Journal.
 
 ### Player actions
-Every player action (move, wait, drink, groom, etc.) follows the same pattern: validate → execute → advance turn → log → render. The bot calls the same action functions that the player UI does.
+Every player action (move, wait, drink, groom, etc.) follows the same pattern: `startTurn()` → action logic → `endTurn()` → `render()`. The bot calls the same action functions that the player UI does.
+
+### Profiles and saves
+Multiple profiles are supported. All persistence uses `localStorage` under versioned keys. Each profile stores cross-run stats, Field Journal knowledge, achievements, the Fossil Record, and an active run snapshot (restorable if the tab is closed mid-run).
+
+### Field Journal, Fossil Record, and Achievements
+- **Field Journal**: accumulates knowledge about encounter types across runs. Knowledge tiers (0–30) unlock natural-history text and gameplay tips.
+- **Fossil Record**: stores the last 10 run outcomes per profile (turns survived, cause of death, companions, date).
+- **Achievements**: 50 definitions checked each turn, on death, and at run end. Stored per profile; displayed in the Field Journal's Awards tab.
 
 ### Bot / debug tools
-The bot (`botState`) runs the game automatically by picking random valid actions on a timer. It records every step, validates game invariants after each action, and accumulates QA issues. When it stops, it can push reports directly to GitHub via the API.
+The bot (`botState`) runs the game automatically using a weighted strategy with a goal planner and loop detection. It records every step, validates invariants after each action, and accumulates QA issues. When it stops, compact and full reports are generated and can be pushed to GitHub via the API.
 
 ### Logging / reporting
 Two logging layers:
@@ -57,11 +70,11 @@ Two logging layers:
 - `debugTrace` — raw diagnostic events, max 8,000 entries
 
 Bot reports have two formats:
-- **Compact** — QA issues, run summaries, patch gate summary. Use for routine review.
-- **Full** — everything above plus per-step snapshots and raw JSON. Only needed for deep debugging.
+- **Compact** — QA issues, death-cause rollup, run summary table, patch gate summary. Use for routine review.
+- **Full** — everything above plus per-step snapshots and raw JSON. Use only for deep debugging.
 
 ### Rendering
-All rendering is done by a single `render()` call that redraws the map, UI panels, and button states. There is no virtual DOM or reactive framework — it is direct DOM manipulation.
+All rendering is done by a single `render()` call that redraws the map, UI panels, vitals bars, encounter card, and button states. There is no virtual DOM or reactive framework — it is direct DOM manipulation. `render()` is always the last call in `endTurn()`.
 
 ---
 
@@ -71,12 +84,14 @@ All rendering is done by a single `render()` call that redraws the map, UI panel
 - **The bot auto-save uses the GitHub API directly from the browser.** It requires a fine-grained PAT with `Contents: read and write`. The PAT is stored in `sessionStorage` and clears when the tab closes.
 - **`game/play.html` and `game/evolution_game_v66_57.html` must be kept in sync** on each release. If you edit one, copy the change to the other, or replace `play.html` entirely.
 - **`index.html` and `manifest.json` must both reference `game/play.html`.** The syntax check script verifies `index.html`. Check `manifest.json` manually on releases.
+- **`player.knowledge` / `player.classKnowledge`** accumulate across runs and feed the Field Journal. Incorrect resets at run boundaries lose journal data permanently.
 
 ---
 
 ## Do not touch without checking
 
-- The encounter resolution logic (lines ~5000–8000) — tightly coupled, easy to break survival balance
+- The encounter resolution logic (~11328–12523) — tightly coupled, easy to break survival balance
 - The world generation functions — changing these affects the entire map layout and habitat distribution
 - The `render()` function and anything that calls it — re-entrancy issues can cause visible glitches
 - The bot timer and step logic — race conditions are possible if the timer interval and step validation get out of sync
+- The profile save/resume logic — incorrect resets silently lose player data across runs

--- a/docs/bug-guardrails.md
+++ b/docs/bug-guardrails.md
@@ -117,6 +117,41 @@ If a compact report still shows mostly `unknown` while run-level context is pres
 
 ---
 
+## BG-004 — Documentation drift: docs not updated alongside code changes
+
+**Status:** Active guardrail
+
+**Observed failure:**
+Multiple PRs were merged without updating documentation that described the affected systems. Over time, `docs/architecture-notes.md` described line ranges from an earlier build (~13,400 lines) while the actual file had grown to ~18,400 lines. Systems added since the docs were last written (profiles, saves, Field Journal, Fossil Record, Achievements) were absent from architecture documentation entirely.
+
+**Player/tester symptom:**
+Not directly visible in gameplay, but the codebase became harder to oversee. Reviewers and AI assistants had to guess at structure rather than reading reliable documentation.
+
+**Root cause:**
+Documentation updates were not treated as a mandatory part of the PR process. No PR template section required authors to explicitly check whether docs were affected.
+
+**Known affected area:**
+- All documentation files whenever code, structure, systems, or workflow change.
+- Specifically: `README.md`, `docs/current-game-structure.md`, `docs/architecture-notes.md`, `docs/project-plan.md`, `docs/bug-guardrails.md`, `docs/release-checklist.md`, `.github/pull_request_template.md`, `CLAUDE.md`.
+
+**Future guardrail:**
+Every PR must explicitly confirm documentation status using one of these two forms in the PR body:
+
+- `Documentation updated: [list of files]`
+- `Documentation checked; no wider docs required because: [specific reason]`
+
+Silence on documentation impact is a process failure.
+
+**Required PR check:**
+- Check `docs/documentation-map.md` to identify which documents apply to the change.
+- Update any affected document in the same PR.
+- Include the documentation gate statement in the PR body.
+
+**Reviewer instruction:**
+Do not describe a PR as complete, safe, or ready to merge unless the documentation gate statement is present in the PR body.
+
+---
+
 ## Entry template for future bugs
 
 ```md

--- a/docs/current-game-structure.md
+++ b/docs/current-game-structure.md
@@ -1,0 +1,302 @@
+# Current Game Structure
+
+This document describes what the game is, how it works, and what lives where in the codebase. It is the primary reference for understanding the current build before any architectural changes are made.
+
+Last updated: 2026-06-03 (Phase 1 documentation repair).
+
+---
+
+## What the game is
+
+Evolution Game is a browser-based single-player survival simulation. The player controls a small early primate navigating a procedurally generated prehistoric forest. The goal is to survive, explore, eat, drink, avoid predators, and learn about the world.
+
+The entire game is a single HTML file (`game/play.html`, ~18,400 lines). There is no build step, no bundler, and no server. Open the file in a browser and it works.
+
+---
+
+## How the game starts
+
+When the page loads, the browser parses the HTML, loads all CSS and JavaScript in one block, then calls `initGame()`. If an active profile has a saved run, the player is offered a resume. Otherwise a new run begins under the active profile.
+
+```mermaid
+flowchart TD
+    A[Page loads] --> B[CSS + JS parsed as one block]
+    B --> C[initGame called]
+    C --> D[Generate terrain and habitats]
+    D --> E{Active profile with saved run?}
+    E -->|Yes| F[Offer resume]
+    F --> G{Player accepts?}
+    G -->|Yes| H[profileResumeActiveRun: restore player state, group, knowledge, run tracking]
+    G -->|No| I[profileStartNewRun]
+    E -->|No| I
+    H --> J[render]
+    I --> J
+    J --> K[Game ready]
+```
+
+---
+
+## Turn flow
+
+Every player action follows the same three-step pattern: **startTurn → action logic → endTurn → render**.
+
+`startTurn()` applies metabolic costs, advances time of day, ticks poison and alcohol, and checks for death. If the player is already dead it returns false and the action is cancelled.
+
+`endTurn()` processes the consequences: tile checks, passive threat reactions, pursuit updates, group and parasite updates, noise events, and fresh encounter rolls. It always ends with `render()`.
+
+```mermaid
+flowchart TD
+    A[Player presses button or key] --> B[startTurn]
+    B --> C{Player dead?}
+    C -->|Yes| Z[Action blocked]
+    C -->|No| D[Increment turn counter]
+    D --> E[Apply energy and hydration costs for this action type]
+    E --> F[Tick poison and alcohol]
+    F --> G[Advance time of day]
+    G --> H[Action-specific logic]
+    H --> I[endTurn]
+    I --> J[Check tile for queued entities]
+    J --> K[Passive threat check on current animal]
+    K --> L[Update active pursuit]
+    L --> M[Update social group]
+    M --> N[Apply parasite pressure]
+    N --> O[Roll for new encounter]
+    O --> P[render]
+    P --> Q[Screen updated]
+```
+
+---
+
+## Survival needs
+
+The player has four survival stats tracked each turn:
+
+| Stat | What it measures | Consequence if neglected |
+|------|-----------------|--------------------------|
+| Fitness | Physical health and injury | Reaches zero → death |
+| Energy | Fuel for action | Zero energy drains fitness over time |
+| Hydration | Water level | Low hydration adds energy penalty; zero drains fitness each turn |
+| Growth progress | Accumulated growth conditions met | Fills when energy ≥ 75 and hydration ≥ 45; size increases when full |
+
+Each action has a metabolic profile (energy and hydration cost). High-exertion actions (climbing, fleeing) burn more; passive actions (waiting, grooming) burn less.
+
+---
+
+## Encounter lifecycle
+
+Encounters are the main interactive events. They can be animals, plants, carcasses, nests, or environmental hazards. Most encounters arrive at the end of a turn via `endTurn()` and remain until the player resolves them.
+
+```mermaid
+flowchart TD
+    A[endTurn trigger] --> B{Active encounter or carcass?}
+    B -->|No| C[Roll for new encounter: immediate, layer peril, or same-species]
+    C --> D{Something rolled?}
+    D -->|Yes| E[Set currentEncounter]
+    D -->|No| Z[No event this turn]
+    B -->|Yes| F[Existing encounter continues]
+    E --> G[render: encounter card shown to player]
+    F --> G
+    G --> H[Player chooses action: eat, fight, flee, investigate, wait, or ignore]
+    H --> I{Outcome}
+    I -->|Safe| J[Clear encounter]
+    I -->|Threat triggered| K[Fitness damage applied]
+    I -->|Pursuit launched| L[activePursuit set]
+    J --> M[endTurn and render]
+    K --> M
+    L --> N[Pursuit resolves or escalates each endTurn]
+    N --> M
+```
+
+Encounters have a `dangerProfile` (`safe`, `nuisance`, `risky`, `predator`, `fatal`, `venomous_ambush`, `grapple`). Resolution logic uses this alongside the player's current state, group size, layer, and the encounter's `temperament`. Persistence type determines how long an encounter stays on the tile: `ephemeral` (animals that may leave), `lingering` (ambush predators), or `static` (forageables, nests, carcasses).
+
+---
+
+## Poison system
+
+Poison is a separate state on the player (`player.poison`). It has a rank (1–3), a source key, and a remaining duration. Each call to `startTurn()` ticks the poison, applying fitness damage per turn. Higher ranks do more damage. The player can have an active encounter AND active poison simultaneously. Past poison exposures are stored in `player.poisonHistory`.
+
+---
+
+## Profiles and save system
+
+The game supports multiple named profiles. All data is stored in `localStorage` under versioned keys. There is no server-side save.
+
+```mermaid
+flowchart TD
+    A[Game opens] --> B{Profile store in localStorage?}
+    B -->|No| C[Create default profile]
+    B -->|Yes| D[Load profiles]
+    D --> E{Active profile has a saved run?}
+    E -->|Yes| F[Offer resume]
+    F --> G{Player accepts?}
+    G -->|Yes| H[Restore player state, group, knowledge, run tracking]
+    G -->|No| I[Start new run under active profile]
+    E -->|No| I
+    C --> I
+    H --> J[Game running]
+    I --> J
+    J --> K[Each turn: profileSaveActiveRun writes current state to localStorage]
+    K --> J
+    J --> L[Player dies]
+    L --> M[profileOnRunEnd: update cross-run stats]
+    M --> N[checkAchievements on final state]
+    N --> O[Save entry to Fossil Record]
+    O --> P[Clear active run state from profile]
+    P --> Q[Death modal shown]
+```
+
+Each profile stores:
+- Cross-run stats (best turn count, total runs, total matings, etc.)
+- Field Journal knowledge accumulated across all runs
+- Achievements (50 definitions, stored as unlocked/date pairs)
+- Fossil Record entries (last 10 runs: turns, cause of death, companions, date)
+- Active run state (restorable if the tab is closed mid-run)
+
+---
+
+## Field Journal
+
+The Field Journal is the player's accumulated knowledge database. It is opened via a button and shows five tabs: **Plants & fungi**, **Animals**, **Fruit & berries**, **Fossils**, and **Awards**.
+
+Knowledge accumulates across runs. Investigating an encounter increases the knowledge level for that encounter type (0–30, six tiers: unknown → noticed → familiar → understood → expert → natural-historian). Higher levels unlock natural-history text, behaviour notes, and gameplay tips. Knowledge is stored per profile and persists across runs.
+
+---
+
+## Fossil Record
+
+The Fossil Record stores the last 10 run outcomes: turns survived, cause of death, companion count, date, and profile ID. It is accessible from the Field Journal's Fossils tab at any time during a run, and is briefly summarised on the death screen. Entries are tagged with a profile ID; deleting a profile removes its entries.
+
+---
+
+## Achievements
+
+There are 50 achievement definitions across 8 categories (Survival, Foraging, Exploration, Social, Danger, Growth, Milestones). Achievements are checked every turn, on death, and when a run ends. When unlocked, a toast notification appears. Achievements are stored per profile and shown in the Field Journal's Awards tab.
+
+---
+
+## Group and social system
+
+The player can recruit same-species companions (`socialGroup.members`). The group has cohesion (drops under stress), shared food/water history, and a loss counter. Group members improve threat detection and can occasionally intercept predator attacks. Social encounters with the same species can trigger socialisation prompts leading to group membership.
+
+---
+
+## Ecology and world state
+
+The global `environment` object covers:
+- Current weather (clear, rain, storm, heat, wildfire, etc.)
+- Wind direction (affects scent detection)
+- Time of day (dawn, day, dusk, night — affects encounter rates and visibility)
+- Short ecological cycles (fruiting pulse, insect bloom, dry spell, wet spell, scavenger pulse, predator lull, predator spike)
+
+`worldTick()` advances cycles each turn and can change weather and cycle state. These affect which encounters spawn and how dangerous they are.
+
+---
+
+## Bot and QA tooling
+
+The bot (`botState`) runs the game automatically for QA purposes. It uses a weighted strategy (survival-driven: seeks food/water when needed, avoids known threats, flees pursuit) and records every step.
+
+```mermaid
+flowchart TD
+    A[User presses Start Bot] --> B[botState.running = true, timer started]
+    B --> C[stepRandomBot fires every 400ms]
+    C --> D[updateBotMemory: track threats, parasite turns, goal stagnation]
+    D --> E[pickBotAction: weighted strategy with goal planner and loop detection]
+    E --> F[Execute chosen action]
+    F --> G[scanForSuspiciousState: check game invariants]
+    G --> H{Player dead?}
+    H -->|Yes| I[Record run summary in botState.runs]
+    I --> J{maxTurns reached?}
+    J -->|No| K[resetGameForBot and continue next run]
+    K --> C
+    J -->|Yes| L[Bot stops]
+    H -->|No| M{maxTurns reached?}
+    M -->|Yes| L
+    M -->|No| C
+    L --> N[Generate compact and full reports]
+    N --> O[Reports available for download or GitHub API push]
+```
+
+Reports come in two formats:
+- **Compact** — QA issues, death-cause rollup, run summary table, patch gate summary. Use for routine review.
+- **Full** — everything above plus per-step snapshots and raw JSON. Use only for deep debugging.
+
+The bot can push reports directly to GitHub via the API using a fine-grained PAT stored in `sessionStorage` (cleared when the tab closes).
+
+---
+
+## Render lifecycle
+
+All visual updates go through a single `render()` call. It redraws the full UI from current state every time it runs — there is no virtual DOM or reactive framework.
+
+```mermaid
+flowchart TD
+    A[render called] --> B[Update theme and CSS classes]
+    B --> C[Update narration text]
+    C --> D[Render last outcome banner]
+    D --> E[Redraw map tiles with symbols and explored state]
+    E --> F[Update player vitals bars: fitness, energy, hydration, growth]
+    F --> G{Active encounter?}
+    G -->|Yes| H[Render encounter card with description and action buttons]
+    G -->|No| I[Render exploration action buttons]
+    H --> J[Update group panel]
+    I --> J
+    J --> K[Update habitat, terrain, time, and weather labels]
+    K --> L[Update world map canvas if visible]
+    L --> M[Recalculate all button enabled states]
+    M --> N[Screen updated]
+```
+
+`render()` is always the last call in `endTurn()`. It is also called directly after profile modals, encounter resolution, and bot steps.
+
+---
+
+## What lives in game/play.html (approximate line ranges)
+
+| Lines | Area |
+|-------|------|
+| 1–990 | HTML head, CSS styles, HTML body structure (UI panels, buttons, modals) |
+| 990–1020 | Game version constant |
+| 1021–3413 | Static data: encounter definitions (~100+ encounters with spawn, poison, natural-history blocks) |
+| 3414–3630 | Spawn tables: layer-based encounter probability lists |
+| 3631–4252 | World generation: terrain, habitats, altitude, water, clay deposits |
+| 4253–4791 | Player state object and dynamic world state (waterState, socialGroup, nearbyEntities) |
+| 4792–5829 | Achievements (50 defs), profiles, save/load, Field Journal, Fossil Record |
+| 5830–6281 | Core utilities: logging, cloning, clamping, debug tracing, invariant checks |
+| 6282–7612 | Turn flow: startTurn, endTurn, metabolism, time of day, ecology tick |
+| 7613–8429 | Nearby entity simulation: spawning, persistence, world registry |
+| 8430–11327 | Social system, same-species encounters, group management, calls |
+| 11328–11826 | Threat and predator logic: pursuit, escalation, flee/fight resolution |
+| 11827–12523 | Player action handlers: move, eat, drink, climb, wait, groom, look, etc. |
+| 12524–14471 | Investigation system, carcass interactions, encounter resolution helpers, Field Journal render |
+| 14472–15839 | Bot/QA: botState, strategy, step execution, goal planner, loop detection |
+| 15840–16687 | Debug helpers: compact/full report generation, GitHub API push, debug downloads |
+| 16688–17140 | Rendering helpers: encounter card HTML builder, button state logic |
+| 17141–18434 | Main render function, event listeners, game initialisation call, tag extension pass |
+
+---
+
+## Known fragile areas
+
+- **Any syntax error in the `<script>` block breaks the entire game.** The browser cannot run the script at all if parsing fails. Run `node scripts/check_html_js_syntax.mjs` before every game-file PR.
+- **`game/play.html` and `game/evolution_game_v66_57.html` must be kept in sync** on each release. If one is edited, both must be updated.
+- **The bot auto-save uses the GitHub API directly from the browser.** It requires a fine-grained PAT stored in `sessionStorage`; it clears when the tab closes.
+- **The encounter resolution area** (~11328–12523) is tightly coupled. Changes there can break survival balance in non-obvious ways.
+- **The `render()` function** is called very frequently. Missing a call or adding an unexpected recursive call causes visible glitches.
+- **`player.knowledge` / `player.classKnowledge`** accumulate across runs and feed the Field Journal. Incorrect resets at run boundaries lose journal data permanently.
+
+---
+
+## What will eventually become modular
+
+The rebuild plan (see `docs/project-plan.md`) targets extraction in this rough order:
+
+1. CSS and HTML templates (currently embedded in the `<style>` and `<body>` sections)
+2. Static encounter data and spawn tables (lines 1021–3630)
+3. Pure helper functions with no side effects
+4. State and save schema (player object, world state, profile schema)
+5. Turn engine (startTurn, endTurn, encounter resolution)
+6. Rendering layer
+7. Bot/QA tools
+
+No extraction has begun yet. This document will be updated as each phase completes.

--- a/docs/documentation-map.md
+++ b/docs/documentation-map.md
@@ -1,0 +1,84 @@
+# Documentation Map
+
+This document explains what each documentation file covers, when it must be updated, and what questions it answers. Use it when deciding which files need updating for a given change.
+
+---
+
+## Files and their purpose
+
+### CHANGELOG.txt
+**What it covers:** Plain-English history of every change to the project.  
+**Update when:** Any PR that touches code, documentation, workflow, app-loading files, bot/debug tools, or repository structure.  
+**Answers:** What changed, when, and who made it?
+
+---
+
+### README.md
+**What it covers:** Project overview, play link, current build version, repository layout, development workflow, and notes for AI assistants.  
+**Update when:** New top-level files or directories are added; the build version changes; workflow rules change significantly; a new phase or direction is introduced.  
+**Answers:** What is this project? How do I play it? How is the repo laid out? How does development work?
+
+---
+
+### docs/current-game-structure.md
+**What it covers:** What the game currently is, how every system works, what lives in `game/play.html`, runtime flow diagrams, and known fragile areas.  
+**Update when:** A new system is added or significantly changed; line ranges shift noticeably; a fragile area is fixed or a new one appears; a rebuild phase moves code out of `play.html`.  
+**Answers:** How does the game work right now? What happens during a turn? How does saving work? What is the bot?
+
+---
+
+### docs/architecture-notes.md
+**What it covers:** The internal layout of `game/play.html`: section line ranges, key data structures, fragile areas, and do-not-touch warnings.  
+**Update when:** Significant code is added, moved, or restructured; line ranges become stale; a new fragile area is identified.  
+**Answers:** Where is this code in the file? What should I not change without checking?
+
+---
+
+### docs/project-plan.md
+**What it covers:** Non-code planning: current phase, priorities, design direction, open questions, and the idea intake log.  
+**Update when:** The current phase changes; a major design decision is made; a new area of work is agreed; an idea is raised that should not be lost.  
+**Answers:** What are we building? What should we build next? What design decisions have been made?
+
+---
+
+### docs/bug-guardrails.md
+**What it covers:** Documented failure modes: serious bugs, repeated mistakes, and the prevention checks that come from them.  
+**Update when:** A patch introduces or fixes a serious bug; a failure mode recurs; a new mandatory PR check is identified.  
+**Answers:** What has gone wrong before? What checks must pass before this PR is ready?
+
+---
+
+### docs/release-checklist.md
+**What it covers:** Step-by-step checklist for releasing a new version: version constants, file sync, syntax check, bot testing, documentation gate, and GitHub steps.  
+**Update when:** The release process changes; new mandatory checks are added; documentation gate requirements change.  
+**Answers:** What do I need to do before and after a release?
+
+---
+
+### .github/pull_request_template.md
+**What it covers:** The required PR checklist: scope, bug guardrails, syntax/render safety, CHANGELOG, commit message check, and documentation gate.  
+**Update when:** New mandatory PR checks are added; the documentation gate wording changes; new scope categories appear.  
+**Answers:** What must every PR address before it can be merged?
+
+---
+
+### CLAUDE.md
+**What it covers:** Operating rules for AI assistants: execution modes, scope control, documentation requirements, version control rules, and workflow.  
+**Update when:** The workflow changes; new rules are needed; the documentation gate requirements change; new forbidden patterns are identified.  
+**Answers:** How should Claude behave when working on this repo?
+
+---
+
+## Quick reference — when to update which files
+
+| Change type | Required doc updates |
+|-------------|---------------------|
+| New gameplay system or major feature | README, current-game-structure, project-plan, CHANGELOG |
+| System significantly changed | current-game-structure, architecture-notes, CHANGELOG |
+| Code moved or file structure changed | README (layout), architecture-notes, current-game-structure, CHANGELOG |
+| Bug introduced and fixed | bug-guardrails (new or updated entry), CHANGELOG |
+| New release | release-checklist review, README (build version), CHANGELOG |
+| New mandatory PR check | pull_request_template, release-checklist, bug-guardrails (if from a bug) |
+| New assistant workflow rule | CLAUDE.md, CHANGELOG |
+| New phase or design direction | project-plan, README, CHANGELOG |
+| Documentation repair only | CHANGELOG |

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -24,11 +24,42 @@ This is not a promise to build everything. It is a shared memory and prioritisat
 
 ## Current broad phase
 
-**Phase:** Early ecology and playability expansion.
+**Phase:** Controlled rebuild — Phase 1 (documentation repair and enforcement).
 
-The current build has enough basic systems to play and test, but many mechanics are still first-pass. The immediate goal is to make the ecosystem feel more alive while keeping the game stable and testable.
+The game has grown beyond what is safe to maintain as a single large HTML file. Rather than a rewrite, the plan is a structured, evidence-first rebuild that keeps the playable game stable throughout.
 
-Current emphasis:
+### Rebuild phases
+
+**Phase 1 — Documentation repair and enforcement** *(current)*  
+Repair all existing documentation to accurately describe the current game. Create `docs/current-game-structure.md` and `docs/documentation-map.md`. Make documentation checks mandatory in every PR via the PR template.
+
+**Phase 2 — Architecture plan** *(next)*  
+After documentation is in order, produce and agree a proposed modular structure. Likely shape:
+- `src/data/` — encounters, spawn tables, natural-history text
+- `src/state/` — player state, world state, profiles, save schema
+- `src/engine/` — turn logic, encounters, poison, ecology, group systems
+- `src/ui/` — rendering, map, player panel, modals, Field Journal
+- `src/qa/` — bot runner, invariant checks, report generation
+- `scripts/` — build and check tools
+
+**Phase 3 — Safe extraction** *(after Phase 2 is approved)*  
+Extract code in small PRs with a single purpose each. Probable order: CSS/templates → static data → pure helpers → state/save schema → turn engine → rendering → bot/QA tools.
+
+Each extraction PR must: have one purpose, avoid gameplay changes, update docs, update CHANGELOG, pass syntax/smoke checks, and keep the playable build working.
+
+### What the rebuild is not
+
+- Not a total rewrite
+- Not a framework migration
+- Not a gameplay redesign or balance pass
+- Not a feature expansion
+- Not moving fast and hoping it works
+
+### Previously active: early ecology and playability expansion
+
+*(Paused while Phase 1 completes. Will resume as gameplay work within the new structure.)*
+
+The earlier focus was making the ecosystem feel more alive:
 
 - richer encounter behaviour,
 - clearer survival pressures,

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -25,11 +25,17 @@ Run through this every time a new version becomes the stable build.
 - [ ] No new `ERR_*` errors compared to previous build
 - [ ] Consolidated report produced if multiple runs were done
 
-## Documentation
+## Documentation gate
+
+Check `docs/documentation-map.md` to identify which files apply to this release.
 
 - [ ] `CHANGELOG.txt` updated with a plain-English entry
+- [ ] `docs/current-game-structure.md` checked — line ranges and system descriptions still accurate
+- [ ] `docs/architecture-notes.md` checked — line ranges still accurate; new fragile areas noted
 - [ ] `docs/bug-guardrails.md` checked — any new lessons from this patch added
-- [ ] `docs/project-plan.md` updated if design changed
+- [ ] `docs/project-plan.md` updated if design or phase changed
+- [ ] `README.md` updated if build version, layout, or workflow changed
+- [ ] PR body includes documentation gate statement: `Documentation updated: [files]` or `Documentation checked; no wider docs required because: [reason]`
 
 ## GitHub
 


### PR DESCRIPTION
…structure and documentation-map

- docs/current-game-structure.md (new): owner-facing description of all current game systems with six Mermaid diagrams (runtime structure, turn flow, save/profile flow, encounter lifecycle, render lifecycle, bot/QA lifecycle) and accurate line ranges for play.html (~18,400 lines)
- docs/documentation-map.md (new): single-page guide to what each doc covers, when to update it, and a quick-reference update table
- docs/architecture-notes.md: corrected line ranges (13,400 → 18,400); added profiles/saves, Field Journal, Fossil Record, Achievements, and natural-history system to key areas; updated fragile areas list
- docs/project-plan.md: updated current phase to Phase 1 of controlled rebuild; added three-phase rebuild plan; parked ecology expansion work
- docs/bug-guardrails.md: added BG-004 (documentation drift)
- docs/release-checklist.md: added full documentation gate checklist
- .github/pull_request_template.md: added mandatory documentation gate section with per-file tick list and required gate statement
- README.md: updated layout table; added controlled rebuild plan section
- CHANGELOG.txt: prepended Phase 1 entry
- No changes to game/play.html or any code files

## Summary

<!-- Plain-English summary of what changed and why. -->

## Scope check

Tick every area touched by this PR:

- [ ] Gameplay logic / mechanics
- [ ] UI / layout / presentation
- [ ] Bot / debug / QA tools
- [ ] GitHub Pages / app loading / PWA files
- [ ] Documentation / workflow only
- [ ] Other: <!-- describe -->

## Known bug guardrails

Before marking this PR ready, check `docs/bug-guardrails.md` for any previously documented failure mode that may apply.

- [ ] Reviewed `docs/bug-guardrails.md`
- [ ] Any applicable guardrail checks have been completed
- [ ] If this PR fixes a bug/coding error, a new guardrail entry was added or an existing one was updated
- [ ] If no guardrail applies, state why here: <!-- reason -->

**GPT/Claude instruction:** If a patch introduces or fixes a serious bug, do not treat it as fully resolved until the lesson learned is captured in `docs/bug-guardrails.md` or there is a clear reason not to add one.

## Mandatory syntax/render safety check

Required for any PR touching `game/*.html`, `index.html`, `manifest.json`, bot/debug tooling, or app-loading behaviour.

- [ ] `node scripts/check_html_js_syntax.mjs` passed, or equivalent syntax check performed
- [ ] `game/play.html` opened in a browser
- [ ] Game renders without a blank or half-loaded screen
- [ ] Map is visible
- [ ] Player/status UI is visible
- [ ] Core action controls are visible
- [ ] At least one action/turn can be taken
- [ ] Browser console checked for red JavaScript errors
- [ ] If bot/debug tools were touched: bot can start and stop without crashing

If this check was not run, state clearly here:

> Syntax/render safety check not run.

## Mandatory CHANGELOG reminder

- [ ] `CHANGELOG.txt` updated with a timestamped plain-English entry for this PR
- [ ] Entry states who made the change
- [ ] Entry states whether gameplay logic, UI/layout, bot/debug tools, app-loading behaviour, or documentation changed
- [ ] If the changelog was intentionally not updated, explain why here: <!-- reason -->

**GPT/Claude instruction:** Do not describe a PR as complete, safe, or ready to merge unless the changelog status is explicitly addressed.

## Commit message check

- [ ] No `claude.ai/code/session_...` URLs in any commit message on this PR (repo is public)

## Testing / review notes

<!-- List what was actually checked. Do not claim tests were run if they were not. -->

## Reviewer confirmation

Reviewer must explicitly state one of:

- `Bug guardrails reviewed; applicable checks passed.`
- `Bug guardrails not reviewed.`

Reviewer must explicitly state one of:

- `Syntax/render safety check passed.`
- `Syntax/render safety check not run.`

Reviewer must also explicitly state one of:

- `CHANGELOG updated.`
- `CHANGELOG not updated: [reason].`
