### PR TITLE
Extract run tracking state factory source

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,19 @@
+[2026-06-03 extract-run-tracking | Claude]
+Fifth controlled extraction — run-tracking state factory source extracted and build script extended.
+
+- Created src/state/run-tracking.js: the freshRunTracking() function moved mechanically from game/play.html, byte-identical to the original.
+  - freshRunTracking() returns the initial run-tracking state object used to reset per-run stats at the start of each run (food counts, poison history, pursuit escapes, night survival, tile exploration, etc.).
+  - No field names changed. No default values changed. Set usage unchanged.
+- Edited game/play.html: the freshRunTracking() block is now wrapped in // BEGIN/END GENERATED JS: src/state/run-tracking.js markers.
+  - The generated region stays exactly where freshRunTracking() lived: after profileUpdateStats, before the [ACHIEVEMENTS] section — preserving load order.
+  - Only freshRunTracking() was extracted. profileUpdateStats, profile/save logic, achievement logic, and all other run-management code remain in game/play.html. No call sites changed.
+  - game/play.html remains the directly playable artifact.
+- Extended scripts/build_play_html.mjs: now inlines CSS, encounter data, core utils, achievement definitions, and run-tracking state factory. Fails clearly if src/state/run-tracking.js or its region markers are missing. Idempotent.
+- game/evolution_game_v66_57.html NOT changed: historical archive, not kept byte-synced between releases.
+- Docs: README.md (repo layout tree + build scaffold table), docs/current-game-structure.md (line-range table, build scaffold table), docs/architecture-notes.md (generated region + markers, line-range table, fragile-area note), docs/release-checklist.md (build step check for run-tracking).
+- Verification: node scripts/build_play_html.mjs (idempotent — no change) and node scripts/check_html_js_syntax.mjs both pass. Extracted source verified to match the inline region (excluding markers and trailing whitespace).
+- Source/build structure change only. No gameplay logic, run-tracking fields or defaults, save/profile logic, achievement logic, rendering, CSS, encounter data, or core utility code changed.
+
 [2026-06-03 extract-achievement-data | Claude]
 Fourth controlled extraction — achievement definitions source extracted and build script extended.
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ evolution-game/
 │   ├── data/
 │   │   ├── encounter-data.js         Encounter + spawn-table source (inlined into play.html by the build script)
 │   │   └── achievement-data.js       Achievement definitions source (inlined into play.html by the build script)
-│   └── utils/
-│       └── core-utils.js             Pure utility helpers source (inlined into play.html by the build script)
+│   ├── utils/
+│   │   └── core-utils.js             Pure utility helpers source (inlined into play.html by the build script)
+│   └── state/
+│       └── run-tracking.js           Run-tracking state factory source (inlined into play.html by the build script)
 ├── docs/
 │   ├── current-game-structure.md     How the game works now: systems, flows, line ranges
 │   ├── documentation-map.md          What each doc covers and when to update it
@@ -137,14 +139,15 @@ The rebuild is not a rewrite, not a framework migration, and not a gameplay rede
 
 ### Build scaffold
 
-Four source extractions are complete:
+Five source extractions are complete:
 
 | Source file | What it contains | Destination in play.html |
 |-------------|-----------------|--------------------------|
 | `src/styles/game.css` | All CSS | Inline `<style>` block |
 | `src/data/encounter-data.js` | `encounters`, `encounterTables`, `hiddenSubtypePools` | Two JS regions (~line 1040 and ~line 6037) |
 | `src/utils/core-utils.js` | Pure stateless helper functions | One JS region (~line 5835) |
-| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions only; persistence stays in play.html) | One JS region (~line 4798) |
+| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions only; persistence stays in play.html) | One JS region (~line 4800) |
+| `src/state/run-tracking.js` | `freshRunTracking()` (factory only; save/profile logic stays in play.html) | One JS region (~line 4763) |
 
 `game/play.html` keeps all content **inline** so it stays directly playable with no build step or runtime dependency. To regenerate `game/play.html` after editing any source file:
 

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -8,7 +8,7 @@ This document is a map of how the game HTML file is organised. Read this before 
 
 The entire game lives in one large HTML file (`game/play.html`, ~18,400 lines). There is no build step, no bundler, and no separate JavaScript files. Everything — CSS, HTML structure, and all JavaScript — is in one file.
 
