### PR TITLE
Extract pure utility helpers source

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,25 @@
+[2026-06-03 extract-core-utils | Claude]
+Third controlled extraction — pure utility helper source extracted and build script extended.
+
+- Created src/utils/core-utils.js: thirteen pure stateless helper functions moved mechanically from game/play.html.
+  - strengthOf, effective, clamp, capitalise, roll, choice — basic math and value utilities.
+  - sanitizeNarrativeText, ensureNarrativeString, containsCodeLikeText, cleanNarrative — text-sanitisation helpers.
+  - escapeHtml — HTML-escaping utility.
+  - clonePlain — JSON deep-clone.
+  - chooseWeighted — weighted random selection (takes items array, no side effects).
+  - All thirteen are pure: no DOM access, no localStorage, no mutation of player/world/encounter/bot state, no calls to render/startTurn/endTurn/save functions.
+  - Byte-identical to original code; no logic changed.
+  - chooseWeighted was previously located after the encounter-data [2/2] generated region; it is now in the [UTILS] generated region (safe — function declarations are hoisted). applyHiddenSubtype continues to call it correctly.
+  - Non-pure utilities (addLog, setNarration, setGroupNotice, etc.) remain in game/play.html outside the generated region.
+- Edited game/play.html: [UTILS] section reorganised so pure helpers form a contiguous block wrapped in generated-region markers. Non-pure utilities follow immediately after the END marker. The encounter-data [2/2] region and all code from [TURN] onwards are unchanged.
+  - Only structural change: BEGIN/END markers inserted, functions reordered within [UTILS] (safe due to hoisting). All code is byte-identical to the originals.
+  - game/play.html remains the directly playable artifact.
+- Extended scripts/build_play_html.mjs: now inlines CSS, encounter data, and core-utils. Fails clearly if src/utils/core-utils.js or its region markers are missing. Idempotent.
+- game/evolution_game_v66_57.html NOT changed: historical archive, not kept byte-synced between releases.
+- Docs: README.md (repo layout tree fixed — added src/data/, src/utils/, build_play_html.mjs; build scaffold table updated), docs/current-game-structure.md (build scaffold table and line ranges), docs/architecture-notes.md (single-file structure section, line-range table, known fragile areas), docs/release-checklist.md (build step check for core-utils).
+- Verification: node scripts/build_play_html.mjs (idempotent — no change) and node scripts/check_html_js_syntax.mjs both pass. Browser render not manually verified in this environment.
+- Source/build structure change only. No gameplay logic, encounter values, JavaScript outside the generated regions, save/profile logic, or rendering changed.
+
 [2026-06-03 fix-encounter-data-build-wiring | Claude]
 Corrective build-wiring patch — build script now actually inlines the encounter data source.
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,12 @@ evolution-game/
 │   ├── play.html                     Stable playable build used by public link/PWA
 │   └── evolution_game_v66_57.html    Versioned playable build
 ├── src/
-│   └── styles/
-│       └── game.css                  CSS source (inlined into play.html by the build script)
+│   ├── styles/
+│   │   └── game.css                  CSS source (inlined into play.html by the build script)
+│   ├── data/
+│   │   └── encounter-data.js         Encounter + spawn-table source (inlined into play.html by the build script)
+│   └── utils/
+│       └── core-utils.js             Pure utility helpers source (inlined into play.html by the build script)
 ├── docs/
 │   ├── current-game-structure.md     How the game works now: systems, flows, line ranges
 │   ├── documentation-map.md          What each doc covers and when to update it
@@ -106,6 +110,7 @@ evolution-game/
 │   ├── bot-runs/                     Raw bot run outputs when intentionally saved
 │   └── consolidated/                 AI-reviewed summaries and bug reports
 ├── scripts/
+│   ├── build_play_html.mjs           Inlines src/ source files into game/play.html
 │   ├── check_html_js_syntax.mjs      JavaScript syntax checker for game HTML files
 │   └── ingest_bot_report.sh          Helper for manually ingesting downloaded bot logs
 └── .github/
@@ -131,12 +136,13 @@ The rebuild is not a rewrite, not a framework migration, and not a gameplay rede
 
 ### Build scaffold
 
