### PR TITLE
Extract profile store core source

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,24 @@
+[2026-06-04 extract-profile-store-core | Claude]
+Eighth controlled extraction — profile store core helper functions extracted and build script extended.
+
+- Created src/state/profile-store-core.js: five profile store functions moved mechanically from game/play.html, byte-identical to the originals.
+  - profileLoadStore(): reads profile data from localStorage, returning profileEmptyStore() on parse failure.
+  - profileSaveStore(data): writes profile data to localStorage, returning true/false.
+  - profileCreateNew(name): creates a new profile entry, persists it, and sets currentProfileId.
+  - profileGetActive(): returns the current profile object or null.
+  - profileCheckBuildCompatibility(profile): compares profile.buildId to GAME_VERSION.
+  - No function names changed. No function bodies changed. No localStorage keys changed. No profile schema changed.
+- Edited game/play.html: the five functions replaced with a single // BEGIN/END GENERATED JS: src/state/profile-store-core.js region.
+  - The generated region sits immediately after the profile-factories region and before profileCaptureWorldArrays — preserving load order.
+  - The five functions were contiguous; no hoisting shuffle was required.
+  - Only the five approved functions were extracted. profileCaptureWorldArrays, profileCaptureState, profileRestoreState, profileUpdateStats, profileOnRunEnd, fossil record logic, active-run logic, achievement persistence, and save/load logic remain in game/play.html. No call sites changed.
+  - game/play.html remains the directly playable artifact.
+- Extended scripts/build_play_html.mjs: now inlines CSS, encounter data, core utils, achievement definitions, run-tracking state factory, profile/storage constants, profile factory helpers, and profile store core helpers. Fails clearly if src/state/profile-store-core.js or its region markers are missing. Idempotent.
+- game/evolution_game_v66_57.html NOT changed: historical archive, not kept byte-synced between releases.
+- Docs: README.md (repo layout tree + build scaffold table), docs/current-game-structure.md (line-range table, build scaffold table, marker table), docs/architecture-notes.md (generated region + markers, line-range table, fragile-area note), docs/release-checklist.md (build step check for profile-store-core).
+- Verification: node scripts/build_play_html.mjs (idempotent — no change) and node scripts/check_html_js_syntax.mjs both pass. Extracted source verified to match the inline region (excluding markers and trailing whitespace).
+- Source/build structure change only. No gameplay logic, function bodies, call sites, save/profile behaviour, localStorage keys, profile schema, achievement logic, fossil record logic, rendering, CSS, encounter data, core utility code, run-tracking code, profile/storage constants, or factory helpers changed.
+
 [2026-06-04 extract-profile-factories | Claude]
 Seventh controlled extraction — profile factory helper functions extracted and build script extended.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ evolution-game/
 │   └── state/
 │       ├── run-tracking.js           Run-tracking state factory source (inlined into play.html by the build script)
 │       ├── profile-storage-constants.js  Profile/storage constant declarations (inlined into play.html by the build script)
-│       └── profile-factories.js      Profile factory/helper functions source (inlined into play.html by the build script)
+│       ├── profile-factories.js      Profile factory/helper functions source (inlined into play.html by the build script)
+│       └── profile-store-core.js     Profile store core helpers source (inlined into play.html by the build script)
 ├── docs/
 │   ├── current-game-structure.md     How the game works now: systems, flows, line ranges
 │   ├── documentation-map.md          What each doc covers and when to update it
@@ -141,17 +142,18 @@ The rebuild is not a rewrite, not a framework migration, and not a gameplay rede
 
 ### Build scaffold
 
-Seven source extractions are complete:
+Eight source extractions are complete:
 
 | Source file | What it contains | Destination in play.html |
 |-------------|-----------------|--------------------------|
 | `src/styles/game.css` | All CSS | Inline `<style>` block |
 | `src/data/encounter-data.js` | `encounters`, `encounterTables`, `hiddenSubtypePools` | Two JS regions (~line 1040 and ~line 6037) |
 | `src/utils/core-utils.js` | Pure stateless helper functions | One JS region (~line 5835) |
-| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions only; persistence stays in play.html) | One JS region (~line 4804) |
-| `src/state/run-tracking.js` | `freshRunTracking()` (factory only; save/profile logic stays in play.html) | One JS region (~line 4767) |
+| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions only; persistence stays in play.html) | One JS region (~line 4806) |
+| `src/state/run-tracking.js` | `freshRunTracking()` (factory only; save/profile logic stays in play.html) | One JS region (~line 4769) |
 | `src/state/profile-storage-constants.js` | Profile/storage key constants (7 `const` declarations; all profile logic stays in play.html) | One JS region (~line 4481) |
 | `src/state/profile-factories.js` | Profile factory/helper functions (`profileGenerateId`, `profileEmptyStore`, `profileDefaultStats`; all other profile logic stays in play.html) | One JS region (~line 4500) |
+| `src/state/profile-store-core.js` | Profile store core helpers (`profileLoadStore`, `profileSaveStore`, `profileCreateNew`, `profileGetActive`, `profileCheckBuildCompatibility`; all other profile logic stays in play.html) | One JS region (~line 4514) |
 
 `game/play.html` keeps all content **inline** so it stays directly playable with no build step or runtime dependency. To regenerate `game/play.html` after editing any source file:
 

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -8,7 +8,7 @@ This document is a map of how the game HTML file is organised. Read this before 
 
 The entire game lives in one large HTML file (`game/play.html`, ~18,400 lines). There is no build step, no bundler, and no separate JavaScript files. Everything — CSS, HTML structure, and all JavaScript — is in one file.
 
-Seven source files have been extracted and are inlined back into `game/play.html` by `scripts/build_play_html.mjs`. The playable file still ships all content inline, so it works with no build step at runtime. The build script replaces only the regions between these marker comments:
+Eight source files have been extracted and are inlined back into `game/play.html` by `scripts/build_play_html.mjs`. The playable file still ships all content inline, so it works with no build step at runtime. The build script replaces only the regions between these marker comments:
 
 **CSS** (inside the `<style>` block) — source `src/styles/game.css`:
 ```
@@ -54,6 +54,14 @@ This region sits immediately after the `// ===== PROFILE SAVE SYSTEM =====` bann
 ```
 This region sits after the profile state variables and before `profileLoadStore`, preserving load order. Only `profileGenerateId`, `profileEmptyStore`, and `profileDefaultStats` are extracted; `profileLoadStore`, `profileSaveStore`, `profileCreateNew`, fossil record logic, active-run logic, achievement persistence, and save/load logic remain in `game/play.html`. The three functions were not contiguous in the original file; they have been consolidated into this single region (safe because `function` declarations are hoisted). Profile factory helpers should be edited in `src/state/profile-factories.js`, not inside the generated region of `game/play.html`.
 
+**Profile store core helpers** (inside the `<script>` block, ~line 4514) — five profile store functions:
+```
+// BEGIN GENERATED JS: src/state/profile-store-core.js
+...generated js...
+// END GENERATED JS: src/state/profile-store-core.js
+```
+This region sits immediately after the profile factory helpers region and before `profileCaptureWorldArrays`, preserving load order. Only `profileLoadStore`, `profileSaveStore`, `profileCreateNew`, `profileGetActive`, and `profileCheckBuildCompatibility` are extracted; `profileCaptureWorldArrays`, `profileCaptureState`, `profileRestoreState`, `profileUpdateStats`, `profileOnRunEnd`, fossil record logic, active-run logic, achievement persistence, and save/load logic remain in `game/play.html`. Profile store core helpers should be edited in `src/state/profile-store-core.js`, not inside the generated region of `game/play.html`.
+
 **Run-tracking state factory** (inside the `<script>` block, ~line 4763) — the `freshRunTracking()` function only:
 ```
 // BEGIN GENERATED JS: src/state/run-tracking.js
@@ -72,7 +80,7 @@ This region sits between `freshRunTracking` and `loadAchievements`, preserving l
 
 `src/data/encounter-data.js` uses a `// << SPLIT: hiddenSubtypePools >>` line to divide part 1 from part 2; the build script splits on it and inlines each part into its region. The split marker itself is not inlined. All other source files have no split marker and each maps to one contiguous region.
 
