### PR TITLE
Extract profile storage constants source

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,19 @@
+[2026-06-04 extract-profile-storage-constants | Claude]
+Sixth controlled extraction — profile/storage constant declarations extracted and build script extended.
+
+- Created src/state/profile-storage-constants.js: seven const declarations moved mechanically from game/play.html, byte-identical to the originals.
+  - PROFILE_STORE_KEY, ACTIVE_PROFILE_KEY_STORE, FOSSIL_RECORD_KEY, FOSSIL_RECORD_CAP, ACHIEVEMENTS_STORE_KEY, PROFILE_LOG_CAP, PROFILE_TRACE_CAP.
+  - No constant names changed. No constant values changed.
+- Edited game/play.html: the seven-constant block is now wrapped in // BEGIN/END GENERATED JS: src/state/profile-storage-constants.js markers.
+  - The generated region stays exactly where the constants lived: immediately after the // ===== PROFILE SAVE SYSTEM ===== banner and before let currentProfileId = null; — preserving load order.
+  - Only the seven constants were extracted. All profile functions (profileLoadStore, profileSaveStore, profileCreateNew, etc.), fossil record logic, active-run logic, achievement persistence, and save/load logic remain in game/play.html. No call sites changed.
+  - game/play.html remains the directly playable artifact.
+- Extended scripts/build_play_html.mjs: now inlines CSS, encounter data, core utils, achievement definitions, run-tracking state factory, and profile/storage constants. Fails clearly if src/state/profile-storage-constants.js or its region markers are missing. Idempotent.
+- game/evolution_game_v66_57.html NOT changed: historical archive, not kept byte-synced between releases.
+- Docs: README.md (repo layout tree + build scaffold table), docs/current-game-structure.md (line-range table, build scaffold table), docs/architecture-notes.md (generated region + markers, line-range table, fragile-area note), docs/release-checklist.md (build step check for profile-storage-constants).
+- Verification: node scripts/build_play_html.mjs (idempotent — no change) and node scripts/check_html_js_syntax.mjs both pass. Extracted source verified to match the inline region (excluding markers and trailing whitespace).
+- Source/build structure change only. No gameplay logic, constant values, save/profile logic, achievement logic, fossil record logic, rendering, CSS, encounter data, core utility code, or run-tracking code changed.
+
 [2026-06-03 extract-run-tracking | Claude]
 Fifth controlled extraction — run-tracking state factory source extracted and build script extended.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ evolution-game/
 │   ├── utils/
 │   │   └── core-utils.js             Pure utility helpers source (inlined into play.html by the build script)
 │   └── state/
-│       └── run-tracking.js           Run-tracking state factory source (inlined into play.html by the build script)
+│       ├── run-tracking.js           Run-tracking state factory source (inlined into play.html by the build script)
+│       └── profile-storage-constants.js  Profile/storage constant declarations (inlined into play.html by the build script)
 ├── docs/
 │   ├── current-game-structure.md     How the game works now: systems, flows, line ranges
 │   ├── documentation-map.md          What each doc covers and when to update it
@@ -139,7 +140,7 @@ The rebuild is not a rewrite, not a framework migration, and not a gameplay rede
 
 ### Build scaffold
 
-Five source extractions are complete:
+Six source extractions are complete:
 
 | Source file | What it contains | Destination in play.html |
 |-------------|-----------------|--------------------------|
@@ -148,6 +149,7 @@ Five source extractions are complete:
 | `src/utils/core-utils.js` | Pure stateless helper functions | One JS region (~line 5835) |
 | `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions only; persistence stays in play.html) | One JS region (~line 4800) |
 | `src/state/run-tracking.js` | `freshRunTracking()` (factory only; save/profile logic stays in play.html) | One JS region (~line 4763) |
+| `src/state/profile-storage-constants.js` | Profile/storage key constants (7 `const` declarations; all profile logic stays in play.html) | One JS region (~line 4481) |
 
 `game/play.html` keeps all content **inline** so it stays directly playable with no build step or runtime dependency. To regenerate `game/play.html` after editing any source file:
 

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -38,6 +38,14 @@ Five source files have been extracted and are inlined back into `game/play.html`
 // END GENERATED JS: src/utils/core-utils.js
 ```
 
