### PR TITLE
Extract profile factory helpers source

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,22 @@
+[2026-06-04 extract-profile-factories | Claude]
+Seventh controlled extraction — profile factory helper functions extracted and build script extended.
+
+- Created src/state/profile-factories.js: three factory/helper functions moved mechanically from game/play.html, byte-identical to the originals.
+  - profileGenerateId(prefix): generates a unique timestamped ID string.
+  - profileEmptyStore(): returns a minimal empty profile store object.
+  - profileDefaultStats(): returns a zeroed stats object for a new profile.
+  - No function names changed. No function bodies changed.
+- Edited game/play.html: all three functions replaced with a single // BEGIN/END GENERATED JS: src/state/profile-factories.js region.
+  - The functions were not contiguous in the original; they have been consolidated into one region before profileLoadStore. This is safe because function declarations are hoisted.
+  - The generated region sits after the profile state variables (currentProfileId, etc.) and before profileLoadStore — preserving load order.
+  - Only the three approved functions were extracted. profileLoadStore, profileSaveStore, profileCreateNew, fossil record logic, active-run logic, achievement persistence, and save/load logic remain in game/play.html. No call sites changed.
+  - game/play.html remains the directly playable artifact.
+- Extended scripts/build_play_html.mjs: now inlines CSS, encounter data, core utils, achievement definitions, run-tracking state factory, profile/storage constants, and profile factory helpers. Fails clearly if src/state/profile-factories.js or its region markers are missing. Idempotent.
+- game/evolution_game_v66_57.html NOT changed: historical archive, not kept byte-synced between releases.
+- Docs: README.md (repo layout tree + build scaffold table), docs/current-game-structure.md (line-range table, build scaffold table), docs/architecture-notes.md (generated region + markers, line-range table, fragile-area note), docs/release-checklist.md (build step check for profile-factories).
+- Verification: node scripts/build_play_html.mjs (idempotent — no change) and node scripts/check_html_js_syntax.mjs both pass. Extracted source verified to match the inline region (excluding markers and trailing whitespace).
+- Source/build structure change only. No gameplay logic, function bodies, call sites, save/profile behaviour, achievement logic, fossil record logic, rendering, CSS, encounter data, core utility code, run-tracking code, or profile/storage constants changed.
+
 [2026-06-04 extract-profile-storage-constants | Claude]
 Sixth controlled extraction — profile/storage constant declarations extracted and build script extended.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ evolution-game/
 │   │   └── core-utils.js             Pure utility helpers source (inlined into play.html by the build script)
 │   └── state/
 │       ├── run-tracking.js           Run-tracking state factory source (inlined into play.html by the build script)
-│       └── profile-storage-constants.js  Profile/storage constant declarations (inlined into play.html by the build script)
+│       ├── profile-storage-constants.js  Profile/storage constant declarations (inlined into play.html by the build script)
+│       └── profile-factories.js      Profile factory/helper functions source (inlined into play.html by the build script)
 ├── docs/
 │   ├── current-game-structure.md     How the game works now: systems, flows, line ranges
 │   ├── documentation-map.md          What each doc covers and when to update it
@@ -140,16 +141,17 @@ The rebuild is not a rewrite, not a framework migration, and not a gameplay rede
 
 ### Build scaffold
 
-Six source extractions are complete:
+Seven source extractions are complete:
 
 | Source file | What it contains | Destination in play.html |
 |-------------|-----------------|--------------------------|
 | `src/styles/game.css` | All CSS | Inline `<style>` block |
 | `src/data/encounter-data.js` | `encounters`, `encounterTables`, `hiddenSubtypePools` | Two JS regions (~line 1040 and ~line 6037) |
 | `src/utils/core-utils.js` | Pure stateless helper functions | One JS region (~line 5835) |
-| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions only; persistence stays in play.html) | One JS region (~line 4800) |
-| `src/state/run-tracking.js` | `freshRunTracking()` (factory only; save/profile logic stays in play.html) | One JS region (~line 4763) |
+| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions only; persistence stays in play.html) | One JS region (~line 4804) |
+| `src/state/run-tracking.js` | `freshRunTracking()` (factory only; save/profile logic stays in play.html) | One JS region (~line 4767) |
 | `src/state/profile-storage-constants.js` | Profile/storage key constants (7 `const` declarations; all profile logic stays in play.html) | One JS region (~line 4481) |