-**Edit CSS in `src/styles/game.css`, encounter data in `src/data/encounter-data.js`, pure utility helpers in `src/utils/core-utils.js`, achievement definitions in `src/data/achievement-data.js`, run-tracking factory in `src/state/run-tracking.js`, profile/storage constants in `src/state/profile-storage-constants.js`, and profile factory helpers in `src/state/profile-factories.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
+**Edit CSS in `src/styles/game.css`, encounter data in `src/data/encounter-data.js`, pure utility helpers in `src/utils/core-utils.js`, achievement definitions in `src/data/achievement-data.js`, run-tracking factory in `src/state/run-tracking.js`, profile/storage constants in `src/state/profile-storage-constants.js`, profile factory helpers in `src/state/profile-factories.js`, and profile store core helpers in `src/state/profile-store-core.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
 
 `game/evolution_game_v66_57.html` is the versioned archive of an earlier build. It is a historical snapshot and is not kept byte-in-sync with `game/play.html` between releases; `game/play.html` is the stable public-facing copy that gets replaced on each release.
 
@@ -92,9 +100,10 @@ This region sits between `freshRunTracking` and `loadAchievements`, preserving l
 | 4479–4489 | Profile/storage constants — generated, source in `src/state/profile-storage-constants.js` |
 | 4491–4499 | Profile state variables (currentProfileId, currentRunId, runGodModeUsed, etc.) |
 | 4500–4512 | Profile factory helpers — generated, source in `src/state/profile-factories.js` |
-| 4514–4766 | Profile functions (profileLoadStore, profileSaveStore, profileCreateNew, etc.) |
-| 4767–4798 | Run-tracking state factory (`freshRunTracking`) — generated, source in `src/state/run-tracking.js` |
-| 4804–4869 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source in `src/data/achievement-data.js` |
+| 4514–4577 | Profile store core helpers — generated, source in `src/state/profile-store-core.js` |
+| 4579–4768 | Remaining profile functions (profileCaptureWorldArrays, profileCaptureState, profileRestoreState, profileUpdateStats, profileOnRunEnd, etc.) |
+| 4769–4800 | Run-tracking state factory (`freshRunTracking`) — generated, source in `src/state/run-tracking.js` |
+| 4806–4871 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source in `src/data/achievement-data.js` |
 | 4867–5829 | Achievement persistence (load/save/check), profile stats, profiles, save/load, Field Journal, Fossil Record |
 | 5830–5924 | Core utility helpers — generated, source in `src/utils/core-utils.js`: pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation) |
 | 5925–6036 | Remaining [UTILS]: logging, narration setters, noise, risk memory (not extracted — side effects) |
@@ -158,7 +167,7 @@ All rendering is done by a single `render()` call that redraws the map, UI panel
 - **`game/play.html` and `game/evolution_game_v66_57.html` must be kept in sync** on each release. If you edit one, copy the change to the other, or replace `play.html` entirely.
 - **`index.html` and `manifest.json` must both reference `game/play.html`.** The syntax check script verifies `index.html`. Check `manifest.json` manually on releases.
 - **`player.knowledge` / `player.classKnowledge`** accumulate across runs and feed the Field Journal. Incorrect resets at run boundaries lose journal data permanently.
-- **The CSS region, both encounter-data regions, the core-utils region, the achievement-data region, the run-tracking region, the profile-storage-constants region, and the profile-factories region in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css`, `src/data/encounter-data.js`, `src/utils/core-utils.js`, `src/data/achievement-data.js`, `src/state/run-tracking.js`, `src/state/profile-storage-constants.js`, and `src/state/profile-factories.js` instead. Do not remove any BEGIN/END marker comments or the `// << SPLIT: hiddenSubtypePools >>` line — the build script requires all of them.
+- **The CSS region, both encounter-data regions, the core-utils region, the achievement-data region, the run-tracking region, the profile-storage-constants region, the profile-factories region, and the profile-store-core region in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css`, `src/data/encounter-data.js`, `src/utils/core-utils.js`, `src/data/achievement-data.js`, `src/state/run-tracking.js`, `src/state/profile-storage-constants.js`, `src/state/profile-factories.js`, and `src/state/profile-store-core.js` instead. Do not remove any BEGIN/END marker comments or the `// << SPLIT: hiddenSubtypePools >>` line — the build script requires all of them.
 
 ---
 

--- a/docs/current-game-structure.md
+++ b/docs/current-game-structure.md
@@ -12,19 +12,20 @@ Evolution Game is a browser-based single-player survival simulation. The player 
 
 The game runs from a single HTML file (`game/play.html`, ~18,400 lines). There is no bundler and no server. Open the file in a browser and it works.
 
-Seven source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
+Eight source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
 
 | Source file | What it contains | In play.html |
 |-------------|-----------------|--------------|
 | `src/styles/game.css` | All CSS | Inline `<style>` block |
 | `src/data/encounter-data.js` | `encounters`, `encounterTables`, `hiddenSubtypePools` | Two inline JS regions |
 | `src/utils/core-utils.js` | Pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation helpers) | One inline JS region (~line 5835) |
-| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions array only) | One inline JS region (~line 4804) |
-| `src/state/run-tracking.js` | `freshRunTracking()` factory (run-tracking schema only) | One inline JS region (~line 4767) |
+| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions array only) | One inline JS region (~line 4806) |
+| `src/state/run-tracking.js` | `freshRunTracking()` factory (run-tracking schema only) | One inline JS region (~line 4769) |
 | `src/state/profile-storage-constants.js` | Profile/storage key constants (7 `const` declarations) | One inline JS region (~line 4481) |
 | `src/state/profile-factories.js` | Profile factory helpers (`profileGenerateId`, `profileEmptyStore`, `profileDefaultStats`) | One inline JS region (~line 4500) |
+| `src/state/profile-store-core.js` | Profile store core helpers (`profileLoadStore`, `profileSaveStore`, `profileCreateNew`, `profileGetActive`, `profileCheckBuildCompatibility`) | One inline JS region (~line 4514) |
 
-`scripts/build_play_html.mjs` inlines all source files back into `game/play.html`. Only configuration-like declarations and simple factory/helper functions are extracted — `profileLoadStore`, `profileSaveStore`, `profileCreateNew`, fossil record logic, active-run logic, achievement persistence, save/load logic, and all other game code remain inside `game/play.html`. All JavaScript engine code and HTML structure also remain inside `game/play.html` for now.
+`scripts/build_play_html.mjs` inlines all source files back into `game/play.html`. Only configuration-like declarations and simple factory/helper functions are extracted — `profileCaptureWorldArrays`, `profileCaptureState`, `profileRestoreState`, `profileUpdateStats`, `profileOnRunEnd`, fossil record logic, active-run logic, achievement persistence, save/load logic, and all other game code remain inside `game/play.html`. All JavaScript engine code and HTML structure also remain inside `game/play.html` for now.
 
 ---
 
@@ -277,9 +278,10 @@ flowchart TD
 | 4479–4489 | Profile/storage constants — generated, source is `src/state/profile-storage-constants.js` |
 | 4491–4499 | Profile state variables (currentProfileId, currentRunId, runGodModeUsed, etc.) |
 | 4500–4512 | Profile factory helpers — generated, source is `src/state/profile-factories.js` |
-| 4514–4766 | Profile functions (profileLoadStore, profileSaveStore, profileCreateNew, etc.) |
-| 4767–4798 | Run-tracking state factory (`freshRunTracking`) — generated, source is `src/state/run-tracking.js` |
-| 4804–4869 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source is `src/data/achievement-data.js` |
+| 4514–4577 | Profile store core helpers — generated, source is `src/state/profile-store-core.js` |
+| 4579–4768 | Remaining profile functions (profileCaptureWorldArrays, profileCaptureState, profileRestoreState, profileUpdateStats, profileOnRunEnd, etc.) |
+| 4769–4800 | Run-tracking state factory (`freshRunTracking`) — generated, source is `src/state/run-tracking.js` |
+| 4806–4871 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source is `src/data/achievement-data.js` |
 | 4867–5829 | Achievement persistence (load/save/check), profile stats, profiles, save/load, Field Journal, Fossil Record |
 | 5830–5924 | Core utilities — generated, source is `src/utils/core-utils.js`: pure helpers (clamp, roll, choice, clonePlain, escapeHtml, etc.) |
 | 5925–6036 | Remaining utilities: logging, debug helpers, narration setters |
@@ -334,6 +336,7 @@ The rebuild plan (see `docs/project-plan.md`) targets extraction in this rough o
 | `src/state/run-tracking.js` | `// BEGIN/END GENERATED JS: src/state/run-tracking.js` |
 | `src/state/profile-storage-constants.js` | `// BEGIN/END GENERATED JS: src/state/profile-storage-constants.js` |
 | `src/state/profile-factories.js` | `// BEGIN/END GENERATED JS: src/state/profile-factories.js` |