+**Profile/storage constants** (inside the `<script>` block, ~line 4481) — seven `const` declarations only:
+```
+// BEGIN GENERATED JS: src/state/profile-storage-constants.js
+...generated js...
+// END GENERATED JS: src/state/profile-storage-constants.js
+```
+This region sits immediately after the `// ===== PROFILE SAVE SYSTEM =====` banner and before `let currentProfileId = null;`, preserving load order. Only the key/cap constants are extracted; all profile functions (`profileLoadStore`, `profileSaveStore`, `profileCreateNew`, etc.), fossil record logic, active-run logic, achievement persistence, and save/load logic remain in `game/play.html`. Profile/storage constants should be edited in `src/state/profile-storage-constants.js`, not inside the generated region of `game/play.html`.
+
 **Run-tracking state factory** (inside the `<script>` block, ~line 4763) — the `freshRunTracking()` function only:
 ```
 // BEGIN GENERATED JS: src/state/run-tracking.js
@@ -56,7 +64,7 @@ This region sits between `freshRunTracking` and `loadAchievements`, preserving l
 
 `src/data/encounter-data.js` uses a `// << SPLIT: hiddenSubtypePools >>` line to divide part 1 from part 2; the build script splits on it and inlines each part into its region. The split marker itself is not inlined. All other source files have no split marker and each maps to one contiguous region.
 
-**Edit CSS in `src/styles/game.css`, encounter data in `src/data/encounter-data.js`, pure utility helpers in `src/utils/core-utils.js`, achievement definitions in `src/data/achievement-data.js`, and run-tracking factory in `src/state/run-tracking.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
+**Edit CSS in `src/styles/game.css`, encounter data in `src/data/encounter-data.js`, pure utility helpers in `src/utils/core-utils.js`, achievement definitions in `src/data/achievement-data.js`, run-tracking factory in `src/state/run-tracking.js`, and profile/storage constants in `src/state/profile-storage-constants.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
 
 `game/evolution_game_v66_57.html` is the versioned archive of an earlier build. It is a historical snapshot and is not kept byte-in-sync with `game/play.html` between releases; `game/play.html` is the stable public-facing copy that gets replaced on each release.
 
@@ -72,7 +80,9 @@ This region sits between `freshRunTracking` and `loadAchievements`, preserving l
 | 990–1020 | Game version constant (`GAME_VERSION`) |
 | 1021–3501 | Static data: encounters + spawn tables — generated, source in `src/data/encounter-data.js` [1/2] |
 | 3502–4254 | World generation: terrain, habitats, altitude, water, clay deposits |
-| 4253–4791 | Player state object and dynamic world state (waterState, socialGroup, nearbyEntities) |
+| 4253–4478 | Player state object and dynamic world state (waterState, socialGroup, nearbyEntities) |
+| 4479–4489 | Profile/storage constants — generated, source in `src/state/profile-storage-constants.js` |
+| 4491–4762 | Profile state variables and profile functions (currentProfileId, profileLoadStore, profileSaveStore, etc.) |
 | 4763–4794 | Run-tracking state factory (`freshRunTracking`) — generated, source in `src/state/run-tracking.js` |
 | 4800–4865 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source in `src/data/achievement-data.js` |
 | 4867–5829 | Achievement persistence (load/save/check), profile stats, profiles, save/load, Field Journal, Fossil Record |
@@ -138,7 +148,7 @@ All rendering is done by a single `render()` call that redraws the map, UI panel
 - **`game/play.html` and `game/evolution_game_v66_57.html` must be kept in sync** on each release. If you edit one, copy the change to the other, or replace `play.html` entirely.
 - **`index.html` and `manifest.json` must both reference `game/play.html`.** The syntax check script verifies `index.html`. Check `manifest.json` manually on releases.
 - **`player.knowledge` / `player.classKnowledge`** accumulate across runs and feed the Field Journal. Incorrect resets at run boundaries lose journal data permanently.