+| `src/state/profile-factories.js` | Profile factory/helper functions (`profileGenerateId`, `profileEmptyStore`, `profileDefaultStats`; all other profile logic stays in play.html) | One JS region (~line 4500) |
 
 `game/play.html` keeps all content **inline** so it stays directly playable with no build step or runtime dependency. To regenerate `game/play.html` after editing any source file:
 

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -8,7 +8,7 @@ This document is a map of how the game HTML file is organised. Read this before 
 
 The entire game lives in one large HTML file (`game/play.html`, ~18,400 lines). There is no build step, no bundler, and no separate JavaScript files. Everything — CSS, HTML structure, and all JavaScript — is in one file.
 
-Five source files have been extracted and are inlined back into `game/play.html` by `scripts/build_play_html.mjs`. The playable file still ships all content inline, so it works with no build step at runtime. The build script replaces only the regions between these marker comments:
+Seven source files have been extracted and are inlined back into `game/play.html` by `scripts/build_play_html.mjs`. The playable file still ships all content inline, so it works with no build step at runtime. The build script replaces only the regions between these marker comments:
 
 **CSS** (inside the `<style>` block) — source `src/styles/game.css`:
 ```
@@ -46,6 +46,14 @@ Five source files have been extracted and are inlined back into `game/play.html`
 ```
 This region sits immediately after the `// ===== PROFILE SAVE SYSTEM =====` banner and before `let currentProfileId = null;`, preserving load order. Only the key/cap constants are extracted; all profile functions (`profileLoadStore`, `profileSaveStore`, `profileCreateNew`, etc.), fossil record logic, active-run logic, achievement persistence, and save/load logic remain in `game/play.html`. Profile/storage constants should be edited in `src/state/profile-storage-constants.js`, not inside the generated region of `game/play.html`.
 
+**Profile factory helpers** (inside the `<script>` block, ~line 4500) — three factory/helper functions:
+```
+// BEGIN GENERATED JS: src/state/profile-factories.js
+...generated js...
+// END GENERATED JS: src/state/profile-factories.js
+```
+This region sits after the profile state variables and before `profileLoadStore`, preserving load order. Only `profileGenerateId`, `profileEmptyStore`, and `profileDefaultStats` are extracted; `profileLoadStore`, `profileSaveStore`, `profileCreateNew`, fossil record logic, active-run logic, achievement persistence, and save/load logic remain in `game/play.html`. The three functions were not contiguous in the original file; they have been consolidated into this single region (safe because `function` declarations are hoisted). Profile factory helpers should be edited in `src/state/profile-factories.js`, not inside the generated region of `game/play.html`.
+
 **Run-tracking state factory** (inside the `<script>` block, ~line 4763) — the `freshRunTracking()` function only:
 ```
 // BEGIN GENERATED JS: src/state/run-tracking.js
@@ -64,7 +72,7 @@ This region sits between `freshRunTracking` and `loadAchievements`, preserving l
 
 `src/data/encounter-data.js` uses a `// << SPLIT: hiddenSubtypePools >>` line to divide part 1 from part 2; the build script splits on it and inlines each part into its region. The split marker itself is not inlined. All other source files have no split marker and each maps to one contiguous region.
 
-**Edit CSS in `src/styles/game.css`, encounter data in `src/data/encounter-data.js`, pure utility helpers in `src/utils/core-utils.js`, achievement definitions in `src/data/achievement-data.js`, run-tracking factory in `src/state/run-tracking.js`, and profile/storage constants in `src/state/profile-storage-constants.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
+**Edit CSS in `src/styles/game.css`, encounter data in `src/data/encounter-data.js`, pure utility helpers in `src/utils/core-utils.js`, achievement definitions in `src/data/achievement-data.js`, run-tracking factory in `src/state/run-tracking.js`, profile/storage constants in `src/state/profile-storage-constants.js`, and profile factory helpers in `src/state/profile-factories.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
 
 `game/evolution_game_v66_57.html` is the versioned archive of an earlier build. It is a historical snapshot and is not kept byte-in-sync with `game/play.html` between releases; `game/play.html` is the stable public-facing copy that gets replaced on each release.
 