-Two source extractions are complete:
+Three source extractions are complete:
 
 | Source file | What it contains | Destination in play.html |
 |-------------|-----------------|--------------------------|
 | `src/styles/game.css` | All CSS | Inline `<style>` block |
-| `src/data/encounter-data.js` | `encounters`, `encounterTables`, `hiddenSubtypePools` | Two JS regions (~line 1040 and ~line 6035) |
+| `src/data/encounter-data.js` | `encounters`, `encounterTables`, `hiddenSubtypePools` | Two JS regions (~line 1040 and ~line 6037) |
+| `src/utils/core-utils.js` | Pure stateless helper functions | One JS region (~line 5835) |
 
 `game/play.html` keeps all content **inline** so it stays directly playable with no build step or runtime dependency. To regenerate `game/play.html` after editing any source file:
 

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -8,7 +8,7 @@ This document is a map of how the game HTML file is organised. Read this before 
 
 The entire game lives in one large HTML file (`game/play.html`, ~18,400 lines). There is no build step, no bundler, and no separate JavaScript files. Everything — CSS, HTML structure, and all JavaScript — is in one file.
 
-Two source files have been extracted and are inlined back into `game/play.html` by `scripts/build_play_html.mjs`. The playable file still ships all content inline, so it works with no build step at runtime. The build script replaces only the regions between these marker comments:
+Three source files have been extracted and are inlined back into `game/play.html` by `scripts/build_play_html.mjs`. The playable file still ships all content inline, so it works with no build step at runtime. The build script replaces only the regions between these marker comments:
 
 **CSS** (inside the `<style>` block) — source `src/styles/game.css`:
 ```
@@ -31,9 +31,16 @@ Two source files have been extracted and are inlined back into `game/play.html` 
 // END GENERATED JS: src/data/encounter-data.js [2/2]
 ```
 
-`src/data/encounter-data.js` uses a `// << SPLIT: hiddenSubtypePools >>` line to divide part 1 from part 2; the build script splits on it and inlines each part into its region. The split marker itself is not inlined.
+**Core utility helpers** (inside the `<script>` block, ~line 5835) — pure stateless helper functions:
+```
+// BEGIN GENERATED JS: src/utils/core-utils.js
+...generated js...
+// END GENERATED JS: src/utils/core-utils.js
+```
 
-**Edit CSS in `src/styles/game.css` and encounter data in `src/data/encounter-data.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
+`src/data/encounter-data.js` uses a `// << SPLIT: hiddenSubtypePools >>` line to divide part 1 from part 2; the build script splits on it and inlines each part into its region. The split marker itself is not inlined. `src/utils/core-utils.js` has no split marker and maps to one contiguous region.
+
+**Edit CSS in `src/styles/game.css`, encounter data in `src/data/encounter-data.js`, and pure utility helpers in `src/utils/core-utils.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
 
 `game/evolution_game_v66_57.html` is the versioned archive of an earlier build. It is a historical snapshot and is not kept byte-in-sync with `game/play.html` between releases; `game/play.html` is the stable public-facing copy that gets replaced on each release.
 
@@ -51,7 +58,8 @@ Two source files have been extracted and are inlined back into `game/play.html` 
 | 3502–4254 | World generation: terrain, habitats, altitude, water, clay deposits |
 | 4253–4791 | Player state object and dynamic world state (waterState, socialGroup, nearbyEntities) |
 | 4792–5829 | Achievements (50 defs), profiles, save/load, Field Journal, Fossil Record |
-| 5830–6036 | Core utilities: logging, clamping, cloning, debug tracing |
+| 5830–5924 | Core utility helpers — generated, source in `src/utils/core-utils.js`: pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation) |
+| 5925–6036 | Remaining [UTILS]: logging, narration setters, noise, risk memory (not extracted — side effects) |
 | 6037–6115 | hiddenSubtypePools — generated, source in `src/data/encounter-data.js` [2/2] |
 | 6116–7614 | Remaining utilities + turn flow: `startTurn`, `endTurn`, metabolism, ecology tick |
 | 7613–8429 | Nearby entity simulation: spawning, persistence, world registry |
@@ -112,7 +120,7 @@ All rendering is done by a single `render()` call that redraws the map, UI panel
 - **`game/play.html` and `game/evolution_game_v66_57.html` must be kept in sync** on each release. If you edit one, copy the change to the other, or replace `play.html` entirely.
 - **`index.html` and `manifest.json` must both reference `game/play.html`.** The syntax check script verifies `index.html`. Check `manifest.json` manually on releases.
 - **`player.knowledge` / `player.classKnowledge`** accumulate across runs and feed the Field Journal. Incorrect resets at run boundaries lose journal data permanently.
-- **The CSS region and both encounter-data regions in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css` and `src/data/encounter-data.js` instead. Do not remove the BEGIN/END marker comments or the `// << SPLIT: hiddenSubtypePools >>` line — the build script requires all of them.
+- **The CSS region, both encounter-data regions, and the core-utils region in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css`, `src/data/encounter-data.js`, and `src/utils/core-utils.js` instead. Do not remove any BEGIN/END marker comments or the `// << SPLIT: hiddenSubtypePools >>` line — the build script requires all of them.
 
 ---
 