-- **The CSS region, both encounter-data regions, the core-utils region, the achievement-data region, and the run-tracking region in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css`, `src/data/encounter-data.js`, `src/utils/core-utils.js`, `src/data/achievement-data.js`, and `src/state/run-tracking.js` instead. Do not remove any BEGIN/END marker comments or the `// << SPLIT: hiddenSubtypePools >>` line — the build script requires all of them.
+- **The CSS region, both encounter-data regions, the core-utils region, the achievement-data region, the run-tracking region, and the profile-storage-constants region in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css`, `src/data/encounter-data.js`, `src/utils/core-utils.js`, `src/data/achievement-data.js`, `src/state/run-tracking.js`, and `src/state/profile-storage-constants.js` instead. Do not remove any BEGIN/END marker comments or the `// << SPLIT: hiddenSubtypePools >>` line — the build script requires all of them.
 
 ---
 

--- a/docs/current-game-structure.md
+++ b/docs/current-game-structure.md
@@ -12,7 +12,7 @@ Evolution Game is a browser-based single-player survival simulation. The player 
 
 The game runs from a single HTML file (`game/play.html`, ~18,400 lines). There is no bundler and no server. Open the file in a browser and it works.
 
-Five source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
+Six source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
 
 | Source file | What it contains | In play.html |
 |-------------|-----------------|--------------|
@@ -21,8 +21,9 @@ Five source extractions are complete. The playable file `game/play.html` still c
 | `src/utils/core-utils.js` | Pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation helpers) | One inline JS region (~line 5835) |
 | `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions array only) | One inline JS region (~line 4800) |
 | `src/state/run-tracking.js` | `freshRunTracking()` factory (run-tracking schema only) | One inline JS region (~line 4763) |
+| `src/state/profile-storage-constants.js` | Profile/storage key constants (7 `const` declarations) | One inline JS region (~line 4481) |
 
-`scripts/build_play_html.mjs` inlines all source files back into `game/play.html`. Only the `ACHIEVEMENT_DEFS` definitions array and the `freshRunTracking()` factory function are extracted — achievement persistence, profile/save logic, `checkAchievements`, achievement rendering/toast logic, and all other game state management remain inside `game/play.html`. All other JavaScript engine code and HTML structure also remain inside `game/play.html` for now.
+`scripts/build_play_html.mjs` inlines all source files back into `game/play.html`. Only configuration-like declarations are extracted — all profile functions (`profileLoadStore`, `profileSaveStore`, `profileCreateNew`, etc.), achievement persistence, fossil record logic, active-run logic, save/load logic, and all other game code remain inside `game/play.html`. All JavaScript engine code and HTML structure also remain inside `game/play.html` for now.
 
 ---
 
@@ -271,7 +272,9 @@ flowchart TD
 | 990–1020 | Game version constant |
 | 1021–3501 | Static data: encounter definitions + spawn tables — generated, source is `src/data/encounter-data.js` [1/2] |
 | 3631–4252 | World generation: terrain, habitats, altitude, water, clay deposits |
-| 4253–4791 | Player state object and dynamic world state (waterState, socialGroup, nearbyEntities) |
+| 4253–4478 | Player state object and dynamic world state (waterState, socialGroup, nearbyEntities) |
+| 4479–4489 | Profile/storage constants — generated, source is `src/state/profile-storage-constants.js` |
+| 4491–4762 | Profile state variables and profile functions (currentProfileId, profileLoadStore, profileSaveStore, etc.) |
 | 4763–4794 | Run-tracking state factory (`freshRunTracking`) — generated, source is `src/state/run-tracking.js` |
 | 4800–4865 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source is `src/data/achievement-data.js` |
 | 4867–5829 | Achievement persistence (load/save/check), profile stats, profiles, save/load, Field Journal, Fossil Record |
@@ -326,6 +329,7 @@ The rebuild plan (see `docs/project-plan.md`) targets extraction in this rough o
 | `src/utils/core-utils.js` | `// BEGIN/END GENERATED JS: src/utils/core-utils.js` |
 | `src/data/achievement-data.js` | `// BEGIN/END GENERATED JS: src/data/achievement-data.js` |
 | `src/state/run-tracking.js` | `// BEGIN/END GENERATED JS: src/state/run-tracking.js` |