-Four source files have been extracted and are inlined back into `game/play.html` by `scripts/build_play_html.mjs`. The playable file still ships all content inline, so it works with no build step at runtime. The build script replaces only the regions between these marker comments:
+Five source files have been extracted and are inlined back into `game/play.html` by `scripts/build_play_html.mjs`. The playable file still ships all content inline, so it works with no build step at runtime. The build script replaces only the regions between these marker comments:
 
 **CSS** (inside the `<style>` block) — source `src/styles/game.css`:
 ```
@@ -38,7 +38,15 @@ Four source files have been extracted and are inlined back into `game/play.html`
 // END GENERATED JS: src/utils/core-utils.js
 ```
 
-**Achievement definitions** (inside the `<script>` block, ~line 4798) — the `ACHIEVEMENT_DEFS` array only:
+**Run-tracking state factory** (inside the `<script>` block, ~line 4763) — the `freshRunTracking()` function only:
+```
+// BEGIN GENERATED JS: src/state/run-tracking.js
+...generated js...
+// END GENERATED JS: src/state/run-tracking.js
+```
+This region sits between the profile-stats update code and the `[ACHIEVEMENTS]` section, preserving load order. Only the `freshRunTracking()` factory is extracted; profile/save logic, `profileUpdateStats`, achievement logic, and all other run-management code remain in `game/play.html`. The run-tracking state factory should be edited in `src/state/run-tracking.js`, not inside the generated region of `game/play.html`.
+
+**Achievement definitions** (inside the `<script>` block, ~line 4800) — the `ACHIEVEMENT_DEFS` array only:
 ```
 // BEGIN GENERATED JS: src/data/achievement-data.js
 ...generated js...
@@ -46,9 +54,9 @@ Four source files have been extracted and are inlined back into `game/play.html`
 ```
 This region sits between `freshRunTracking` and `loadAchievements`, preserving load order and access to surrounding functions/globals (e.g. the `check` callbacks reference `socialGroup`). Only the definitions array is extracted; achievement persistence (`loadAchievements`, `saveAchievements`, `checkAchievements`), profile/save logic, and achievement rendering/toast logic remain in `game/play.html`. Achievement definitions should be edited in `src/data/achievement-data.js`, not inside the generated region of `game/play.html`.
 
-`src/data/encounter-data.js` uses a `// << SPLIT: hiddenSubtypePools >>` line to divide part 1 from part 2; the build script splits on it and inlines each part into its region. The split marker itself is not inlined. `src/utils/core-utils.js` and `src/data/achievement-data.js` have no split marker and each maps to one contiguous region.
+`src/data/encounter-data.js` uses a `// << SPLIT: hiddenSubtypePools >>` line to divide part 1 from part 2; the build script splits on it and inlines each part into its region. The split marker itself is not inlined. All other source files have no split marker and each maps to one contiguous region.
 
-**Edit CSS in `src/styles/game.css`, encounter data in `src/data/encounter-data.js`, pure utility helpers in `src/utils/core-utils.js`, and achievement definitions in `src/data/achievement-data.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
+**Edit CSS in `src/styles/game.css`, encounter data in `src/data/encounter-data.js`, pure utility helpers in `src/utils/core-utils.js`, achievement definitions in `src/data/achievement-data.js`, and run-tracking factory in `src/state/run-tracking.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
 
 `game/evolution_game_v66_57.html` is the versioned archive of an earlier build. It is a historical snapshot and is not kept byte-in-sync with `game/play.html` between releases; `game/play.html` is the stable public-facing copy that gets replaced on each release.
 