@@ -82,9 +90,11 @@ This region sits between `freshRunTracking` and `loadAchievements`, preserving l
 | 3502–4254 | World generation: terrain, habitats, altitude, water, clay deposits |
 | 4253–4478 | Player state object and dynamic world state (waterState, socialGroup, nearbyEntities) |
 | 4479–4489 | Profile/storage constants — generated, source in `src/state/profile-storage-constants.js` |
-| 4491–4762 | Profile state variables and profile functions (currentProfileId, profileLoadStore, profileSaveStore, etc.) |
-| 4763–4794 | Run-tracking state factory (`freshRunTracking`) — generated, source in `src/state/run-tracking.js` |
-| 4800–4865 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source in `src/data/achievement-data.js` |
+| 4491–4499 | Profile state variables (currentProfileId, currentRunId, runGodModeUsed, etc.) |
+| 4500–4512 | Profile factory helpers — generated, source in `src/state/profile-factories.js` |
+| 4514–4766 | Profile functions (profileLoadStore, profileSaveStore, profileCreateNew, etc.) |
+| 4767–4798 | Run-tracking state factory (`freshRunTracking`) — generated, source in `src/state/run-tracking.js` |
+| 4804–4869 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source in `src/data/achievement-data.js` |
 | 4867–5829 | Achievement persistence (load/save/check), profile stats, profiles, save/load, Field Journal, Fossil Record |
 | 5830–5924 | Core utility helpers — generated, source in `src/utils/core-utils.js`: pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation) |
 | 5925–6036 | Remaining [UTILS]: logging, narration setters, noise, risk memory (not extracted — side effects) |
@@ -148,7 +158,7 @@ All rendering is done by a single `render()` call that redraws the map, UI panel
 - **`game/play.html` and `game/evolution_game_v66_57.html` must be kept in sync** on each release. If you edit one, copy the change to the other, or replace `play.html` entirely.
 - **`index.html` and `manifest.json` must both reference `game/play.html`.** The syntax check script verifies `index.html`. Check `manifest.json` manually on releases.
 - **`player.knowledge` / `player.classKnowledge`** accumulate across runs and feed the Field Journal. Incorrect resets at run boundaries lose journal data permanently.
-- **The CSS region, both encounter-data regions, the core-utils region, the achievement-data region, the run-tracking region, and the profile-storage-constants region in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css`, `src/data/encounter-data.js`, `src/utils/core-utils.js`, `src/data/achievement-data.js`, `src/state/run-tracking.js`, and `src/state/profile-storage-constants.js` instead. Do not remove any BEGIN/END marker comments or the `// << SPLIT: hiddenSubtypePools >>` line — the build script requires all of them.
+- **The CSS region, both encounter-data regions, the core-utils region, the achievement-data region, the run-tracking region, the profile-storage-constants region, and the profile-factories region in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css`, `src/data/encounter-data.js`, `src/utils/core-utils.js`, `src/data/achievement-data.js`, `src/state/run-tracking.js`, `src/state/profile-storage-constants.js`, and `src/state/profile-factories.js` instead. Do not remove any BEGIN/END marker comments or the `// << SPLIT: hiddenSubtypePools >>` line — the build script requires all of them.
 
 ---
 

--- a/docs/current-game-structure.md
+++ b/docs/current-game-structure.md
@@ -12,18 +12,19 @@ Evolution Game is a browser-based single-player survival simulation. The player 
 
 The game runs from a single HTML file (`game/play.html`, ~18,400 lines). There is no bundler and no server. Open the file in a browser and it works.
 
-Six source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
+Seven source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
 
 | Source file | What it contains | In play.html |
 |-------------|-----------------|--------------|
 | `src/styles/game.css` | All CSS | Inline `<style>` block |
 | `src/data/encounter-data.js` | `encounters`, `encounterTables`, `hiddenSubtypePools` | Two inline JS regions |
 | `src/utils/core-utils.js` | Pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation helpers) | One inline JS region (~line 5835) |
-| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions array only) | One inline JS region (~line 4800) |
-| `src/state/run-tracking.js` | `freshRunTracking()` factory (run-tracking schema only) | One inline JS region (~line 4763) |
+| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions array only) | One inline JS region (~line 4804) |
+| `src/state/run-tracking.js` | `freshRunTracking()` factory (run-tracking schema only) | One inline JS region (~line 4767) |
 | `src/state/profile-storage-constants.js` | Profile/storage key constants (7 `const` declarations) | One inline JS region (~line 4481) |
+| `src/state/profile-factories.js` | Profile factory helpers (`profileGenerateId`, `profileEmptyStore`, `profileDefaultStats`) | One inline JS region (~line 4500) |
 
-`scripts/build_play_html.mjs` inlines all source files back into `game/play.html`. Only configuration-like declarations are extracted — all profile functions (`profileLoadStore`, `profileSaveStore`, `profileCreateNew`, etc.), achievement persistence, fossil record logic, active-run logic, save/load logic, and all other game code remain inside `game/play.html`. All JavaScript engine code and HTML structure also remain inside `game/play.html` for now.
+`scripts/build_play_html.mjs` inlines all source files back into `game/play.html`. Only configuration-like declarations and simple factory/helper functions are extracted — `profileLoadStore`, `profileSaveStore`, `profileCreateNew`, fossil record logic, active-run logic, achievement persistence, save/load logic, and all other game code remain inside `game/play.html`. All JavaScript engine code and HTML structure also remain inside `game/play.html` for now.
 
 ---
 
@@ -274,9 +275,11 @@ flowchart TD
 | 3631–4252 | World generation: terrain, habitats, altitude, water, clay deposits |
 | 4253–4478 | Player state object and dynamic world state (waterState, socialGroup, nearbyEntities) |
 | 4479–4489 | Profile/storage constants — generated, source is `src/state/profile-storage-constants.js` |
-| 4491–4762 | Profile state variables and profile functions (currentProfileId, profileLoadStore, profileSaveStore, etc.) |
-| 4763–4794 | Run-tracking state factory (`freshRunTracking`) — generated, source is `src/state/run-tracking.js` |
-| 4800–4865 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source is `src/data/achievement-data.js` |
+| 4491–4499 | Profile state variables (currentProfileId, currentRunId, runGodModeUsed, etc.) |
+| 4500–4512 | Profile factory helpers — generated, source is `src/state/profile-factories.js` |
+| 4514–4766 | Profile functions (profileLoadStore, profileSaveStore, profileCreateNew, etc.) |
+| 4767–4798 | Run-tracking state factory (`freshRunTracking`) — generated, source is `src/state/run-tracking.js` |
+| 4804–4869 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source is `src/data/achievement-data.js` |
 | 4867–5829 | Achievement persistence (load/save/check), profile stats, profiles, save/load, Field Journal, Fossil Record |
 | 5830–5924 | Core utilities — generated, source is `src/utils/core-utils.js`: pure helpers (clamp, roll, choice, clonePlain, escapeHtml, etc.) |
 | 5925–6036 | Remaining utilities: logging, debug helpers, narration setters |
@@ -330,6 +333,7 @@ The rebuild plan (see `docs/project-plan.md`) targets extraction in this rough o
 | `src/data/achievement-data.js` | `// BEGIN/END GENERATED JS: src/data/achievement-data.js` |
 | `src/state/run-tracking.js` | `// BEGIN/END GENERATED JS: src/state/run-tracking.js` |
 | `src/state/profile-storage-constants.js` | `// BEGIN/END GENERATED JS: src/state/profile-storage-constants.js` |