+| `src/state/profile-storage-constants.js` | `// BEGIN/END GENERATED JS: src/state/profile-storage-constants.js` |
 
 The source file `src/data/encounter-data.js` contains a `// << SPLIT: hiddenSubtypePools >>` line dividing part 1 (encounters + encounterTables) from part 2 (hiddenSubtypePools). The build script splits on this marker and inlines each part into its respective location in `play.html`. All other source files have no split marker — each maps to one contiguous region.
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -19,7 +19,8 @@ Run through this every time a new version becomes the stable build.
 - [ ] If `src/utils/core-utils.js` was changed, `node scripts/build_play_html.mjs` was run to inline the utility helpers into `game/play.html`
 - [ ] If `src/data/achievement-data.js` was changed, `node scripts/build_play_html.mjs` was run to inline the achievement definitions into `game/play.html`
 - [ ] If `src/state/run-tracking.js` was changed, `node scripts/build_play_html.mjs` was run to inline the run-tracking factory into `game/play.html`
-- [ ] The generated regions in `game/play.html` were not hand-edited (CSS → `src/styles/game.css`; encounter data → `src/data/encounter-data.js`; utility helpers → `src/utils/core-utils.js`; achievement defs → `src/data/achievement-data.js`; run-tracking factory → `src/state/run-tracking.js`)
+- [ ] If `src/state/profile-storage-constants.js` was changed, `node scripts/build_play_html.mjs` was run to inline the profile/storage constants into `game/play.html`
+- [ ] The generated regions in `game/play.html` were not hand-edited (CSS → `src/styles/game.css`; encounter data → `src/data/encounter-data.js`; utility helpers → `src/utils/core-utils.js`; achievement defs → `src/data/achievement-data.js`; run-tracking factory → `src/state/run-tracking.js`; profile/storage constants → `src/state/profile-storage-constants.js`)
 
 ## Syntax and render check
 

--- a/game/play.html
+++ b/game/play.html
@@ -4478,6 +4478,7 @@ let qaBackSnapshot = null;
 
 // ===== PROFILE SAVE SYSTEM =====
 
+// BEGIN GENERATED JS: src/state/profile-storage-constants.js
 const PROFILE_STORE_KEY = "evolutionGameProfiles_v1";
 const ACTIVE_PROFILE_KEY_STORE = "evolutionGameActiveProfileId_v1";
 const FOSSIL_RECORD_KEY = "evolutionGameFossilRecord_v1";
@@ -4485,6 +4486,7 @@ const FOSSIL_RECORD_CAP = 10;
 const ACHIEVEMENTS_STORE_KEY = "evolutionGameAchievements_v1";
 const PROFILE_LOG_CAP = 150;
 const PROFILE_TRACE_CAP = 200;
+// END GENERATED JS: src/state/profile-storage-constants.js
 
 let currentProfileId = null;
 let currentRunId = null;

--- a/scripts/build_play_html.mjs
+++ b/scripts/build_play_html.mjs
@@ -12,6 +12,7 @@
 //   3. src/utils/core-utils.js    → one JS region (~line 5833)
 //   4. src/data/achievement-data.js → one JS region (~line 4800)
 //   5. src/state/run-tracking.js   → one JS region (~line 4763)
+//   6. src/state/profile-storage-constants.js → one JS region (~line 4481)
 //
 // Why inline (not external files): game/play.html must open straight from
 // disk — or via the GitHub Pages link — with no build step and no runtime
@@ -34,6 +35,7 @@ const DATA_SOURCE     = resolve(repoRoot, 'src/data/encounter-data.js');
 const UTILS_SOURCE    = resolve(repoRoot, 'src/utils/core-utils.js');
 const ACHIEVE_SOURCE  = resolve(repoRoot, 'src/data/achievement-data.js');
 const RUNTRACK_SOURCE = resolve(repoRoot, 'src/state/run-tracking.js');
+const PROFCONST_SOURCE = resolve(repoRoot, 'src/state/profile-storage-constants.js');
 const PLAY_HTML       = resolve(repoRoot, 'game/play.html');
 
 // CSS markers (CSS comment style, inside <style>)