@@ -65,8 +73,9 @@ This region sits between `freshRunTracking` and `loadAchievements`, preserving l
 | 1021–3501 | Static data: encounters + spawn tables — generated, source in `src/data/encounter-data.js` [1/2] |
 | 3502–4254 | World generation: terrain, habitats, altitude, water, clay deposits |
 | 4253–4791 | Player state object and dynamic world state (waterState, socialGroup, nearbyEntities) |
-| 4798–4863 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source in `src/data/achievement-data.js` |
-| 4865–5829 | Achievement persistence (load/save/check), profiles, save/load, Field Journal, Fossil Record |
+| 4763–4794 | Run-tracking state factory (`freshRunTracking`) — generated, source in `src/state/run-tracking.js` |
+| 4800–4865 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source in `src/data/achievement-data.js` |
+| 4867–5829 | Achievement persistence (load/save/check), profile stats, profiles, save/load, Field Journal, Fossil Record |
 | 5830–5924 | Core utility helpers — generated, source in `src/utils/core-utils.js`: pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation) |
 | 5925–6036 | Remaining [UTILS]: logging, narration setters, noise, risk memory (not extracted — side effects) |
 | 6037–6115 | hiddenSubtypePools — generated, source in `src/data/encounter-data.js` [2/2] |
@@ -129,7 +138,7 @@ All rendering is done by a single `render()` call that redraws the map, UI panel
 - **`game/play.html` and `game/evolution_game_v66_57.html` must be kept in sync** on each release. If you edit one, copy the change to the other, or replace `play.html` entirely.
 - **`index.html` and `manifest.json` must both reference `game/play.html`.** The syntax check script verifies `index.html`. Check `manifest.json` manually on releases.
 - **`player.knowledge` / `player.classKnowledge`** accumulate across runs and feed the Field Journal. Incorrect resets at run boundaries lose journal data permanently.
-- **The CSS region, both encounter-data regions, the core-utils region, and the achievement-data region in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css`, `src/data/encounter-data.js`, `src/utils/core-utils.js`, and `src/data/achievement-data.js` instead. Do not remove any BEGIN/END marker comments or the `// << SPLIT: hiddenSubtypePools >>` line — the build script requires all of them.
+- **The CSS region, both encounter-data regions, the core-utils region, the achievement-data region, and the run-tracking region in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css`, `src/data/encounter-data.js`, `src/utils/core-utils.js`, `src/data/achievement-data.js`, and `src/state/run-tracking.js` instead. Do not remove any BEGIN/END marker comments or the `// << SPLIT: hiddenSubtypePools >>` line — the build script requires all of them.
 
 ---
 

--- a/docs/current-game-structure.md
+++ b/docs/current-game-structure.md
@@ -12,16 +12,17 @@ Evolution Game is a browser-based single-player survival simulation. The player 
 
 The game runs from a single HTML file (`game/play.html`, ~18,400 lines). There is no bundler and no server. Open the file in a browser and it works.
 
-Four source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
+Five source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
 
 | Source file | What it contains | In play.html |
 |-------------|-----------------|--------------|
 | `src/styles/game.css` | All CSS | Inline `<style>` block |
 | `src/data/encounter-data.js` | `encounters`, `encounterTables`, `hiddenSubtypePools` | Two inline JS regions |
 | `src/utils/core-utils.js` | Pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation helpers) | One inline JS region (~line 5835) |
-| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions array only) | One inline JS region (~line 4798) |
+| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions array only) | One inline JS region (~line 4800) |
+| `src/state/run-tracking.js` | `freshRunTracking()` factory (run-tracking schema only) | One inline JS region (~line 4763) |
 
-`scripts/build_play_html.mjs` inlines all source files back into `game/play.html`. Only the `ACHIEVEMENT_DEFS` definitions array is extracted — achievement persistence, profile/save logic, `checkAchievements`, and achievement rendering/toast logic all remain inside `game/play.html`. All other JavaScript engine code, HTML structure, and game state also remain inside `game/play.html` for now.
+`scripts/build_play_html.mjs` inlines all source files back into `game/play.html`. Only the `ACHIEVEMENT_DEFS` definitions array and the `freshRunTracking()` factory function are extracted — achievement persistence, profile/save logic, `checkAchievements`, achievement rendering/toast logic, and all other game state management remain inside `game/play.html`. All other JavaScript engine code and HTML structure also remain inside `game/play.html` for now.
 
 ---
 
