### PR TITLE
Extract achievement definitions source

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,19 @@
+[2026-06-03 extract-achievement-data | Claude]
+Fourth controlled extraction — achievement definitions source extracted and build script extended.
+
+- Created src/data/achievement-data.js: the const ACHIEVEMENT_DEFS array (50 definitions) moved mechanically from game/play.html, byte-identical to the original.
+  - Treated as static game configuration with functions: the check callbacks remain plain JavaScript and are inlined into the same script context (no JSON conversion).
+  - No achievement keys, names, descriptions, icons, or categories changed. No check callbacks changed.
+- Edited game/play.html: the ACHIEVEMENT_DEFS block is now wrapped in // BEGIN/END GENERATED JS: src/data/achievement-data.js markers.
+  - The generated region stays exactly where ACHIEVEMENT_DEFS lived: after freshRunTracking, before loadAchievements — preserving load order and access to surrounding functions/globals.
+  - Only ACHIEVEMENT_DEFS was extracted. Achievement persistence (loadAchievements, saveAchievements, checkAchievements), profile/save logic, freshRunTracking, and achievement rendering/toast logic all remain in game/play.html. No call sites changed.
+  - game/play.html remains the directly playable artifact (no external JS dependency added).
+- Extended scripts/build_play_html.mjs: now inlines CSS, encounter data, core utils, and achievement definitions. Fails clearly if src/data/achievement-data.js or its region markers are missing, or if END precedes BEGIN. Idempotent.
+- game/evolution_game_v66_57.html NOT changed: historical archive, not kept byte-synced between releases.
+- Docs: README.md (repo layout tree + build scaffold table), docs/current-game-structure.md (line-range table, build scaffold table, extraction note), docs/architecture-notes.md (generated region + markers, line-range table, fragile-area note), docs/release-checklist.md (build step check for achievement data).
+- Verification: node scripts/build_play_html.mjs (idempotent — no change) and node scripts/check_html_js_syntax.mjs both pass. Extracted source verified to match the inline region (excluding marker comments and trailing whitespace).
+- Source/build structure change only. No gameplay logic, achievement values or callbacks, save/profile logic, rendering, CSS, encounter data, or core utility code changed.
+
 [2026-06-03 extract-core-utils | Claude]
 Third controlled extraction — pure utility helper source extracted and build script extended.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ evolution-game/
 │   ├── styles/
 │   │   └── game.css                  CSS source (inlined into play.html by the build script)
 │   ├── data/
-│   │   └── encounter-data.js         Encounter + spawn-table source (inlined into play.html by the build script)
+│   │   ├── encounter-data.js         Encounter + spawn-table source (inlined into play.html by the build script)
+│   │   └── achievement-data.js       Achievement definitions source (inlined into play.html by the build script)
 │   └── utils/
 │       └── core-utils.js             Pure utility helpers source (inlined into play.html by the build script)
 ├── docs/
@@ -136,13 +137,14 @@ The rebuild is not a rewrite, not a framework migration, and not a gameplay rede
 
 ### Build scaffold
 
-Three source extractions are complete:
+Four source extractions are complete:
 
 | Source file | What it contains | Destination in play.html |
 |-------------|-----------------|--------------------------|
 | `src/styles/game.css` | All CSS | Inline `<style>` block |
 | `src/data/encounter-data.js` | `encounters`, `encounterTables`, `hiddenSubtypePools` | Two JS regions (~line 1040 and ~line 6037) |
 | `src/utils/core-utils.js` | Pure stateless helper functions | One JS region (~line 5835) |
+| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions only; persistence stays in play.html) | One JS region (~line 4798) |
 
 `game/play.html` keeps all content **inline** so it stays directly playable with no build step or runtime dependency. To regenerate `game/play.html` after editing any source file:
 

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -8,7 +8,7 @@ This document is a map of how the game HTML file is organised. Read this before 
 
 The entire game lives in one large HTML file (`game/play.html`, ~18,400 lines). There is no build step, no bundler, and no separate JavaScript files. Everything — CSS, HTML structure, and all JavaScript — is in one file.
 