+| `src/state/profile-store-core.js` | `// BEGIN/END GENERATED JS: src/state/profile-store-core.js` |
 
 The source file `src/data/encounter-data.js` contains a `// << SPLIT: hiddenSubtypePools >>` line dividing part 1 (encounters + encounterTables) from part 2 (hiddenSubtypePools). The build script splits on this marker and inlines each part into its respective location in `play.html`. All other source files have no split marker — each maps to one contiguous region.
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -21,7 +21,8 @@ Run through this every time a new version becomes the stable build.
 - [ ] If `src/state/run-tracking.js` was changed, `node scripts/build_play_html.mjs` was run to inline the run-tracking factory into `game/play.html`
 - [ ] If `src/state/profile-storage-constants.js` was changed, `node scripts/build_play_html.mjs` was run to inline the profile/storage constants into `game/play.html`
 - [ ] If `src/state/profile-factories.js` was changed, `node scripts/build_play_html.mjs` was run to inline the profile factory helpers into `game/play.html`
-- [ ] The generated regions in `game/play.html` were not hand-edited (CSS → `src/styles/game.css`; encounter data → `src/data/encounter-data.js`; utility helpers → `src/utils/core-utils.js`; achievement defs → `src/data/achievement-data.js`; run-tracking factory → `src/state/run-tracking.js`; profile/storage constants → `src/state/profile-storage-constants.js`; profile factory helpers → `src/state/profile-factories.js`)
+- [ ] If `src/state/profile-store-core.js` was changed, `node scripts/build_play_html.mjs` was run to inline the profile store core helpers into `game/play.html`
+- [ ] The generated regions in `game/play.html` were not hand-edited (CSS → `src/styles/game.css`; encounter data → `src/data/encounter-data.js`; utility helpers → `src/utils/core-utils.js`; achievement defs → `src/data/achievement-data.js`; run-tracking factory → `src/state/run-tracking.js`; profile/storage constants → `src/state/profile-storage-constants.js`; profile factory helpers → `src/state/profile-factories.js`; profile store core helpers → `src/state/profile-store-core.js`)
 
 ## Syntax and render check
 

--- a/game/play.html
+++ b/game/play.html
@@ -4511,6 +4511,7 @@ function profileDefaultStats() {
 }
 // END GENERATED JS: src/state/profile-factories.js
 