@@ -271,8 +272,9 @@ flowchart TD
 | 1021–3501 | Static data: encounter definitions + spawn tables — generated, source is `src/data/encounter-data.js` [1/2] |
 | 3631–4252 | World generation: terrain, habitats, altitude, water, clay deposits |
 | 4253–4791 | Player state object and dynamic world state (waterState, socialGroup, nearbyEntities) |
-| 4798–4863 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source is `src/data/achievement-data.js` |
-| 4865–5829 | Achievement persistence (load/save/check), profiles, save/load, Field Journal, Fossil Record |
+| 4763–4794 | Run-tracking state factory (`freshRunTracking`) — generated, source is `src/state/run-tracking.js` |
+| 4800–4865 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source is `src/data/achievement-data.js` |
+| 4867–5829 | Achievement persistence (load/save/check), profile stats, profiles, save/load, Field Journal, Fossil Record |
 | 5830–5924 | Core utilities — generated, source is `src/utils/core-utils.js`: pure helpers (clamp, roll, choice, clonePlain, escapeHtml, etc.) |
 | 5925–6036 | Remaining utilities: logging, debug helpers, narration setters |
 | 6037–6115 | hiddenSubtypePools — generated, source is `src/data/encounter-data.js` [2/2] |
@@ -323,7 +325,8 @@ The rebuild plan (see `docs/project-plan.md`) targets extraction in this rough o
 | `src/data/encounter-data.js` [2/2] | `// BEGIN/END GENERATED JS: src/data/encounter-data.js [2/2]` |
 | `src/utils/core-utils.js` | `// BEGIN/END GENERATED JS: src/utils/core-utils.js` |
 | `src/data/achievement-data.js` | `// BEGIN/END GENERATED JS: src/data/achievement-data.js` |
+| `src/state/run-tracking.js` | `// BEGIN/END GENERATED JS: src/state/run-tracking.js` |
 
-The source file `src/data/encounter-data.js` contains a `// << SPLIT: hiddenSubtypePools >>` line dividing part 1 (encounters + encounterTables) from part 2 (hiddenSubtypePools). The build script splits on this marker and inlines each part into its respective location in `play.html`. `src/utils/core-utils.js` and `src/data/achievement-data.js` have no split marker — each maps to one contiguous region.
+The source file `src/data/encounter-data.js` contains a `// << SPLIT: hiddenSubtypePools >>` line dividing part 1 (encounters + encounterTables) from part 2 (hiddenSubtypePools). The build script splits on this marker and inlines each part into its respective location in `play.html`. All other source files have no split marker — each maps to one contiguous region.
 
 Run `node scripts/build_play_html.mjs` after editing any source file. Do not hand-edit generated regions in `game/play.html`. This document will be updated as each further extraction completes.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -18,7 +18,8 @@ Run through this every time a new version becomes the stable build.
 - [ ] If `src/data/encounter-data.js` was changed, `node scripts/build_play_html.mjs` was run to inline the encounter data into `game/play.html`
 - [ ] If `src/utils/core-utils.js` was changed, `node scripts/build_play_html.mjs` was run to inline the utility helpers into `game/play.html`
 - [ ] If `src/data/achievement-data.js` was changed, `node scripts/build_play_html.mjs` was run to inline the achievement definitions into `game/play.html`