-Three source files have been extracted and are inlined back into `game/play.html` by `scripts/build_play_html.mjs`. The playable file still ships all content inline, so it works with no build step at runtime. The build script replaces only the regions between these marker comments:
+Four source files have been extracted and are inlined back into `game/play.html` by `scripts/build_play_html.mjs`. The playable file still ships all content inline, so it works with no build step at runtime. The build script replaces only the regions between these marker comments:
 
 **CSS** (inside the `<style>` block) — source `src/styles/game.css`:
 ```
@@ -38,9 +38,17 @@ Three source files have been extracted and are inlined back into `game/play.html
 // END GENERATED JS: src/utils/core-utils.js
 ```
 
-`src/data/encounter-data.js` uses a `// << SPLIT: hiddenSubtypePools >>` line to divide part 1 from part 2; the build script splits on it and inlines each part into its region. The split marker itself is not inlined. `src/utils/core-utils.js` has no split marker and maps to one contiguous region.
+**Achievement definitions** (inside the `<script>` block, ~line 4798) — the `ACHIEVEMENT_DEFS` array only:
+```
+// BEGIN GENERATED JS: src/data/achievement-data.js
+...generated js...
+// END GENERATED JS: src/data/achievement-data.js
+```
+This region sits between `freshRunTracking` and `loadAchievements`, preserving load order and access to surrounding functions/globals (e.g. the `check` callbacks reference `socialGroup`). Only the definitions array is extracted; achievement persistence (`loadAchievements`, `saveAchievements`, `checkAchievements`), profile/save logic, and achievement rendering/toast logic remain in `game/play.html`. Achievement definitions should be edited in `src/data/achievement-data.js`, not inside the generated region of `game/play.html`.
 
-**Edit CSS in `src/styles/game.css`, encounter data in `src/data/encounter-data.js`, and pure utility helpers in `src/utils/core-utils.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
+`src/data/encounter-data.js` uses a `// << SPLIT: hiddenSubtypePools >>` line to divide part 1 from part 2; the build script splits on it and inlines each part into its region. The split marker itself is not inlined. `src/utils/core-utils.js` and `src/data/achievement-data.js` have no split marker and each maps to one contiguous region.
+
+**Edit CSS in `src/styles/game.css`, encounter data in `src/data/encounter-data.js`, pure utility helpers in `src/utils/core-utils.js`, and achievement definitions in `src/data/achievement-data.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
 
 `game/evolution_game_v66_57.html` is the versioned archive of an earlier build. It is a historical snapshot and is not kept byte-in-sync with `game/play.html` between releases; `game/play.html` is the stable public-facing copy that gets replaced on each release.
 
@@ -57,7 +65,8 @@ Three source files have been extracted and are inlined back into `game/play.html
 | 1021–3501 | Static data: encounters + spawn tables — generated, source in `src/data/encounter-data.js` [1/2] |
 | 3502–4254 | World generation: terrain, habitats, altitude, water, clay deposits |
 | 4253–4791 | Player state object and dynamic world state (waterState, socialGroup, nearbyEntities) |
-| 4792–5829 | Achievements (50 defs), profiles, save/load, Field Journal, Fossil Record |
+| 4798–4863 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source in `src/data/achievement-data.js` |
+| 4865–5829 | Achievement persistence (load/save/check), profiles, save/load, Field Journal, Fossil Record |
 | 5830–5924 | Core utility helpers — generated, source in `src/utils/core-utils.js`: pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation) |
 | 5925–6036 | Remaining [UTILS]: logging, narration setters, noise, risk memory (not extracted — side effects) |
 | 6037–6115 | hiddenSubtypePools — generated, source in `src/data/encounter-data.js` [2/2] |
@@ -120,7 +129,7 @@ All rendering is done by a single `render()` call that redraws the map, UI panel
 - **`game/play.html` and `game/evolution_game_v66_57.html` must be kept in sync** on each release. If you edit one, copy the change to the other, or replace `play.html` entirely.
 - **`index.html` and `manifest.json` must both reference `game/play.html`.** The syntax check script verifies `index.html`. Check `manifest.json` manually on releases.
 - **`player.knowledge` / `player.classKnowledge`** accumulate across runs and feed the Field Journal. Incorrect resets at run boundaries lose journal data permanently.
-- **The CSS region, both encounter-data regions, and the core-utils region in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css`, `src/data/encounter-data.js`, and `src/utils/core-utils.js` instead. Do not remove any BEGIN/END marker comments or the `// << SPLIT: hiddenSubtypePools >>` line — the build script requires all of them.
+- **The CSS region, both encounter-data regions, the core-utils region, and the achievement-data region in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css`, `src/data/encounter-data.js`, `src/utils/core-utils.js`, and `src/data/achievement-data.js` instead. Do not remove any BEGIN/END marker comments or the `// << SPLIT: hiddenSubtypePools >>` line — the build script requires all of them.
 
 ---
 