+// BEGIN GENERATED JS: src/state/profile-store-core.js
 function profileLoadStore() {
   try {
     const raw = localStorage.getItem(PROFILE_STORE_KEY);
@@ -4573,6 +4574,7 @@ function profileCheckBuildCompatibility(profile) {
   if (!compatible) addDebugTrace("profile-build-mismatch", {savedBuild, localBuild, profileId: profile.profileId});
   return {compatible, savedBuild, localBuild};
 }
+// END GENERATED JS: src/state/profile-store-core.js
 
 function profileCaptureWorldArrays() {
   return {

--- a/scripts/build_play_html.mjs
+++ b/scripts/build_play_html.mjs
@@ -14,6 +14,7 @@
 //   5. src/state/run-tracking.js   → one JS region (~line 4763)
 //   6. src/state/profile-storage-constants.js → one JS region (~line 4481)
 //   7. src/state/profile-factories.js → one JS region (~line 4500)
+//   8. src/state/profile-store-core.js → one JS region (~line 4514)
 //
 // Why inline (not external files): game/play.html must open straight from
 // disk — or via the GitHub Pages link — with no build step and no runtime
@@ -38,6 +39,7 @@ const ACHIEVE_SOURCE  = resolve(repoRoot, 'src/data/achievement-data.js');
 const RUNTRACK_SOURCE = resolve(repoRoot, 'src/state/run-tracking.js');
 const PROFCONST_SOURCE   = resolve(repoRoot, 'src/state/profile-storage-constants.js');
 const PROFFACT_SOURCE    = resolve(repoRoot, 'src/state/profile-factories.js');
+const PROFCORE_SOURCE    = resolve(repoRoot, 'src/state/profile-store-core.js');
 const PLAY_HTML          = resolve(repoRoot, 'game/play.html');
 
 // CSS markers (CSS comment style, inside <style>)
@@ -70,6 +72,10 @@ const JS_END_PROFCONST   = '// END GENERATED JS: src/state/profile-storage-const
 const JS_BEGIN_PROFFACT = '// BEGIN GENERATED JS: src/state/profile-factories.js';
 const JS_END_PROFFACT   = '// END GENERATED JS: src/state/profile-factories.js';
 
+// Profile-store-core markers (JS comment style, inside <script>)
+const JS_BEGIN_PROFCORE = '// BEGIN GENERATED JS: src/state/profile-store-core.js';
+const JS_END_PROFCORE   = '// END GENERATED JS: src/state/profile-store-core.js';
+
 // The split comment that divides the source file into part1 and part2.
 // It is NOT inlined into game/play.html.
 const JS_SPLIT  = '// << SPLIT: hiddenSubtypePools >>';
@@ -101,6 +107,7 @@ if (!existsSync(ACHIEVE_SOURCE))  fail('cannot find src/data/achievement-data.js
 if (!existsSync(RUNTRACK_SOURCE))  fail('cannot find src/state/run-tracking.js');
 if (!existsSync(PROFCONST_SOURCE)) fail('cannot find src/state/profile-storage-constants.js');
 if (!existsSync(PROFFACT_SOURCE))  fail('cannot find src/state/profile-factories.js');
+if (!existsSync(PROFCORE_SOURCE))  fail('cannot find src/state/profile-store-core.js');
 if (!existsSync(PLAY_HTML))        fail('cannot find game/play.html');
 
 const css          = readFileSync(CSS_SOURCE,       'utf8');
@@ -110,6 +117,7 @@ const jsAchieve    = readFileSync(ACHIEVE_SOURCE,   'utf8');
 const jsRunTrack   = readFileSync(RUNTRACK_SOURCE,  'utf8');
 const jsProfConst  = readFileSync(PROFCONST_SOURCE, 'utf8');
 const jsProfFact   = readFileSync(PROFFACT_SOURCE,  'utf8');
+const jsProfCore   = readFileSync(PROFCORE_SOURCE,  'utf8');
 let   html         = readFileSync(PLAY_HTML,        'utf8');
 
 // --- Split encounter-data into two parts at the SPLIT marker ---
@@ -128,6 +136,7 @@ html = inlineRegion(html, JS_BEGIN_ACHIEVE,  JS_END_ACHIEVE,  jsAchieve.replace(
 html = inlineRegion(html, JS_BEGIN_RUNTRACK,  JS_END_RUNTRACK,  jsRunTrack.replace(/\s+$/, ''),  'run-tracking');
 html = inlineRegion(html, JS_BEGIN_PROFCONST, JS_END_PROFCONST, jsProfConst.replace(/\s+$/, ''), 'profile-storage-constants');
 html = inlineRegion(html, JS_BEGIN_PROFFACT,  JS_END_PROFFACT,  jsProfFact.replace(/\s+$/, ''),  'profile-factories');
+html = inlineRegion(html, JS_BEGIN_PROFCORE,  JS_END_PROFCORE,  jsProfCore.replace(/\s+$/, ''),  'profile-store-core');
 
 if (html === original) {
   console.log('build_play_html: no change — game/play.html already matches all source files.');

--- a/src/state/profile-store-core.js
+++ b/src/state/profile-store-core.js
@@ -1,0 +1,62 @@
+function profileLoadStore() {
+  try {
+    const raw = localStorage.getItem(PROFILE_STORE_KEY);
+    if (!raw) return profileEmptyStore();
+    const data = JSON.parse(raw);
+    if (!data || typeof data !== "object") throw new Error("bad-format");
+    return data;
+  } catch (e) {
+    try {
+      const raw = localStorage.getItem(PROFILE_STORE_KEY);
+      if (raw) localStorage.setItem("evolutionGameProfiles_corruptBackup_" + Date.now(), raw.slice(0, 100000));
+    } catch (_) {}
+    return profileEmptyStore();
+  }
+}
+
+function profileSaveStore(data) {
+  try {
+    localStorage.setItem(PROFILE_STORE_KEY, JSON.stringify(data));
+    return true;
+  } catch (e) {
+    addDebugTrace("profile-save-error", {error: String(e)});
+    return false;
+  }
+}
+
+function profileCreateNew(name) {
+  const store = profileLoadStore();
+  const profileId = profileGenerateId("profile");
+  const now = new Date().toISOString();
+  store.profiles[profileId] = {
+    profileId,
+    name: name || "Profile 1",
+    createdAt: now,
+    lastPlayedAt: now,
+    buildId: GAME_VERSION,
+    buildCompatible: true,
+    stats: profileDefaultStats(),
+    activeRun: null,
+    runHistory: [],
+    fieldJournal: {}
+  };
+  profileSaveStore(store);
+  currentProfileId = profileId;
+  try { localStorage.setItem(ACTIVE_PROFILE_KEY_STORE, profileId); } catch (_) {}
+  return store.profiles[profileId];
+}
+
+function profileGetActive() {
+  if (!currentProfileId) return null;
+  const store = profileLoadStore();
+  return store.profiles[currentProfileId] || null;
+}
+
+function profileCheckBuildCompatibility(profile) {
+  if (!profile) return {compatible: false};
+  const savedBuild = profile.buildId || "";
+  const localBuild = GAME_VERSION;
+  const compatible = savedBuild === localBuild;
+  if (!compatible) addDebugTrace("profile-build-mismatch", {savedBuild, localBuild, profileId: profile.profileId});
+  return {compatible, savedBuild, localBuild};
+}


### PR DESCRIPTION
## Summary

Eighth controlled extraction in the build scaffold series. Moves five profile store core helper functions out of `game/play.html` into `src/state/profile-store-core.js`, and wires them into `scripts/build_play_html.mjs` so they are inlined back at build time.

`game/play.html` remains the directly playable artifact — all content is still inline, no runtime dependencies.

---

## What changed

- **Created** `src/state/profile-store-core.js` — holds exactly five functions:
  - `profileLoadStore()` — reads profile data from localStorage, returning an empty store on parse failure
  - `profileSaveStore(data)` — writes profile data to localStorage, returning true/false
  - `profileCreateNew(name)` — creates a new profile entry, persists it, and sets `currentProfileId`
  - `profileGetActive()` — returns the current profile object or null
  - `profileCheckBuildCompatibility(profile)` — compares `profile.buildId` to `GAME_VERSION`
- **`game/play.html`** — the five function declarations replaced with a single `// BEGIN/END GENERATED JS: src/state/profile-store-core.js` region; all surrounding code unchanged
- **`scripts/build_play_html.mjs`** — wired to read `src/state/profile-store-core.js` and inline it into the new region; now inlines all eight source files (CSS, encounter data, core utils, achievement definitions, run-tracking state factory, profile/storage constants, profile factory helpers, profile store core helpers)
- **`README.md`** — repo layout tree and build scaffold table updated
- **`docs/current-game-structure.md`** — line-range table, build scaffold table, and marker table updated
- **`docs/architecture-notes.md`** — generated regions list, line-range table, fragile areas, and do-not-edit directive updated
- **`docs/release-checklist.md`** — build step checklist updated with profile-store-core entry
- **`CHANGELOG.txt`** — entry added

---

## Scope confirmation

Only `profileLoadStore`, `profileSaveStore`, `profileCreateNew`, `profileGetActive`, and `profileCheckBuildCompatibility` were extracted. The five functions were contiguous in the original file; they are replaced by a single generated region placed immediately after the profile-factories region and before `profileCaptureWorldArrays`.

`profileCaptureWorldArrays`, `profileCaptureState`, `profileRestoreState`, `profileUpdateStats`, `profileOnRunEnd`, fossil record logic, active-run logic, achievement persistence, and save/load logic all remain in `game/play.html` unchanged.

No function bodies changed. No call sites changed. No save/profile behaviour changed. No localStorage keys changed. No profile schema changed. No gameplay logic changed. No CSS, encounter data, achievement data, run-tracking data, profile/storage constants, or factory helpers changed.

---

## Verification

- `node scripts/build_play_html.mjs` ran after adding markers — reported **no change** (inline block already matched source exactly)
- `node scripts/check_html_js_syntax.mjs` passed with no errors
- Inline region diff confirmed byte-for-byte match between `src/state/profile-store-core.js` and the generated region in `game/play.html`
- Marker placement: BEGIN at line 4514, END at line 4577; profile-factories region ends at line 4512 immediately before; `profileCaptureWorldArrays` at line 4579 immediately after — load order preserved

---

## Scope

- [ ] Gameplay logic
- [ ] UI/layout
- [ ] Bot/debug tools
- [ ] App-loading/PWA files
- [x] Documentation/workflow
- [x] Repository structure (source extraction / build scaffold)

---

## Smoke check

Static review only. `game/play.html` was not opened in a browser this session. The syntax check passed and the build script confirmed idempotency. George should open `game/play.html` in a browser and confirm the game loads before merging.

---

Documentation updated: `README.md`, `docs/current-game-structure.md`, `docs/architecture-notes.md`, `docs/release-checklist.md`, `CHANGELOG.txt`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKFcTXWzunyBYGnVrpUzLd)_