--- a/docs/current-game-structure.md
+++ b/docs/current-game-structure.md
@@ -12,14 +12,15 @@ Evolution Game is a browser-based single-player survival simulation. The player 
 
 The game runs from a single HTML file (`game/play.html`, ~18,400 lines). There is no bundler and no server. Open the file in a browser and it works.
 
-Two source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
+Three source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
 
 | Source file | What it contains | In play.html |
 |-------------|-----------------|--------------|
 | `src/styles/game.css` | All CSS | Inline `<style>` block |
 | `src/data/encounter-data.js` | `encounters`, `encounterTables`, `hiddenSubtypePools` | Two inline JS regions |
+| `src/utils/core-utils.js` | Pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation helpers) | One inline JS region (~line 5835) |
 
-`scripts/build_play_html.mjs` inlines both source files back into `game/play.html`. All JavaScript engine code, HTML structure, and other data remain inside `game/play.html` for now.
+`scripts/build_play_html.mjs` inlines all source files back into `game/play.html`. All other JavaScript engine code, HTML structure, and game state remain inside `game/play.html` for now.
 
 ---
 
@@ -270,7 +271,8 @@ flowchart TD
 | 3631–4252 | World generation: terrain, habitats, altitude, water, clay deposits |
 | 4253–4791 | Player state object and dynamic world state (waterState, socialGroup, nearbyEntities) |
 | 4792–5829 | Achievements (50 defs), profiles, save/load, Field Journal, Fossil Record |
-| 5830–6036 | Core utilities: logging, cloning, clamping, debug tracing |
+| 5830–5924 | Core utilities — generated, source is `src/utils/core-utils.js`: pure helpers (clamp, roll, choice, clonePlain, escapeHtml, etc.) |
+| 5925–6036 | Remaining utilities: logging, debug helpers, narration setters |
 | 6037–6115 | hiddenSubtypePools — generated, source is `src/data/encounter-data.js` [2/2] |
 | 6116–7614 | Remaining utilities, turn flow: startTurn, endTurn, metabolism, ecology tick |
 | 7613–8429 | Nearby entity simulation: spawning, persistence, world registry |
@@ -302,7 +304,7 @@ The rebuild plan (see `docs/project-plan.md`) targets extraction in this rough o
 
 1. CSS and HTML templates — **CSS extracted to `src/styles/game.css`** ✓; HTML templates still inline
 2. Static encounter data and spawn tables — **`encounters`, `encounterTables`, `hiddenSubtypePools` extracted to `src/data/encounter-data.js`** ✓
-3. Pure helper functions with no side effects
+3. Pure helper functions with no side effects — **pure stateless helpers extracted to `src/utils/core-utils.js`** ✓
 4. State and save schema (player object, world state, profile schema)
 5. Turn engine (startTurn, endTurn, encounter resolution)
 6. Rendering layer
@@ -317,7 +319,8 @@ The rebuild plan (see `docs/project-plan.md`) targets extraction in this rough o
 | `src/styles/game.css` | `/* BEGIN/END GENERATED CSS: src/styles/game.css */` inside `<style>` |
 | `src/data/encounter-data.js` [1/2] | `// BEGIN/END GENERATED JS: src/data/encounter-data.js [1/2]` |
 | `src/data/encounter-data.js` [2/2] | `// BEGIN/END GENERATED JS: src/data/encounter-data.js [2/2]` |
+| `src/utils/core-utils.js` | `// BEGIN/END GENERATED JS: src/utils/core-utils.js` |
 