@@ -55,8 +57,12 @@ const JS_BEGIN_ACHIEVE  = '// BEGIN GENERATED JS: src/data/achievement-data.js';
 const JS_END_ACHIEVE    = '// END GENERATED JS: src/data/achievement-data.js';
 
 // Run-tracking markers (JS comment style, inside <script>)
-const JS_BEGIN_RUNTRACK = '// BEGIN GENERATED JS: src/state/run-tracking.js';
-const JS_END_RUNTRACK   = '// END GENERATED JS: src/state/run-tracking.js';
+const JS_BEGIN_RUNTRACK  = '// BEGIN GENERATED JS: src/state/run-tracking.js';
+const JS_END_RUNTRACK    = '// END GENERATED JS: src/state/run-tracking.js';
+
+// Profile-storage-constants markers (JS comment style, inside <script>)
+const JS_BEGIN_PROFCONST = '// BEGIN GENERATED JS: src/state/profile-storage-constants.js';
+const JS_END_PROFCONST   = '// END GENERATED JS: src/state/profile-storage-constants.js';
 
 // The split comment that divides the source file into part1 and part2.
 // It is NOT inlined into game/play.html.
@@ -86,15 +92,17 @@ if (!existsSync(CSS_SOURCE))      fail('cannot find src/styles/game.css');
 if (!existsSync(DATA_SOURCE))     fail('cannot find src/data/encounter-data.js');
 if (!existsSync(UTILS_SOURCE))    fail('cannot find src/utils/core-utils.js');
 if (!existsSync(ACHIEVE_SOURCE))  fail('cannot find src/data/achievement-data.js');
-if (!existsSync(RUNTRACK_SOURCE)) fail('cannot find src/state/run-tracking.js');
-if (!existsSync(PLAY_HTML))       fail('cannot find game/play.html');
+if (!existsSync(RUNTRACK_SOURCE))  fail('cannot find src/state/run-tracking.js');
+if (!existsSync(PROFCONST_SOURCE)) fail('cannot find src/state/profile-storage-constants.js');
+if (!existsSync(PLAY_HTML))        fail('cannot find game/play.html');
 
-const css        = readFileSync(CSS_SOURCE,      'utf8');
-const jsData     = readFileSync(DATA_SOURCE,     'utf8');
-const jsUtils    = readFileSync(UTILS_SOURCE,    'utf8');
-const jsAchieve  = readFileSync(ACHIEVE_SOURCE,  'utf8');
-const jsRunTrack = readFileSync(RUNTRACK_SOURCE, 'utf8');
-let   html       = readFileSync(PLAY_HTML,       'utf8');
+const css          = readFileSync(CSS_SOURCE,       'utf8');
+const jsData       = readFileSync(DATA_SOURCE,      'utf8');
+const jsUtils      = readFileSync(UTILS_SOURCE,     'utf8');
+const jsAchieve    = readFileSync(ACHIEVE_SOURCE,   'utf8');
+const jsRunTrack   = readFileSync(RUNTRACK_SOURCE,  'utf8');
+const jsProfConst  = readFileSync(PROFCONST_SOURCE, 'utf8');
+let   html         = readFileSync(PLAY_HTML,        'utf8');
 
 // --- Split encounter-data into two parts at the SPLIT marker ---
 const splitIdx = jsData.indexOf(JS_SPLIT);