+| `src/state/profile-factories.js` | `// BEGIN/END GENERATED JS: src/state/profile-factories.js` |
 
 The source file `src/data/encounter-data.js` contains a `// << SPLIT: hiddenSubtypePools >>` line dividing part 1 (encounters + encounterTables) from part 2 (hiddenSubtypePools). The build script splits on this marker and inlines each part into its respective location in `play.html`. All other source files have no split marker — each maps to one contiguous region.
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -20,7 +20,8 @@ Run through this every time a new version becomes the stable build.
 - [ ] If `src/data/achievement-data.js` was changed, `node scripts/build_play_html.mjs` was run to inline the achievement definitions into `game/play.html`
 - [ ] If `src/state/run-tracking.js` was changed, `node scripts/build_play_html.mjs` was run to inline the run-tracking factory into `game/play.html`
 - [ ] If `src/state/profile-storage-constants.js` was changed, `node scripts/build_play_html.mjs` was run to inline the profile/storage constants into `game/play.html`
-- [ ] The generated regions in `game/play.html` were not hand-edited (CSS → `src/styles/game.css`; encounter data → `src/data/encounter-data.js`; utility helpers → `src/utils/core-utils.js`; achievement defs → `src/data/achievement-data.js`; run-tracking factory → `src/state/run-tracking.js`; profile/storage constants → `src/state/profile-storage-constants.js`)
+- [ ] If `src/state/profile-factories.js` was changed, `node scripts/build_play_html.mjs` was run to inline the profile factory helpers into `game/play.html`
+- [ ] The generated regions in `game/play.html` were not hand-edited (CSS → `src/styles/game.css`; encounter data → `src/data/encounter-data.js`; utility helpers → `src/utils/core-utils.js`; achievement defs → `src/data/achievement-data.js`; run-tracking factory → `src/state/run-tracking.js`; profile/storage constants → `src/state/profile-storage-constants.js`; profile factory helpers → `src/state/profile-factories.js`)
 
 ## Syntax and render check
 

--- a/game/play.html
+++ b/game/play.html
@@ -4497,9 +4497,19 @@ let runStartedAt = null;
 let winAchievedThisRun = false;
 let runNewAchievements = [];
 
+// BEGIN GENERATED JS: src/state/profile-factories.js
 function profileGenerateId(prefix) {
   return prefix + "_" + Date.now() + "_" + Math.random().toString(36).slice(2, 8);
 }