-The source file `src/data/encounter-data.js` contains a `// << SPLIT: hiddenSubtypePools >>` line dividing part 1 (encounters + encounterTables) from part 2 (hiddenSubtypePools). The build script splits on this marker and inlines each part into its respective location in `play.html`.
+The source file `src/data/encounter-data.js` contains a `// << SPLIT: hiddenSubtypePools >>` line dividing part 1 (encounters + encounterTables) from part 2 (hiddenSubtypePools). The build script splits on this marker and inlines each part into its respective location in `play.html`. `src/utils/core-utils.js` has no split marker — it maps to one contiguous region.
 
 Run `node scripts/build_play_html.mjs` after editing any source file. Do not hand-edit generated regions in `game/play.html`. This document will be updated as each further extraction completes.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -16,7 +16,8 @@ Run through this every time a new version becomes the stable build.
 
 - [ ] If `src/styles/game.css` was changed, `node scripts/build_play_html.mjs` was run to inline the CSS into `game/play.html`
 - [ ] If `src/data/encounter-data.js` was changed, `node scripts/build_play_html.mjs` was run to inline the encounter data into `game/play.html`
-- [ ] The generated regions in `game/play.html` were not hand-edited (CSS changes go in `src/styles/game.css`; encounter data changes go in `src/data/encounter-data.js`)
+- [ ] If `src/utils/core-utils.js` was changed, `node scripts/build_play_html.mjs` was run to inline the utility helpers into `game/play.html`
+- [ ] The generated regions in `game/play.html` were not hand-edited (CSS changes go in `src/styles/game.css`; encounter data changes go in `src/data/encounter-data.js`; utility helper changes go in `src/utils/core-utils.js`)
 
 ## Syntax and render check
 