@@ -109,7 +117,8 @@ html = inlineRegion(html, JS_BEGIN1,        JS_END1,        jsPart1, 'encounter-
 html = inlineRegion(html, JS_BEGIN2,        JS_END2,        jsPart2, 'encounter-data [2/2]');
 html = inlineRegion(html, JS_BEGIN_UTILS,   JS_END_UTILS,   jsUtils.replace(/\s+$/, ''), 'core-utils');
 html = inlineRegion(html, JS_BEGIN_ACHIEVE,  JS_END_ACHIEVE,  jsAchieve.replace(/\s+$/, ''),  'achievement-data');
-html = inlineRegion(html, JS_BEGIN_RUNTRACK, JS_END_RUNTRACK, jsRunTrack.replace(/\s+$/, ''), 'run-tracking');
+html = inlineRegion(html, JS_BEGIN_RUNTRACK,  JS_END_RUNTRACK,  jsRunTrack.replace(/\s+$/, ''),  'run-tracking');
+html = inlineRegion(html, JS_BEGIN_PROFCONST, JS_END_PROFCONST, jsProfConst.replace(/\s+$/, ''), 'profile-storage-constants');
 
 if (html === original) {
   console.log('build_play_html: no change — game/play.html already matches all source files.');

--- a/src/state/profile-storage-constants.js
+++ b/src/state/profile-storage-constants.js
@@ -1,0 +1,7 @@
+const PROFILE_STORE_KEY = "evolutionGameProfiles_v1";
+const ACTIVE_PROFILE_KEY_STORE = "evolutionGameActiveProfileId_v1";
+const FOSSIL_RECORD_KEY = "evolutionGameFossilRecord_v1";
+const FOSSIL_RECORD_CAP = 10;
+const ACHIEVEMENTS_STORE_KEY = "evolutionGameAchievements_v1";
+const PROFILE_LOG_CAP = 150;
+const PROFILE_TRACE_CAP = 200;


### PR DESCRIPTION
## Summary

Sixth controlled extraction in the build scaffold series. Moves exactly seven `const` declarations (profile/storage keys and caps) out of `game/play.html` into `src/state/profile-storage-constants.js`, and wires them into `scripts/build_play_html.mjs` so they are inlined back at build time.

`game/play.html` remains the directly playable artifact — all content is still inline, no runtime dependencies.

---

## What changed

- **Created** `src/state/profile-storage-constants.js` — holds the seven approved `const` declarations only:
  - `PROFILE_STORE_KEY`
  - `ACTIVE_PROFILE_KEY_STORE`
  - `FOSSIL_RECORD_KEY`
  - `FOSSIL_RECORD_CAP`
  - `ACHIEVEMENTS_STORE_KEY`
  - `PROFILE_LOG_CAP`
  - `PROFILE_TRACE_CAP`
- **`game/play.html`** — the seven declarations replaced with a `// BEGIN/END GENERATED JS: src/state/profile-storage-constants.js` region; all surrounding code unchanged
- **`scripts/build_play_html.mjs`** — wired to read `src/state/profile-storage-constants.js` and inline it into the new region; now inlines all six source files (CSS, encounter data, core utils, achievement definitions, run-tracking state factory, profile/storage constants)
- **`README.md`** — repo layout tree and build scaffold table updated
- **`docs/current-game-structure.md`** — line-range table and build scaffold table updated
- **`docs/architecture-notes.md`** — generated regions list, line-range table, fragile areas, and do-not-edit notes updated
- **`docs/release-checklist.md`** — build step checklist updated with profile-storage-constants entry
- **`CHANGELOG.txt`** — entry added

---

## Scope confirmation

Only the seven approved constants were extracted. No profile functions, no fossil record logic, no active-run logic, no achievement persistence, no save/load logic — all of that remains in `game/play.html`. No gameplay, UI, bot, or encounter logic was touched. No unrequested changes.

---

## Verification

- `node scripts/build_play_html.mjs` ran after adding markers — reported **no change** (inline block already matched source exactly)
- `node scripts/check_html_js_syntax.mjs` passed with no errors
- Inline region diff confirmed byte-for-byte match between `src/state/profile-storage-constants.js` and the generated region in `game/play.html`
- Marker placement: BEGIN at line 4481, END at line 4489; `// ===== PROFILE SAVE SYSTEM =====` banner immediately before at line 4479; `let currentProfileId = null;` immediately after at line 4491 — load order preserved

---

## Scope

- [ ] Gameplay logic
- [ ] UI/layout
- [ ] Bot/debug tools
- [ ] App-loading/PWA files
- [x] Documentation/workflow
- [x] Repository structure (source extraction / build scaffold)

---

## Smoke check

Static review only. `game/play.html` was not opened in a browser this session. The syntax check passed and the build script confirmed idempotency. George should open `game/play.html` in a browser and confirm the game loads before merging.

---

Documentation updated: `README.md`, `docs/current-game-structure.md`, `docs/architecture-notes.md`, `docs/release-checklist.md`, `CHANGELOG.txt`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKFcTXWzunyBYGnVrpUzLd)_