+
+function profileEmptyStore() {
+  return {schemaVersion: 1, profiles: {}};
+}
+
+function profileDefaultStats() {
+  return {totalRuns: 0, completedRuns: 0, deaths: 0, wins: 0, godModeRuns: 0, bestTurn: 0, bestMatingCount: 0, bestKnowledgeUnlocks: 0, totalTurns: 0, totalMatings: 0};
+}
+// END GENERATED JS: src/state/profile-factories.js
 
 function profileLoadStore() {
   try {
@@ -4525,14 +4535,6 @@ function profileSaveStore(data) {
     addDebugTrace("profile-save-error", {error: String(e)});
     return false;
   }
-}
-
-function profileEmptyStore() {
-  return {schemaVersion: 1, profiles: {}};
-}
-
-function profileDefaultStats() {
-  return {totalRuns: 0, completedRuns: 0, deaths: 0, wins: 0, godModeRuns: 0, bestTurn: 0, bestMatingCount: 0, bestKnowledgeUnlocks: 0, totalTurns: 0, totalMatings: 0};
 }
 
 function profileCreateNew(name) {

--- a/scripts/build_play_html.mjs
+++ b/scripts/build_play_html.mjs
@@ -13,6 +13,7 @@
 //   4. src/data/achievement-data.js → one JS region (~line 4800)
 //   5. src/state/run-tracking.js   → one JS region (~line 4763)
 //   6. src/state/profile-storage-constants.js → one JS region (~line 4481)
+//   7. src/state/profile-factories.js → one JS region (~line 4500)
 //
 // Why inline (not external files): game/play.html must open straight from
 // disk — or via the GitHub Pages link — with no build step and no runtime
@@ -35,8 +36,9 @@ const DATA_SOURCE     = resolve(repoRoot, 'src/data/encounter-data.js');
 const UTILS_SOURCE    = resolve(repoRoot, 'src/utils/core-utils.js');
 const ACHIEVE_SOURCE  = resolve(repoRoot, 'src/data/achievement-data.js');
 const RUNTRACK_SOURCE = resolve(repoRoot, 'src/state/run-tracking.js');
-const PROFCONST_SOURCE = resolve(repoRoot, 'src/state/profile-storage-constants.js');
-const PLAY_HTML       = resolve(repoRoot, 'game/play.html');
+const PROFCONST_SOURCE   = resolve(repoRoot, 'src/state/profile-storage-constants.js');
+const PROFFACT_SOURCE    = resolve(repoRoot, 'src/state/profile-factories.js');
+const PLAY_HTML          = resolve(repoRoot, 'game/play.html');
 
 // CSS markers (CSS comment style, inside <style>)
 const CSS_BEGIN = '/* BEGIN GENERATED CSS: src/styles/game.css */';
@@ -63,6 +65,10 @@ const JS_END_RUNTRACK    = '// END GENERATED JS: src/state/run-tracking.js';
 // Profile-storage-constants markers (JS comment style, inside <script>)
 const JS_BEGIN_PROFCONST = '// BEGIN GENERATED JS: src/state/profile-storage-constants.js';
 const JS_END_PROFCONST   = '// END GENERATED JS: src/state/profile-storage-constants.js';
+
+// Profile-factories markers (JS comment style, inside <script>)
+const JS_BEGIN_PROFFACT = '// BEGIN GENERATED JS: src/state/profile-factories.js';
+const JS_END_PROFFACT   = '// END GENERATED JS: src/state/profile-factories.js';
 
 // The split comment that divides the source file into part1 and part2.
 // It is NOT inlined into game/play.html.
@@ -94,6 +100,7 @@ if (!existsSync(UTILS_SOURCE))    fail('cannot find src/utils/core-utils.js');
 if (!existsSync(ACHIEVE_SOURCE))  fail('cannot find src/data/achievement-data.js');
 if (!existsSync(RUNTRACK_SOURCE))  fail('cannot find src/state/run-tracking.js');
 if (!existsSync(PROFCONST_SOURCE)) fail('cannot find src/state/profile-storage-constants.js');
+if (!existsSync(PROFFACT_SOURCE))  fail('cannot find src/state/profile-factories.js');
 if (!existsSync(PLAY_HTML))        fail('cannot find game/play.html');
 
 const css          = readFileSync(CSS_SOURCE,       'utf8');
@@ -102,6 +109,7 @@ const jsUtils      = readFileSync(UTILS_SOURCE,     'utf8');
 const jsAchieve    = readFileSync(ACHIEVE_SOURCE,   'utf8');
 const jsRunTrack   = readFileSync(RUNTRACK_SOURCE,  'utf8');
 const jsProfConst  = readFileSync(PROFCONST_SOURCE, 'utf8');
+const jsProfFact   = readFileSync(PROFFACT_SOURCE,  'utf8');
 let   html         = readFileSync(PLAY_HTML,        'utf8');
 
 // --- Split encounter-data into two parts at the SPLIT marker ---
@@ -119,6 +127,7 @@ html = inlineRegion(html, JS_BEGIN_UTILS,   JS_END_UTILS,   jsUtils.replace(/\s+
 html = inlineRegion(html, JS_BEGIN_ACHIEVE,  JS_END_ACHIEVE,  jsAchieve.replace(/\s+$/, ''),  'achievement-data');
 html = inlineRegion(html, JS_BEGIN_RUNTRACK,  JS_END_RUNTRACK,  jsRunTrack.replace(/\s+$/, ''),  'run-tracking');
 html = inlineRegion(html, JS_BEGIN_PROFCONST, JS_END_PROFCONST, jsProfConst.replace(/\s+$/, ''), 'profile-storage-constants');
+html = inlineRegion(html, JS_BEGIN_PROFFACT,  JS_END_PROFFACT,  jsProfFact.replace(/\s+$/, ''),  'profile-factories');
 
 if (html === original) {
   console.log('build_play_html: no change — game/play.html already matches all source files.');

--- a/src/state/profile-factories.js
+++ b/src/state/profile-factories.js
@@ -1,0 +1,11 @@
+function profileGenerateId(prefix) {
+  return prefix + "_" + Date.now() + "_" + Math.random().toString(36).slice(2, 8);
+}
+
+function profileEmptyStore() {
+  return {schemaVersion: 1, profiles: {}};
+}
+
+function profileDefaultStats() {
+  return {totalRuns: 0, completedRuns: 0, deaths: 0, wins: 0, godModeRuns: 0, bestTurn: 0, bestMatingCount: 0, bestKnowledgeUnlocks: 0, totalTurns: 0, totalMatings: 0};
+}


### PR DESCRIPTION
## Summary

Seventh controlled extraction in the build scaffold series. Moves three profile factory/helper functions out of `game/play.html` into `src/state/profile-factories.js`, and wires them into `scripts/build_play_html.mjs` so they are inlined back at build time.

`game/play.html` remains the directly playable artifact — all content is still inline, no runtime dependencies.

---

## What changed

- **Created** `src/state/profile-factories.js` — holds exactly three functions:
  - `profileGenerateId(prefix)` — generates a unique timestamped ID string
  - `profileEmptyStore()` — returns a minimal empty profile store object
  - `profileDefaultStats()` — returns a zeroed stats object for a new profile
- **`game/play.html`** — the three function declarations replaced with a single `// BEGIN/END GENERATED JS: src/state/profile-factories.js` region; all surrounding code unchanged
- **`scripts/build_play_html.mjs`** — wired to read `src/state/profile-factories.js` and inline it into the new region; now inlines all seven source files (CSS, encounter data, core utils, achievement definitions, run-tracking state factory, profile/storage constants, profile factory helpers)
- **`README.md`** — repo layout tree and build scaffold table updated
- **`docs/current-game-structure.md`** — line-range table, build scaffold table, and marker table updated
- **`docs/architecture-notes.md`** — generated regions list, line-range table, fragile areas, and do-not-edit directive updated
- **`docs/release-checklist.md`** — build step checklist updated with profile-factories entry
- **`CHANGELOG.txt`** — entry added

---

## Scope confirmation

Only `profileGenerateId`, `profileEmptyStore`, and `profileDefaultStats` were extracted. The three functions were not contiguous in the original file; they have been consolidated into one generated region placed before `profileLoadStore`. This is safe because `function` declarations are hoisted in JavaScript.

`profileLoadStore`, `profileSaveStore`, `profileCreateNew`, `profileGetActive`, `profileCheckBuildCompatibility`, `profileCaptureWorldArrays`, `profileCaptureState`, `profileRestoreState`, `profileUpdateStats`, `profileOnRunEnd`, fossil record logic, active-run logic, achievement persistence, and save/load logic all remain in `game/play.html` unchanged.

No function bodies changed. No call sites changed. No save/profile behaviour changed. No gameplay logic changed. No CSS, encounter data, achievement data, run-tracking data, or profile/storage constants changed.

---

## Verification

- `node scripts/build_play_html.mjs` ran after adding markers — reported **no change** (inline block already matched source exactly)
- `node scripts/check_html_js_syntax.mjs` passed with no errors
- Inline region diff confirmed byte-for-byte match between `src/state/profile-factories.js` and the generated region in `game/play.html`
- Marker placement: BEGIN at line 4500, END at line 4512; `let currentProfileId = null;` and other profile state variables at lines 4491–4499 immediately before; `profileLoadStore` at line 4514 immediately after — load order preserved

---

## Scope

- [ ] Gameplay logic
- [ ] UI/layout
- [ ] Bot/debug tools
- [ ] App-loading/PWA files
- [x] Documentation/workflow
- [x] Repository structure (source extraction / build scaffold)

---

## Smoke check

Static review only. `game/play.html` was not opened in a browser this session. The syntax check passed and the build script confirmed idempotency. George should open `game/play.html` in a browser and confirm the game loads before merging.

---

Documentation updated: `README.md`, `docs/current-game-structure.md`, `docs/architecture-notes.md`, `docs/release-checklist.md`, `CHANGELOG.txt`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKFcTXWzunyBYGnVrpUzLd)_