--- a/game/play.html
+++ b/game/play.html
@@ -5832,6 +5832,7 @@ function normaliseEncounter(e, key = "unknown") {
 // ---------------------------------------------------------------------------
 // [UTILS] CORE HELPERS / LOGGING / CLONING
 // ---------------------------------------------------------------------------
+// BEGIN GENERATED JS: src/utils/core-utils.js
 // @target [UTILS] Strength Of
 function strengthOf(entity) {
   return Math.round((entity.size || 1) * 1.2);
@@ -5865,23 +5866,6 @@ function choice(list) {
   return list[Math.floor(Math.random() * list.length)];
 }
 
-function layerNarrationChoice(layerName) {
-  const options = (layerNarration[layerName] || layerNarration["Ground"] || []).filter(item => typeof item === "string");
-  return choice(options);
-}
-
-/**
- * Adds one player-facing event line and one structured debug-log entry.
- *
- * Player log design:
- * - Coordinates and layer are included for reproducible bug reports.
- * - The visible log is compacted where possible to avoid duplicated move lines.
- *
- * Developer log design:
- * - Keeps richer state than the visible log.
- * - Export is capped to prevent unbounded memory growth during long playthroughs.
- */
-// @target [UTILS] Add Log
 function sanitizeNarrativeText(value, fallback = "") {
   if (value === null || value === undefined) return fallback;
   if (typeof value === "string") return value.replace(/\[object Object\]/g, fallback || "forest").trim();
@@ -5915,6 +5899,46 @@ function cleanNarrative(str) {
   return str;
 }
 
+// @target [UTILS] Escape Html
+function escapeHtml(value) {
+  return String(value ?? "").replace(/[&<>"']/g, ch => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[ch] || ch));
+}
+
+// @target [UTILS] Clone Plain
+function clonePlain(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+// @target [UTILS] Choose Weighted
+function chooseWeighted(items) {
+  const total = items.reduce((s, item) => s + item.weight, 0);
+  let r = Math.random() * total;
+
+  for (const item of items) {
+    r -= item.weight;
+    if (r <= 0) return item;
+  }
+
+  return items[0];
+}
+// END GENERATED JS: src/utils/core-utils.js
+
+function layerNarrationChoice(layerName) {
+  const options = (layerNarration[layerName] || layerNarration["Ground"] || []).filter(item => typeof item === "string");
+  return choice(options);
+}
+
+/**
+ * Adds one player-facing event line and one structured debug-log entry.
+ *
+ * Player log design:
+ * - Coordinates and layer are included for reproducible bug reports.
+ * - The visible log is compacted where possible to avoid duplicated move lines.
+ *
+ * Developer log design:
+ * - Keeps richer state than the visible log.
+ * - Export is capped to prevent unbounded memory growth during long playthroughs.
+ */
 function safeNarrativeText(input, fallback = "") {
   const ensured = ensureNarrativeString(input);
   const base = sanitizeNarrativeText(ensured, fallback);
@@ -6004,11 +6028,6 @@ function setNarration(text) {
   lastNarration = raw || layerNarrationChoice(layers[player.z]);
 }
 
-// @target [UTILS] Escape Html
-function escapeHtml(value) {
-  return String(value ?? "").replace(/[&<>"']/g, ch => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[ch] || ch));
-}
-
 // @target [UTILS] Group scene notice helper
 function setGroupNotice(text) {
   const msg = safeNarrativeText(text, "").trim();
@@ -6028,11 +6047,6 @@ function setSmell(text) {
 }
 
 let nextInstanceId = 1;
-
-// @target [UTILS] Clone Plain
-function clonePlain(obj) {
-  return JSON.parse(JSON.stringify(obj));
-}
 
 // BEGIN GENERATED JS: src/data/encounter-data.js [2/2]
 const hiddenSubtypePools = {
@@ -6113,19 +6127,6 @@ const hiddenSubtypePools = {
   ]
 };
 // END GENERATED JS: src/data/encounter-data.js [2/2]
-
-// @target [UTILS] Choose Weighted
-function chooseWeighted(items) {
-  const total = items.reduce((s, item) => s + item.weight, 0);
-  let r = Math.random() * total;
-
-  for (const item of items) {
-    r -= item.weight;
-    if (r <= 0) return item;
-  }
-
-  return items[0];
-}
 
 // @target [UTILS] Apply Hidden Subtype
 function applyHiddenSubtype(e) {

--- a/scripts/build_play_html.mjs
+++ b/scripts/build_play_html.mjs
@@ -9,6 +9,7 @@
 //   2. src/data/encounter-data.js → two JS regions:
 //        [1/2] encounters + encounterTables  (~line 1040)
 //        [2/2] hiddenSubtypePools            (~line 6037)
+//   3. src/utils/core-utils.js    → one JS region (~line 5833)
 //
 // Why inline (not external files): game/play.html must open straight from
 // disk — or via the GitHub Pages link — with no build step and no runtime
@@ -26,9 +27,10 @@ import { dirname, resolve } from 'node:path';
 const here     = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..');
 
-const CSS_SOURCE  = resolve(repoRoot, 'src/styles/game.css');
-const DATA_SOURCE = resolve(repoRoot, 'src/data/encounter-data.js');
-const PLAY_HTML   = resolve(repoRoot, 'game/play.html');
+const CSS_SOURCE   = resolve(repoRoot, 'src/styles/game.css');
+const DATA_SOURCE  = resolve(repoRoot, 'src/data/encounter-data.js');
+const UTILS_SOURCE = resolve(repoRoot, 'src/utils/core-utils.js');
+const PLAY_HTML    = resolve(repoRoot, 'game/play.html');
 
 // CSS markers (CSS comment style, inside <style>)
 const CSS_BEGIN = '/* BEGIN GENERATED CSS: src/styles/game.css */';
@@ -39,6 +41,10 @@ const JS_BEGIN1 = '// BEGIN GENERATED JS: src/data/encounter-data.js [1/2]';
 const JS_END1   = '// END GENERATED JS: src/data/encounter-data.js [1/2]';
 const JS_BEGIN2 = '// BEGIN GENERATED JS: src/data/encounter-data.js [2/2]';
 const JS_END2   = '// END GENERATED JS: src/data/encounter-data.js [2/2]';
+
+// Core-utils markers (JS comment style, inside <script>)
+const JS_BEGIN_UTILS = '// BEGIN GENERATED JS: src/utils/core-utils.js';
+const JS_END_UTILS   = '// END GENERATED JS: src/utils/core-utils.js';
 
 // The split comment that divides the source file into part1 and part2.
 // It is NOT inlined into game/play.html.
@@ -64,13 +70,15 @@ function inlineRegion(html, beginMarker, endMarker, body, label) {
 }
 
 // --- Read sources ---
-if (!existsSync(CSS_SOURCE))  fail('cannot find src/styles/game.css');
-if (!existsSync(DATA_SOURCE)) fail('cannot find src/data/encounter-data.js');
-if (!existsSync(PLAY_HTML))   fail('cannot find game/play.html');
+if (!existsSync(CSS_SOURCE))   fail('cannot find src/styles/game.css');
+if (!existsSync(DATA_SOURCE))  fail('cannot find src/data/encounter-data.js');
+if (!existsSync(UTILS_SOURCE)) fail('cannot find src/utils/core-utils.js');
+if (!existsSync(PLAY_HTML))    fail('cannot find game/play.html');
 
-const css    = readFileSync(CSS_SOURCE,  'utf8');
-const jsData = readFileSync(DATA_SOURCE, 'utf8');
-let   html   = readFileSync(PLAY_HTML,   'utf8');
+const css      = readFileSync(CSS_SOURCE,   'utf8');
+const jsData   = readFileSync(DATA_SOURCE,  'utf8');
+const jsUtils  = readFileSync(UTILS_SOURCE, 'utf8');
+let   html     = readFileSync(PLAY_HTML,    'utf8');
 
 // --- Split encounter-data into two parts at the SPLIT marker ---
 const splitIdx = jsData.indexOf(JS_SPLIT);
@@ -80,9 +88,10 @@ const jsPart2 = jsData.slice(splitIdx + JS_SPLIT.length).replace(/^\n/, '').repl
 
 // --- Apply all three regions ---
 const original = html;
-html = inlineRegion(html, CSS_BEGIN, CSS_END, css.replace(/\s+$/, ''), 'CSS');
-html = inlineRegion(html, JS_BEGIN1, JS_END1, jsPart1, 'encounter-data [1/2]');
-html = inlineRegion(html, JS_BEGIN2, JS_END2, jsPart2, 'encounter-data [2/2]');
+html = inlineRegion(html, CSS_BEGIN,      CSS_END,      css.replace(/\s+$/, ''), 'CSS');
+html = inlineRegion(html, JS_BEGIN1,      JS_END1,      jsPart1, 'encounter-data [1/2]');
+html = inlineRegion(html, JS_BEGIN2,      JS_END2,      jsPart2, 'encounter-data [2/2]');
+html = inlineRegion(html, JS_BEGIN_UTILS, JS_END_UTILS, jsUtils.replace(/\s+$/, ''), 'core-utils');
 
 if (html === original) {
   console.log('build_play_html: no change — game/play.html already matches all source files.');

--- a/src/utils/core-utils.js
+++ b/src/utils/core-utils.js
@@ -1,0 +1,88 @@
+// @target [UTILS] Strength Of
+function strengthOf(entity) {
+  return Math.round((entity.size || 1) * 1.2);
+}
+
+// @target [UTILS] Fitness-scaled value helper
+function effective(value, fitness) {
+  return value * (fitness / 100);
+}
+
+// @target [UTILS] Clamp
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+// @target [UTILS] Capitalise first letter helper
+function capitalise(value) {
+  const text = String(value || "");
+  if (!text) return "";
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+// @target [UTILS] Percent chance roll helper
+function roll(percentChance) {
+  return Math.random() * 100 < percentChance;
+}
+
+// @target [UTILS] Choice
+function choice(list) {
+  if (!Array.isArray(list) || !list.length) return "";
+  return list[Math.floor(Math.random() * list.length)];
+}
+
+function sanitizeNarrativeText(value, fallback = "") {
+  if (value === null || value === undefined) return fallback;
+  if (typeof value === "string") return value.replace(/\[object Object\]/g, fallback || "forest").trim();
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) return sanitizeNarrativeText(value.join(" "), fallback);
+  if (typeof value === "object") {
+    if (typeof value.text === "string") return value.text.trim();
+    if (typeof value.name === "string") return value.name.trim();
+    return fallback;
+  }
+  return fallback;
+}
+
+function ensureNarrativeString(input) {
+  if (typeof input === "string") return input;
+  try {
+    if (typeof input === "function") return "[invalid text]";
+    if (typeof input === "object") return "[unreadable]";
+    return String(input);
+  } catch {
+    return "[error]";
+  }
+}
+
+function containsCodeLikeText(str) {
+  return /const [a-zA-Z_$]|function [a-zA-Z_$]|=>|&&|\|\||\{|\}/.test(str);
+}
+
+function cleanNarrative(str) {
+  if (containsCodeLikeText(str)) return "[text error]";
+  return str;
+}
+
+// @target [UTILS] Escape Html
+function escapeHtml(value) {
+  return String(value ?? "").replace(/[&<>"']/g, ch => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[ch] || ch));
+}
+
+// @target [UTILS] Clone Plain
+function clonePlain(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+// @target [UTILS] Choose Weighted
+function chooseWeighted(items) {
+  const total = items.reduce((s, item) => s + item.weight, 0);
+  let r = Math.random() * total;
+
+  for (const item of items) {
+    r -= item.weight;
+    if (r <= 0) return item;
+  }
+
+  return items[0];
+}


### PR DESCRIPTION
## Summary

Third controlled extraction in the build scaffold. Pure stateless helpers are moved to `src/utils/core-utils.js` and inlined back into `game/play.html` via the extended build script.

**Scope:** source/build structure only. No gameplay logic, encounter values, save/profile logic, or rendering changed.

---

## What changed

### New file: `src/utils/core-utils.js`

Thirteen pure stateless helper functions extracted from the `[UTILS]` section of `game/play.html`:

| Function | Reason it is pure |
|----------|------------------|
| `strengthOf(entity)` | Reads only its argument; returns a number |
| `effective(value, fitness)` | Pure arithmetic on arguments |
| `clamp(value, min, max)` | Pure arithmetic on arguments |
| `capitalise(value)` | Pure string transformation |
| `roll(percentChance)` | `Math.random()` only; no state mutation |
| `choice(list)` | `Math.random()` only; no state mutation |
| `sanitizeNarrativeText(value, fallback)` | Pure string transformation |
| `ensureNarrativeString(input)` | Pure string transformation |
| `containsCodeLikeText(str)` | Pure regex test on argument |
| `cleanNarrative(str)` | Calls only `containsCodeLikeText`; pure |
| `escapeHtml(value)` | Pure string transformation |
| `clonePlain(obj)` | JSON round-trip clone; no side effects |
| `chooseWeighted(items)` | `Math.random()` on argument; no state mutation |

All thirteen: no DOM access, no localStorage, no mutation of `player`, `world`, `currentEncounter`, `socialGroup`, `botState`, `debugLog`, or any other game state. No calls to `render`, `startTurn`, `endTurn`, action handlers, save/profile functions, or encounter resolution functions.

Not extracted (remain in `game/play.html` outside the markers): `layerNarrationChoice` (reads `layerNarration` global), `safeNarrativeText` (calls `addDebugTrace`), `addLog`, `compactVisibleMovementLog`, `setNarration`, `setGroupNotice`, `setHeard`, `setSmell`.

### `game/play.html` — `[UTILS]` section reorganised

The pure helpers now form one contiguous generated region delimited by `// BEGIN/END GENERATED JS: src/utils/core-utils.js` markers. Non-pure utilities follow immediately after the END marker, unchanged.

`chooseWeighted` was previously located after the encounter-data `[2/2]` generated region. It has been moved into the new generated region within `[UTILS]`. This is safe: `function` declarations are hoisted, so `applyHiddenSubtype` (which calls `chooseWeighted`) continues to work regardless of declaration order.

All code is byte-identical to the originals. The encounter-data regions, and all code from `[TURN]` onwards, are untouched.

### `scripts/build_play_html.mjs` extended

Now inlines three source files:
1. `src/styles/game.css` → CSS region
2. `src/data/encounter-data.js` → encounter-data regions [1/2] and [2/2]
3. `src/utils/core-utils.js` → core-utils region

Fails clearly if `src/utils/core-utils.js` or its BEGIN/END markers are missing. Idempotent.

---

## Verification

- `node scripts/build_play_html.mjs` — reports "no change" (idempotent)
- `node scripts/check_html_js_syntax.mjs` — all checks passed
- Browser render: not manually verified in this environment

---

## Documentation updated: CHANGELOG.txt, README.md, docs/current-game-structure.md, docs/architecture-notes.md, docs/release-checklist.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKFcTXWzunyBYGnVrpUzLd)_