--- a/docs/current-game-structure.md
+++ b/docs/current-game-structure.md
@@ -12,15 +12,16 @@ Evolution Game is a browser-based single-player survival simulation. The player 
 
 The game runs from a single HTML file (`game/play.html`, ~18,400 lines). There is no bundler and no server. Open the file in a browser and it works.
 
-Three source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
+Four source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
 
 | Source file | What it contains | In play.html |
 |-------------|-----------------|--------------|
 | `src/styles/game.css` | All CSS | Inline `<style>` block |
 | `src/data/encounter-data.js` | `encounters`, `encounterTables`, `hiddenSubtypePools` | Two inline JS regions |
 | `src/utils/core-utils.js` | Pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation helpers) | One inline JS region (~line 5835) |
+| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions array only) | One inline JS region (~line 4798) |
 
-`scripts/build_play_html.mjs` inlines all source files back into `game/play.html`. All other JavaScript engine code, HTML structure, and game state remain inside `game/play.html` for now.
+`scripts/build_play_html.mjs` inlines all source files back into `game/play.html`. Only the `ACHIEVEMENT_DEFS` definitions array is extracted — achievement persistence, profile/save logic, `checkAchievements`, and achievement rendering/toast logic all remain inside `game/play.html`. All other JavaScript engine code, HTML structure, and game state also remain inside `game/play.html` for now.
 
 ---
 
@@ -270,7 +271,8 @@ flowchart TD
 | 1021–3501 | Static data: encounter definitions + spawn tables — generated, source is `src/data/encounter-data.js` [1/2] |
 | 3631–4252 | World generation: terrain, habitats, altitude, water, clay deposits |
 | 4253–4791 | Player state object and dynamic world state (waterState, socialGroup, nearbyEntities) |
-| 4792–5829 | Achievements (50 defs), profiles, save/load, Field Journal, Fossil Record |
+| 4798–4863 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source is `src/data/achievement-data.js` |
+| 4865–5829 | Achievement persistence (load/save/check), profiles, save/load, Field Journal, Fossil Record |
 | 5830–5924 | Core utilities — generated, source is `src/utils/core-utils.js`: pure helpers (clamp, roll, choice, clonePlain, escapeHtml, etc.) |
 | 5925–6036 | Remaining utilities: logging, debug helpers, narration setters |
 | 6037–6115 | hiddenSubtypePools — generated, source is `src/data/encounter-data.js` [2/2] |
@@ -320,7 +322,8 @@ The rebuild plan (see `docs/project-plan.md`) targets extraction in this rough o
 | `src/data/encounter-data.js` [1/2] | `// BEGIN/END GENERATED JS: src/data/encounter-data.js [1/2]` |
 | `src/data/encounter-data.js` [2/2] | `// BEGIN/END GENERATED JS: src/data/encounter-data.js [2/2]` |
 | `src/utils/core-utils.js` | `// BEGIN/END GENERATED JS: src/utils/core-utils.js` |
+| `src/data/achievement-data.js` | `// BEGIN/END GENERATED JS: src/data/achievement-data.js` |
 
-The source file `src/data/encounter-data.js` contains a `// << SPLIT: hiddenSubtypePools >>` line dividing part 1 (encounters + encounterTables) from part 2 (hiddenSubtypePools). The build script splits on this marker and inlines each part into its respective location in `play.html`. `src/utils/core-utils.js` has no split marker — it maps to one contiguous region.
+The source file `src/data/encounter-data.js` contains a `// << SPLIT: hiddenSubtypePools >>` line dividing part 1 (encounters + encounterTables) from part 2 (hiddenSubtypePools). The build script splits on this marker and inlines each part into its respective location in `play.html`. `src/utils/core-utils.js` and `src/data/achievement-data.js` have no split marker — each maps to one contiguous region.
 
 Run `node scripts/build_play_html.mjs` after editing any source file. Do not hand-edit generated regions in `game/play.html`. This document will be updated as each further extraction completes.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -17,7 +17,8 @@ Run through this every time a new version becomes the stable build.
 - [ ] If `src/styles/game.css` was changed, `node scripts/build_play_html.mjs` was run to inline the CSS into `game/play.html`
 - [ ] If `src/data/encounter-data.js` was changed, `node scripts/build_play_html.mjs` was run to inline the encounter data into `game/play.html`
 - [ ] If `src/utils/core-utils.js` was changed, `node scripts/build_play_html.mjs` was run to inline the utility helpers into `game/play.html`