-- [ ] The generated regions in `game/play.html` were not hand-edited (CSS changes go in `src/styles/game.css`; encounter data changes go in `src/data/encounter-data.js`; utility helper changes go in `src/utils/core-utils.js`; achievement definition changes go in `src/data/achievement-data.js`)
+- [ ] If `src/state/run-tracking.js` was changed, `node scripts/build_play_html.mjs` was run to inline the run-tracking factory into `game/play.html`
+- [ ] The generated regions in `game/play.html` were not hand-edited (CSS → `src/styles/game.css`; encounter data → `src/data/encounter-data.js`; utility helpers → `src/utils/core-utils.js`; achievement defs → `src/data/achievement-data.js`; run-tracking factory → `src/state/run-tracking.js`)
 
 ## Syntax and render check
 

--- a/game/play.html
+++ b/game/play.html
@@ -4760,6 +4760,7 @@ function profileUpdateStats(profile, summary) {
   s.totalMatings = (s.totalMatings || 0) + (summary.matingCount || 0);
 }
 
+// BEGIN GENERATED JS: src/state/run-tracking.js
 function freshRunTracking() {
   return {
     foodTypesEaten: {},
@@ -4790,6 +4791,7 @@ function freshRunTracking() {
     alertedCount: 0
   };
 }
+// END GENERATED JS: src/state/run-tracking.js
 
 // ---------------------------------------------------------------------------
 // [ACHIEVEMENTS] Definitions and persistence

--- a/scripts/build_play_html.mjs
+++ b/scripts/build_play_html.mjs
@@ -10,7 +10,8 @@
 //        [1/2] encounters + encounterTables  (~line 1040)
 //        [2/2] hiddenSubtypePools            (~line 6037)
 //   3. src/utils/core-utils.js    → one JS region (~line 5833)
-//   4. src/data/achievement-data.js → one JS region (~line 4798)
+//   4. src/data/achievement-data.js → one JS region (~line 4800)
+//   5. src/state/run-tracking.js   → one JS region (~line 4763)
 //
 // Why inline (not external files): game/play.html must open straight from
 // disk — or via the GitHub Pages link — with no build step and no runtime
@@ -28,11 +29,12 @@ import { dirname, resolve } from 'node:path';
 const here     = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..');
 
-const CSS_SOURCE    = resolve(repoRoot, 'src/styles/game.css');
-const DATA_SOURCE   = resolve(repoRoot, 'src/data/encounter-data.js');
-const UTILS_SOURCE  = resolve(repoRoot, 'src/utils/core-utils.js');
-const ACHIEVE_SOURCE = resolve(repoRoot, 'src/data/achievement-data.js');
-const PLAY_HTML     = resolve(repoRoot, 'game/play.html');
+const CSS_SOURCE      = resolve(repoRoot, 'src/styles/game.css');
+const DATA_SOURCE     = resolve(repoRoot, 'src/data/encounter-data.js');
+const UTILS_SOURCE    = resolve(repoRoot, 'src/utils/core-utils.js');
+const ACHIEVE_SOURCE  = resolve(repoRoot, 'src/data/achievement-data.js');
+const RUNTRACK_SOURCE = resolve(repoRoot, 'src/state/run-tracking.js');
+const PLAY_HTML       = resolve(repoRoot, 'game/play.html');
 
 // CSS markers (CSS comment style, inside <style>)
 const CSS_BEGIN = '/* BEGIN GENERATED CSS: src/styles/game.css */';
@@ -49,8 +51,12 @@ const JS_BEGIN_UTILS = '// BEGIN GENERATED JS: src/utils/core-utils.js';
 const JS_END_UTILS   = '// END GENERATED JS: src/utils/core-utils.js';
 
 // Achievement-data markers (JS comment style, inside <script>)
-const JS_BEGIN_ACHIEVE = '// BEGIN GENERATED JS: src/data/achievement-data.js';
-const JS_END_ACHIEVE   = '// END GENERATED JS: src/data/achievement-data.js';
+const JS_BEGIN_ACHIEVE  = '// BEGIN GENERATED JS: src/data/achievement-data.js';
+const JS_END_ACHIEVE    = '// END GENERATED JS: src/data/achievement-data.js';
+
+// Run-tracking markers (JS comment style, inside <script>)
+const JS_BEGIN_RUNTRACK = '// BEGIN GENERATED JS: src/state/run-tracking.js';
+const JS_END_RUNTRACK   = '// END GENERATED JS: src/state/run-tracking.js';
 
 // The split comment that divides the source file into part1 and part2.
 // It is NOT inlined into game/play.html.
@@ -76,17 +82,19 @@ function inlineRegion(html, beginMarker, endMarker, body, label) {
 }
 
 // --- Read sources ---
-if (!existsSync(CSS_SOURCE))     fail('cannot find src/styles/game.css');
-if (!existsSync(DATA_SOURCE))    fail('cannot find src/data/encounter-data.js');
-if (!existsSync(UTILS_SOURCE))   fail('cannot find src/utils/core-utils.js');
-if (!existsSync(ACHIEVE_SOURCE)) fail('cannot find src/data/achievement-data.js');
-if (!existsSync(PLAY_HTML))      fail('cannot find game/play.html');
+if (!existsSync(CSS_SOURCE))      fail('cannot find src/styles/game.css');
+if (!existsSync(DATA_SOURCE))     fail('cannot find src/data/encounter-data.js');
+if (!existsSync(UTILS_SOURCE))    fail('cannot find src/utils/core-utils.js');
+if (!existsSync(ACHIEVE_SOURCE))  fail('cannot find src/data/achievement-data.js');
+if (!existsSync(RUNTRACK_SOURCE)) fail('cannot find src/state/run-tracking.js');
+if (!existsSync(PLAY_HTML))       fail('cannot find game/play.html');
 
-const css       = readFileSync(CSS_SOURCE,     'utf8');
-const jsData    = readFileSync(DATA_SOURCE,    'utf8');
-const jsUtils   = readFileSync(UTILS_SOURCE,   'utf8');
-const jsAchieve = readFileSync(ACHIEVE_SOURCE, 'utf8');
-let   html      = readFileSync(PLAY_HTML,      'utf8');
+const css        = readFileSync(CSS_SOURCE,      'utf8');
+const jsData     = readFileSync(DATA_SOURCE,     'utf8');
+const jsUtils    = readFileSync(UTILS_SOURCE,    'utf8');
+const jsAchieve  = readFileSync(ACHIEVE_SOURCE,  'utf8');
+const jsRunTrack = readFileSync(RUNTRACK_SOURCE, 'utf8');
+let   html       = readFileSync(PLAY_HTML,       'utf8');
 
 // --- Split encounter-data into two parts at the SPLIT marker ---
 const splitIdx = jsData.indexOf(JS_SPLIT);
@@ -100,7 +108,8 @@ html = inlineRegion(html, CSS_BEGIN,        CSS_END,        css.replace(/\s+$/, 
 html = inlineRegion(html, JS_BEGIN1,        JS_END1,        jsPart1, 'encounter-data [1/2]');
 html = inlineRegion(html, JS_BEGIN2,        JS_END2,        jsPart2, 'encounter-data [2/2]');
 html = inlineRegion(html, JS_BEGIN_UTILS,   JS_END_UTILS,   jsUtils.replace(/\s+$/, ''), 'core-utils');
-html = inlineRegion(html, JS_BEGIN_ACHIEVE, JS_END_ACHIEVE, jsAchieve.replace(/\s+$/, ''), 'achievement-data');
+html = inlineRegion(html, JS_BEGIN_ACHIEVE,  JS_END_ACHIEVE,  jsAchieve.replace(/\s+$/, ''),  'achievement-data');
+html = inlineRegion(html, JS_BEGIN_RUNTRACK, JS_END_RUNTRACK, jsRunTrack.replace(/\s+$/, ''), 'run-tracking');
 
 if (html === original) {
   console.log('build_play_html: no change — game/play.html already matches all source files.');

--- a/src/state/run-tracking.js
+++ b/src/state/run-tracking.js
@@ -1,0 +1,30 @@
+function freshRunTracking() {
+  return {
+    foodTypesEaten: {},
+    fruitEaten: 0,
+    insectEaten: 0,
+    leafEaten: 0,
+    fungusEaten: 0,
+    meatEaten: 0,
+    waterDrank: 0,
+    worstPoisonRank: 0,
+    poisonSurvived: false,
+    groupEverJoined: false,
+    matingAttempted: false,
+    companionInterceptHit: false,
+    pursuitsEscaped: 0,
+    nightSurvivedCount: 0,
+    lastTrackedPhase: null,
+    turnsAtMinFitness: 0,
+    lowestFitness: 100,
+    tilesExplored: 0,
+    tilesExploredThisRun: new Set(),
+    startedDying: false,
+    wasNearDeath: false,
+    wildfireThreatened: false,
+    wildfireEscaped: false,
+    investigatedCount: 0,
+    groomedCount: 0,
+    alertedCount: 0
+  };
+}


### PR DESCRIPTION
## Summary

Fifth controlled extraction in the build scaffold. The `freshRunTracking()` function is moved to a source file and inlined back into `game/play.html` via the extended build script.

- `src/state/run-tracking.js` now holds `freshRunTracking()`.
- `game/play.html` remains the directly playable artifact.
- `scripts/build_play_html.mjs` now inlines CSS, encounter data, core utils, achievement definitions, and run-tracking state factory.
- Only `freshRunTracking()` was extracted.
- Profile/save logic remains in `game/play.html`.
- Achievement logic remains in `game/play.html`.
- No gameplay logic changed.
- No run-tracking fields or defaults changed.
- No call sites changed.

**Scope:** source/build structure only.

---

## What changed

### New file: `src/state/run-tracking.js`

Contains exactly `function freshRunTracking() { ... }` (30 lines), moved mechanically and byte-identical to the original. `freshRunTracking()` returns the initial per-run tracking object used to reset per-run stats at the start of each run: food-type counts, poison/night/pursuit history, tile exploration set, near-death flags, wildfire flags, investigation counts, etc.

### `game/play.html` — generated region added

The `freshRunTracking()` block is now wrapped in:
```
// BEGIN GENERATED JS: src/state/run-tracking.js
...inlined freshRunTracking...
// END GENERATED JS: src/state/run-tracking.js
```
The region stays exactly where `freshRunTracking()` lived — after `profileUpdateStats`, before the `[ACHIEVEMENTS]` section — preserving load order and access to surrounding functions/globals.

### `scripts/build_play_html.mjs` extended

Now inlines five source files:
1. `src/styles/game.css` → CSS region
2. `src/data/encounter-data.js` → encounter-data regions [1/2] and [2/2]
3. `src/utils/core-utils.js` → core-utils region
4. `src/data/achievement-data.js` → achievement-data region
5. `src/state/run-tracking.js` → run-tracking region

Fails clearly if `src/state/run-tracking.js` or its BEGIN/END markers are missing, or if END precedes BEGIN. Replaces only marked regions. Idempotent.

---

## Verification

- `freshRunTracking()` was the only extracted function (one top-level function declaration in the region).
- The extracted source and generated inline block match, excluding marker comments and trailing whitespace (verified with `diff`).
- No run-tracking field names changed.
- No default values changed.
- No Set usage changed.
- No call sites changed (`player.runTracking = freshRunTracking()` at three locations in `game/play.html` — all intact).
- No gameplay logic changed.
- No save/profile logic changed.
- No achievement logic changed.
- No rendering changed.
- No CSS changed.
- No encounter data changed.
- No core utility code changed.
- No achievement data changed.
- `node scripts/build_play_html.mjs` — reports "no change" (idempotent).
- `node scripts/check_html_js_syntax.mjs` — all checks passed.
- Browser manual check not run by Claude; awaiting George's browser smoke test.

---

Documentation updated: README.md, docs/current-game-structure.md, docs/architecture-notes.md, docs/release-checklist.md, CHANGELOG.txt

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKFcTXWzunyBYGnVrpUzLd)_