-- [ ] The generated regions in `game/play.html` were not hand-edited (CSS changes go in `src/styles/game.css`; encounter data changes go in `src/data/encounter-data.js`; utility helper changes go in `src/utils/core-utils.js`)
+- [ ] If `src/data/achievement-data.js` was changed, `node scripts/build_play_html.mjs` was run to inline the achievement definitions into `game/play.html`
+- [ ] The generated regions in `game/play.html` were not hand-edited (CSS changes go in `src/styles/game.css`; encounter data changes go in `src/data/encounter-data.js`; utility helper changes go in `src/utils/core-utils.js`; achievement definition changes go in `src/data/achievement-data.js`)
 
 ## Syntax and render check
 

--- a/game/play.html
+++ b/game/play.html
@@ -4795,6 +4795,7 @@ function freshRunTracking() {
 // [ACHIEVEMENTS] Definitions and persistence
 // ---------------------------------------------------------------------------
 
+// BEGIN GENERATED JS: src/data/achievement-data.js
 const ACHIEVEMENT_DEFS = [
   // --- Survival ---
   { key: "survive_10",    cat: "Survival", icon: "🌿", name: "First Light",        desc: "Survive 10 turns.",                        check: (p) => (p.turn || 0) >= 10 },
@@ -4859,6 +4860,7 @@ const ACHIEVEMENT_DEFS = [
   { key: "full_stats",    cat: "Milestones", icon: "✨", name: "Peak Condition",  desc: "End a turn at 100 fitness, energy, and hydration.", check: (p) => (p.fitness || 0) >= 100 && (p.energy || 0) >= 100 && (p.hydration || 0) >= 100 },
   { key: "alerted",       cat: "Milestones", icon: "👂", name: "Sentinel",        desc: "Use the Alert action 3 times in a run.",   check: (p, rt) => (rt.alertedCount || 0) >= 3 }
 ];
+// END GENERATED JS: src/data/achievement-data.js
 
 function loadAchievements(profileId) {
   try {

--- a/scripts/build_play_html.mjs
+++ b/scripts/build_play_html.mjs
@@ -10,6 +10,7 @@
 //        [1/2] encounters + encounterTables  (~line 1040)
 //        [2/2] hiddenSubtypePools            (~line 6037)
 //   3. src/utils/core-utils.js    → one JS region (~line 5833)
+//   4. src/data/achievement-data.js → one JS region (~line 4798)
 //
 // Why inline (not external files): game/play.html must open straight from
 // disk — or via the GitHub Pages link — with no build step and no runtime
@@ -27,10 +28,11 @@ import { dirname, resolve } from 'node:path';
 const here     = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..');
 
-const CSS_SOURCE   = resolve(repoRoot, 'src/styles/game.css');
-const DATA_SOURCE  = resolve(repoRoot, 'src/data/encounter-data.js');
-const UTILS_SOURCE = resolve(repoRoot, 'src/utils/core-utils.js');
-const PLAY_HTML    = resolve(repoRoot, 'game/play.html');
+const CSS_SOURCE    = resolve(repoRoot, 'src/styles/game.css');
+const DATA_SOURCE   = resolve(repoRoot, 'src/data/encounter-data.js');
+const UTILS_SOURCE  = resolve(repoRoot, 'src/utils/core-utils.js');
+const ACHIEVE_SOURCE = resolve(repoRoot, 'src/data/achievement-data.js');
+const PLAY_HTML     = resolve(repoRoot, 'game/play.html');
 
 // CSS markers (CSS comment style, inside <style>)
 const CSS_BEGIN = '/* BEGIN GENERATED CSS: src/styles/game.css */';
@@ -45,6 +47,10 @@ const JS_END2   = '// END GENERATED JS: src/data/encounter-data.js [2/2]';
 // Core-utils markers (JS comment style, inside <script>)
 const JS_BEGIN_UTILS = '// BEGIN GENERATED JS: src/utils/core-utils.js';
 const JS_END_UTILS   = '// END GENERATED JS: src/utils/core-utils.js';
+
+// Achievement-data markers (JS comment style, inside <script>)
+const JS_BEGIN_ACHIEVE = '// BEGIN GENERATED JS: src/data/achievement-data.js';
+const JS_END_ACHIEVE   = '// END GENERATED JS: src/data/achievement-data.js';
 
 // The split comment that divides the source file into part1 and part2.
 // It is NOT inlined into game/play.html.
@@ -70,15 +76,17 @@ function inlineRegion(html, beginMarker, endMarker, body, label) {
 }
 
 // --- Read sources ---
-if (!existsSync(CSS_SOURCE))   fail('cannot find src/styles/game.css');
-if (!existsSync(DATA_SOURCE))  fail('cannot find src/data/encounter-data.js');
-if (!existsSync(UTILS_SOURCE)) fail('cannot find src/utils/core-utils.js');
-if (!existsSync(PLAY_HTML))    fail('cannot find game/play.html');
+if (!existsSync(CSS_SOURCE))     fail('cannot find src/styles/game.css');
+if (!existsSync(DATA_SOURCE))    fail('cannot find src/data/encounter-data.js');
+if (!existsSync(UTILS_SOURCE))   fail('cannot find src/utils/core-utils.js');
+if (!existsSync(ACHIEVE_SOURCE)) fail('cannot find src/data/achievement-data.js');
+if (!existsSync(PLAY_HTML))      fail('cannot find game/play.html');
 
-const css      = readFileSync(CSS_SOURCE,   'utf8');
-const jsData   = readFileSync(DATA_SOURCE,  'utf8');
-const jsUtils  = readFileSync(UTILS_SOURCE, 'utf8');
-let   html     = readFileSync(PLAY_HTML,    'utf8');
+const css       = readFileSync(CSS_SOURCE,     'utf8');
+const jsData    = readFileSync(DATA_SOURCE,    'utf8');
+const jsUtils   = readFileSync(UTILS_SOURCE,   'utf8');
+const jsAchieve = readFileSync(ACHIEVE_SOURCE, 'utf8');
+let   html      = readFileSync(PLAY_HTML,      'utf8');
 
 // --- Split encounter-data into two parts at the SPLIT marker ---
 const splitIdx = jsData.indexOf(JS_SPLIT);
@@ -86,12 +94,13 @@ if (splitIdx === -1) fail(`missing split marker in src/data/encounter-data.js: $
 const jsPart1 = jsData.slice(0, splitIdx).replace(/\s+$/, '');
 const jsPart2 = jsData.slice(splitIdx + JS_SPLIT.length).replace(/^\n/, '').replace(/\s+$/, '');
 
-// --- Apply all three regions ---
+// --- Apply all regions ---
 const original = html;
-html = inlineRegion(html, CSS_BEGIN,      CSS_END,      css.replace(/\s+$/, ''), 'CSS');
-html = inlineRegion(html, JS_BEGIN1,      JS_END1,      jsPart1, 'encounter-data [1/2]');
-html = inlineRegion(html, JS_BEGIN2,      JS_END2,      jsPart2, 'encounter-data [2/2]');
-html = inlineRegion(html, JS_BEGIN_UTILS, JS_END_UTILS, jsUtils.replace(/\s+$/, ''), 'core-utils');
+html = inlineRegion(html, CSS_BEGIN,        CSS_END,        css.replace(/\s+$/, ''), 'CSS');
+html = inlineRegion(html, JS_BEGIN1,        JS_END1,        jsPart1, 'encounter-data [1/2]');
+html = inlineRegion(html, JS_BEGIN2,        JS_END2,        jsPart2, 'encounter-data [2/2]');
+html = inlineRegion(html, JS_BEGIN_UTILS,   JS_END_UTILS,   jsUtils.replace(/\s+$/, ''), 'core-utils');
+html = inlineRegion(html, JS_BEGIN_ACHIEVE, JS_END_ACHIEVE, jsAchieve.replace(/\s+$/, ''), 'achievement-data');
 
 if (html === original) {
   console.log('build_play_html: no change — game/play.html already matches all source files.');

--- a/src/data/achievement-data.js
+++ b/src/data/achievement-data.js
@@ -1,0 +1,64 @@
+const ACHIEVEMENT_DEFS = [
+  // --- Survival ---
+  { key: "survive_10",    cat: "Survival", icon: "🌿", name: "First Light",        desc: "Survive 10 turns.",                        check: (p) => (p.turn || 0) >= 10 },
+  { key: "survive_50",    cat: "Survival", icon: "🌿", name: "Foothold",           desc: "Survive 50 turns.",                        check: (p) => (p.turn || 0) >= 50 },
+  { key: "survive_100",   cat: "Survival", icon: "🌿", name: "Century",            desc: "Survive 100 turns.",                       check: (p) => (p.turn || 0) >= 100 },
+  { key: "survive_250",   cat: "Survival", icon: "🌿", name: "Deep Eocene",        desc: "Survive 250 turns.",                       check: (p) => (p.turn || 0) >= 250 },
+  { key: "survive_500",   cat: "Survival", icon: "🌿", name: "Ancient One",        desc: "Survive 500 turns.",                       check: (p) => (p.turn || 0) >= 500 },
+  { key: "night_3",       cat: "Survival", icon: "🌑", name: "Night Watch",        desc: "Survive 3 nights in a single run.",        check: (p, rt) => (rt.nightSurvivedCount || 0) >= 3 },
+  { key: "night_10",      cat: "Survival", icon: "🌑", name: "Creature of the Dark", desc: "Survive 10 nights in a single run.",    check: (p, rt) => (rt.nightSurvivedCount || 0) >= 10 },
+  { key: "low_fit_surv",  cat: "Survival", icon: "💀", name: "Last Breath",        desc: "Survive a turn at 10 fitness or below.",   check: (p, rt) => rt.wasNearDeath === true },
+  { key: "poison_surv",   cat: "Survival", icon: "☠", name: "Resilient",          desc: "Survive any poison.",                      check: (p, rt) => rt.poisonSurvived === true },
+  { key: "poison_deadly", cat: "Survival", icon: "☠", name: "Iron Gut",           desc: "Survive a deadly poison.",                 check: (p, rt) => (rt.worstPoisonRank || 0) >= 5 },
+
+  // --- Foraging ---
+  { key: "eat_fruit",     cat: "Foraging", icon: "🍎", name: "First Taste",        desc: "Eat a fruit.",                             check: (p, rt) => (rt.fruitEaten || 0) >= 1 },
+  { key: "eat_insect",    cat: "Foraging", icon: "🐛", name: "Bug Hunter",         desc: "Eat an insect.",                           check: (p, rt) => (rt.insectEaten || 0) >= 1 },
+  { key: "eat_fungus",    cat: "Foraging", icon: "🍄", name: "Mycophile",          desc: "Eat a fungus.",                            check: (p, rt) => (rt.fungusEaten || 0) >= 1 },
+  { key: "eat_meat",      cat: "Foraging", icon: "🦴", name: "Scavenger",          desc: "Eat meat from a carcass.",                 check: (p, rt) => (rt.meatEaten || 0) >= 1 },
+  { key: "eat_5types",    cat: "Foraging", icon: "🌾", name: "Opportunist",        desc: "Eat 5 different food types in one run.",   check: (p, rt) => Object.keys(rt.foodTypesEaten || {}).length >= 5 },
+  { key: "eat_10types",   cat: "Foraging", icon: "🌾", name: "Generalist",         desc: "Eat 10 different food types in one run.",  check: (p, rt) => Object.keys(rt.foodTypesEaten || {}).length >= 10 },
+  { key: "eat_fruit_20",  cat: "Foraging", icon: "🍎", name: "Frugivore",          desc: "Eat 20 fruits in a single run.",           check: (p, rt) => (rt.fruitEaten || 0) >= 20 },
+  { key: "eat_insect_10", cat: "Foraging", icon: "🐛", name: "Insectivore",        desc: "Eat 10 insects in a single run.",          check: (p, rt) => (rt.insectEaten || 0) >= 10 },
+  { key: "water_10",      cat: "Foraging", icon: "💧", name: "Hydrated",           desc: "Drink water 10 times in a single run.",    check: (p, rt) => (rt.waterDrank || 0) >= 10 },
+  { key: "knowledge_5",   cat: "Foraging", icon: "📖", name: "Field Naturalist",   desc: "Learn 5 foods across all runs.",           check: (p, rt, ps) => Object.keys(p.knownFoods || {}).length >= 5 },
+
+  // --- Exploration ---
+  { key: "explore_25",    cat: "Exploration", icon: "🗺", name: "Wanderer",         desc: "Explore 25 tiles in a single run.",        check: (p, rt) => (rt.tilesExplored || 0) >= 25 },
+  { key: "explore_100",   cat: "Exploration", icon: "🗺", name: "Trailblazer",      desc: "Explore 100 tiles in a single run.",       check: (p, rt) => (rt.tilesExplored || 0) >= 100 },
+  { key: "explore_250",   cat: "Exploration", icon: "🗺", name: "Cartographer",     desc: "Explore 250 tiles in a single run.",       check: (p, rt) => (rt.tilesExplored || 0) >= 250 },
+  { key: "investigate_3", cat: "Exploration", icon: "🔍", name: "Curious Mind",     desc: "Investigate 3 encounters in a run.",       check: (p, rt) => (rt.investigatedCount || 0) >= 3 },
+  { key: "investigate_10",cat: "Exploration", icon: "🔍", name: "Scholar",          desc: "Investigate 10 encounters in a run.",      check: (p, rt) => (rt.investigatedCount || 0) >= 10 },
+  { key: "journal_5",     cat: "Exploration", icon: "📕", name: "Archivist",        desc: "Record 5 species in the Field Journal.",   check: (p, rt, ps) => Object.keys(p.knowledgeByEncounterKey || {}).length >= 5 },
+  { key: "journal_20",    cat: "Exploration", icon: "📕", name: "Encyclopaedist",   desc: "Record 20 species in the Field Journal.",  check: (p, rt, ps) => Object.keys(p.knowledgeByEncounterKey || {}).length >= 20 },
+
+  // --- Social ---
+  { key: "join_group",    cat: "Social",   icon: "🐒", name: "Safety in Numbers", desc: "Join a social group.",                     check: (p, rt) => rt.groupEverJoined === true },
+  { key: "mate_once",     cat: "Social",   icon: "❤", name: "Courtship",         desc: "Attempt mating.",                          check: (p, rt) => rt.matingAttempted === true },
+  { key: "mate_3",        cat: "Social",   icon: "❤", name: "Progenitor",        desc: "Mate 3 times across all runs.",            check: (p, rt, ps) => (ps.totalMatings || 0) >= 3 },
+  { key: "groom_3",       cat: "Social",   icon: "🙈", name: "Groomer",           desc: "Groom a companion 3 times in a run.",      check: (p, rt) => (rt.groomedCount || 0) >= 3 },
+  { key: "companion_save",cat: "Social",   icon: "🛡", name: "Protector",         desc: "Have a companion intercept a predator.",   check: (p, rt) => rt.companionInterceptHit === true },
+  { key: "group_5",       cat: "Social",   icon: "🐒", name: "Troop",             desc: "Be in a group of 5+ companions.",          check: (p) => (socialGroup && socialGroup.members && socialGroup.members.length >= 5) },
+
+  // --- Danger ---
+  { key: "escape_1",      cat: "Danger",   icon: "💨", name: "Close Call",        desc: "Escape a predator pursuit.",               check: (p, rt) => (rt.pursuitsEscaped || 0) >= 1 },
+  { key: "escape_5",      cat: "Danger",   icon: "💨", name: "Ghost",             desc: "Escape 5 predator pursuits in a run.",     check: (p, rt) => (rt.pursuitsEscaped || 0) >= 5 },
+  { key: "escape_10",     cat: "Danger",   icon: "💨", name: "Untouchable",       desc: "Escape 10 predator pursuits in a run.",    check: (p, rt) => (rt.pursuitsEscaped || 0) >= 10 },
+  { key: "survive_wildfire", cat: "Danger",icon: "🔥", name: "Through the Flames",desc: "Survive a wildfire.",                      check: (p, rt) => rt.wildfireEscaped === true },
+
+  // --- Growth ---
+  { key: "grown",         cat: "Growth",   icon: "🌱", name: "Coming of Age",     desc: "Grow to adult size.",                      check: (p) => (p.size || 0) >= 10 },
+  { key: "turns_100_profile", cat: "Growth", icon: "⏳", name: "Seasoned",        desc: "Accumulate 100 turns across all runs.",    check: (p, rt, ps) => (ps.totalTurns || 0) >= 100 },
+  { key: "turns_500_profile", cat: "Growth", icon: "⏳", name: "Veteran",         desc: "Accumulate 500 turns across all runs.",    check: (p, rt, ps) => (ps.totalTurns || 0) >= 500 },
+  { key: "turns_1000_profile",cat: "Growth", icon: "⏳", name: "Elder",           desc: "Accumulate 1000 turns across all runs.",   check: (p, rt, ps) => (ps.totalTurns || 0) >= 1000 },
+  { key: "runs_5",        cat: "Growth",   icon: "🔁", name: "Persistent",        desc: "Complete 5 runs.",                         check: (p, rt, ps) => (ps.totalRuns || 0) >= 5 },
+  { key: "runs_20",       cat: "Growth",   icon: "🔁", name: "Indomitable",       desc: "Complete 20 runs.",                        check: (p, rt, ps) => (ps.totalRuns || 0) >= 20 },
+
+  // --- Milestones ---
+  { key: "first_death",   cat: "Milestones", icon: "🪦", name: "Fossil",          desc: "Die for the first time.",                  check: (p, rt, ps) => (ps.totalRuns || 0) >= 1 },
+  { key: "best_50",       cat: "Milestones", icon: "🏆", name: "Record Holder",   desc: "Survive 50 turns in a single run.",        check: (p, rt, ps) => (ps.bestTurn || 0) >= 50 },
+  { key: "best_200",      cat: "Milestones", icon: "🏆", name: "Champion",        desc: "Survive 200 turns in a single run.",       check: (p, rt, ps) => (ps.bestTurn || 0) >= 200 },
+  { key: "companion_1",   cat: "Milestones", icon: "👁", name: "Not Alone",       desc: "Recruit your first companion.",            check: (p, rt) => rt.groupEverJoined === true },
+  { key: "full_stats",    cat: "Milestones", icon: "✨", name: "Peak Condition",  desc: "End a turn at 100 fitness, energy, and hydration.", check: (p) => (p.fitness || 0) >= 100 && (p.energy || 0) >= 100 && (p.hydration || 0) >= 100 },
+  { key: "alerted",       cat: "Milestones", icon: "👂", name: "Sentinel",        desc: "Use the Alert action 3 times in a run.",   check: (p, rt) => (rt.alertedCount || 0) >= 3 }
+];


### PR DESCRIPTION
## Summary

Fourth controlled extraction in the build scaffold. The `ACHIEVEMENT_DEFS` definitions array is moved to a source file and inlined back into `game/play.html` via the extended build script.

- `src/data/achievement-data.js` now holds `ACHIEVEMENT_DEFS`.
- `game/play.html` remains the directly playable artifact.
- `scripts/build_play_html.mjs` now inlines CSS, encounter data, core utils, and achievement definitions.
- Only `ACHIEVEMENT_DEFS` was extracted.
- Achievement persistence logic remains in `game/play.html`.
- Profile/save logic remains in `game/play.html`.
- No gameplay logic changed.
- No achievement values or callbacks changed.
- No call sites changed.

**Scope:** source/build structure only.

---

## What changed

### New file: `src/data/achievement-data.js`

Contains exactly `const ACHIEVEMENT_DEFS = [ ... ];` (50 definitions), moved mechanically and byte-identical to the original. `ACHIEVEMENT_DEFS` includes `check` callbacks, so it is treated as static game configuration with functions, not pure JSON — it remains plain JavaScript and is inlined into the same script context.

### `game/play.html` — generated region added

The `ACHIEVEMENT_DEFS` block is now wrapped in:
```
// BEGIN GENERATED JS: src/data/achievement-data.js
...inlined ACHIEVEMENT_DEFS...
// END GENERATED JS: src/data/achievement-data.js
```
The region stays exactly where `ACHIEVEMENT_DEFS` lived — after `freshRunTracking`, before `loadAchievements` — preserving load order and access to surrounding functions/globals (the `check` callbacks reference `socialGroup`).

### `scripts/build_play_html.mjs` extended

Now inlines four source files:
1. `src/styles/game.css` → CSS region
2. `src/data/encounter-data.js` → encounter-data regions [1/2] and [2/2]
3. `src/utils/core-utils.js` → core-utils region
4. `src/data/achievement-data.js` → achievement-data region

Fails clearly if `src/data/achievement-data.js` or its BEGIN/END markers are missing, or if END precedes BEGIN. Replaces only marked regions. Idempotent.

---

## Verification

- `ACHIEVEMENT_DEFS` was the only extracted declaration (one top-level declaration in the region).
- The extracted source and generated inline block match, excluding marker comments and trailing whitespace (verified with `diff`).
- No achievement keys changed.
- No names / descriptions / icons / categories changed.
- No `check` callbacks changed.
- No call sites changed.
- No gameplay logic changed.
- No save/profile logic changed.
- No rendering changed.
- No CSS changed.
- No encounter data changed.
- No core utility code changed.
- `node scripts/build_play_html.mjs` — reports "no change" (idempotent).
- `node scripts/check_html_js_syntax.mjs` — all checks passed.
- Browser manual check not run by Claude; awaiting George's browser smoke test.

---

Documentation updated: README.md, docs/current-game-structure.md, docs/architecture-notes.md, docs/release-checklist.md, CHANGELOG.txt

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKFcTXWzunyBYGnVrpUzLd)_