### PR TITLE
Extract profile state snapshot source

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,22 @@
+[2026-06-04 extract-profile-state-snapshot | Claude]
+Ninth controlled extraction — profile active-run state capture/restore helpers extracted and build script extended.
+
+- Created src/state/profile-state-snapshot.js: three profile state snapshot functions moved mechanically from game/play.html, byte-identical to the originals.
+  - profileCaptureWorldArrays(): returns a deep copy of the six world-grid arrays (terrain, altitude, landform, habitat, muddyShallows, lianaBridges).
+  - profileCaptureState(): builds the full active-run snapshot object (player, world state, encounters, social state, environment, time, log lines, etc.).
+  - profileRestoreState(state): writes a captured snapshot back into the live game state, including the log DOM.
+  - No function names changed. No function bodies changed. No saved field names changed. No restored field names changed. No save schema changed. No restore order changed.
+- Edited game/play.html: the three functions replaced with a single // BEGIN/END GENERATED JS: src/state/profile-state-snapshot.js region.
+  - The generated region sits immediately after the profile-store-core region and before profileKnowledgeCount — preserving load order.
+  - The three functions were contiguous; no hoisting shuffle was required.
+  - Only the three approved functions were extracted. profileKnowledgeCount, profileBuildRunSummary, profileRunIsGodMode, profileUpdateStats, profileOnRunEnd, active-run lifecycle logic, fossil record logic, achievement persistence, and save/load logic remain in game/play.html. No call sites changed.
+  - game/play.html remains the directly playable artifact.
+- Extended scripts/build_play_html.mjs: now inlines CSS, encounter data, core utils, achievement definitions, run-tracking state factory, profile/storage constants, profile factory helpers, profile store core helpers, and profile state snapshot helpers. Fails clearly if src/state/profile-state-snapshot.js or its region markers are missing. Idempotent.
+- game/evolution_game_v66_57.html NOT changed: historical archive, not kept byte-synced between releases.
+- Docs: README.md (repo layout tree + build scaffold table), docs/current-game-structure.md (line-range table, build scaffold table, marker table), docs/architecture-notes.md (generated region + markers, line-range table, fragile-area note), docs/release-checklist.md (build step check for profile-state-snapshot).
+- Verification: node scripts/build_play_html.mjs (idempotent — no change) and node scripts/check_html_js_syntax.mjs both pass. Extracted source verified to match the inline region (excluding markers and trailing whitespace).
+- Source/build structure change only. No gameplay logic, function bodies, call sites, save schema, saved/restored field names, restore order, active-run behaviour, achievement logic, fossil record logic, rendering, CSS, encounter data, core utility code, run-tracking code, profile/storage constants, profile factories, or profile-store-core code changed.
+
 [2026-06-04 extract-profile-store-core | Claude]
 Eighth controlled extraction — profile store core helper functions extracted and build script extended.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ evolution-game/
 │       ├── run-tracking.js           Run-tracking state factory source (inlined into play.html by the build script)
 │       ├── profile-storage-constants.js  Profile/storage constant declarations (inlined into play.html by the build script)
 │       ├── profile-factories.js      Profile factory/helper functions source (inlined into play.html by the build script)
-│       └── profile-store-core.js     Profile store core helpers source (inlined into play.html by the build script)
+│       ├── profile-store-core.js     Profile store core helpers source (inlined into play.html by the build script)
+│       └── profile-state-snapshot.js Profile state capture/restore helpers source (inlined into play.html by the build script)
 ├── docs/
 │   ├── current-game-structure.md     How the game works now: systems, flows, line ranges
 │   ├── documentation-map.md          What each doc covers and when to update it
@@ -142,7 +143,7 @@ The rebuild is not a rewrite, not a framework migration, and not a gameplay rede
 
 ### Build scaffold
 
-Eight source extractions are complete:
+Nine source extractions are complete:
 
 | Source file | What it contains | Destination in play.html |
 |-------------|-----------------|--------------------------|
@@ -154,6 +155,7 @@ Eight source extractions are complete:
 | `src/state/profile-storage-constants.js` | Profile/storage key constants (7 `const` declarations; all profile logic stays in play.html) | One JS region (~line 4481) |
 | `src/state/profile-factories.js` | Profile factory/helper functions (`profileGenerateId`, `profileEmptyStore`, `profileDefaultStats`; all other profile logic stays in play.html) | One JS region (~line 4500) |
 | `src/state/profile-store-core.js` | Profile store core helpers (`profileLoadStore`, `profileSaveStore`, `profileCreateNew`, `profileGetActive`, `profileCheckBuildCompatibility`; all other profile logic stays in play.html) | One JS region (~line 4514) |
+| `src/state/profile-state-snapshot.js` | Profile active-run capture/restore helpers (`profileCaptureWorldArrays`, `profileCaptureState`, `profileRestoreState`; all other profile logic stays in play.html) | One JS region (~line 4579) |
 
 `game/play.html` keeps all content **inline** so it stays directly playable with no build step or runtime dependency. To regenerate `game/play.html` after editing any source file:
 

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -8,7 +8,7 @@ This document is a map of how the game HTML file is organised. Read this before 
 
 The entire game lives in one large HTML file (`game/play.html`, ~18,400 lines). There is no build step, no bundler, and no separate JavaScript files. Everything — CSS, HTML structure, and all JavaScript — is in one file.
 
-Eight source files have been extracted and are inlined back into `game/play.html` by `scripts/build_play_html.mjs`. The playable file still ships all content inline, so it works with no build step at runtime. The build script replaces only the regions between these marker comments:
+Nine source files have been extracted and are inlined back into `game/play.html` by `scripts/build_play_html.mjs`. The playable file still ships all content inline, so it works with no build step at runtime. The build script replaces only the regions between these marker comments:
 
 **CSS** (inside the `<style>` block) — source `src/styles/game.css`:
 ```
@@ -62,6 +62,14 @@ This region sits after the profile state variables and before `profileLoadStore`
 ```
 This region sits immediately after the profile factory helpers region and before `profileCaptureWorldArrays`, preserving load order. Only `profileLoadStore`, `profileSaveStore`, `profileCreateNew`, `profileGetActive`, and `profileCheckBuildCompatibility` are extracted; `profileCaptureWorldArrays`, `profileCaptureState`, `profileRestoreState`, `profileUpdateStats`, `profileOnRunEnd`, fossil record logic, active-run logic, achievement persistence, and save/load logic remain in `game/play.html`. Profile store core helpers should be edited in `src/state/profile-store-core.js`, not inside the generated region of `game/play.html`.
 
+**Profile state snapshot helpers** (inside the `<script>` block, ~line 4579) — three active-run capture/restore functions:
+```
+// BEGIN GENERATED JS: src/state/profile-state-snapshot.js
+...generated js...
+// END GENERATED JS: src/state/profile-state-snapshot.js
+```
+This region sits immediately after the profile store core region and before `profileKnowledgeCount`, preserving load order. Only `profileCaptureWorldArrays`, `profileCaptureState`, and `profileRestoreState` are extracted; `profileKnowledgeCount`, `profileBuildRunSummary`, `profileUpdateStats`, `profileOnRunEnd`, active-run lifecycle logic, fossil record logic, achievement persistence, and save/load logic remain in `game/play.html`. The saved/restored field names, save schema, and restore order are unchanged. Profile state snapshot helpers should be edited in `src/state/profile-state-snapshot.js`, not inside the generated region of `game/play.html`.
+
 **Run-tracking state factory** (inside the `<script>` block, ~line 4763) — the `freshRunTracking()` function only:
 ```
 // BEGIN GENERATED JS: src/state/run-tracking.js
@@ -80,7 +88,7 @@ This region sits between `freshRunTracking` and `loadAchievements`, preserving l
 
 `src/data/encounter-data.js` uses a `// << SPLIT: hiddenSubtypePools >>` line to divide part 1 from part 2; the build script splits on it and inlines each part into its region. The split marker itself is not inlined. All other source files have no split marker and each maps to one contiguous region.
 
-**Edit CSS in `src/styles/game.css`, encounter data in `src/data/encounter-data.js`, pure utility helpers in `src/utils/core-utils.js`, achievement definitions in `src/data/achievement-data.js`, run-tracking factory in `src/state/run-tracking.js`, profile/storage constants in `src/state/profile-storage-constants.js`, profile factory helpers in `src/state/profile-factories.js`, and profile store core helpers in `src/state/profile-store-core.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
+**Edit CSS in `src/styles/game.css`, encounter data in `src/data/encounter-data.js`, pure utility helpers in `src/utils/core-utils.js`, achievement definitions in `src/data/achievement-data.js`, run-tracking factory in `src/state/run-tracking.js`, profile/storage constants in `src/state/profile-storage-constants.js`, profile factory helpers in `src/state/profile-factories.js`, profile store core helpers in `src/state/profile-store-core.js`, and profile state snapshot helpers in `src/state/profile-state-snapshot.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
 
 `game/evolution_game_v66_57.html` is the versioned archive of an earlier build. It is a historical snapshot and is not kept byte-in-sync with `game/play.html` between releases; `game/play.html` is the stable public-facing copy that gets replaced on each release.
 
@@ -101,9 +109,10 @@ This region sits between `freshRunTracking` and `loadAchievements`, preserving l
 | 4491–4499 | Profile state variables (currentProfileId, currentRunId, runGodModeUsed, etc.) |
 | 4500–4512 | Profile factory helpers — generated, source in `src/state/profile-factories.js` |
 | 4514–4577 | Profile store core helpers — generated, source in `src/state/profile-store-core.js` |
-| 4579–4768 | Remaining profile functions (profileCaptureWorldArrays, profileCaptureState, profileRestoreState, profileUpdateStats, profileOnRunEnd, etc.) |
-| 4769–4800 | Run-tracking state factory (`freshRunTracking`) — generated, source in `src/state/run-tracking.js` |
-| 4806–4871 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source in `src/data/achievement-data.js` |
+| 4579–4718 | Profile state snapshot helpers — generated, source in `src/state/profile-state-snapshot.js` |
+| 4720–4770 | Remaining profile functions (profileKnowledgeCount, profileBuildRunSummary, profileUpdateStats, profileOnRunEnd, etc.) |
+| 4771–4802 | Run-tracking state factory (`freshRunTracking`) — generated, source in `src/state/run-tracking.js` |
+| 4808–4873 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source in `src/data/achievement-data.js` |
 | 4867–5829 | Achievement persistence (load/save/check), profile stats, profiles, save/load, Field Journal, Fossil Record |
 | 5830–5924 | Core utility helpers — generated, source in `src/utils/core-utils.js`: pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation) |
 | 5925–6036 | Remaining [UTILS]: logging, narration setters, noise, risk memory (not extracted — side effects) |
@@ -167,7 +176,7 @@ All rendering is done by a single `render()` call that redraws the map, UI panel
 - **`game/play.html` and `game/evolution_game_v66_57.html` must be kept in sync** on each release. If you edit one, copy the change to the other, or replace `play.html` entirely.
 - **`index.html` and `manifest.json` must both reference `game/play.html`.** The syntax check script verifies `index.html`. Check `manifest.json` manually on releases.
 - **`player.knowledge` / `player.classKnowledge`** accumulate across runs and feed the Field Journal. Incorrect resets at run boundaries lose journal data permanently.
-- **The CSS region, both encounter-data regions, the core-utils region, the achievement-data region, the run-tracking region, the profile-storage-constants region, the profile-factories region, and the profile-store-core region in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css`, `src/data/encounter-data.js`, `src/utils/core-utils.js`, `src/data/achievement-data.js`, `src/state/run-tracking.js`, `src/state/profile-storage-constants.js`, `src/state/profile-factories.js`, and `src/state/profile-store-core.js` instead. Do not remove any BEGIN/END marker comments or the `// << SPLIT: hiddenSubtypePools >>` line — the build script requires all of them.
+- **The CSS region, both encounter-data regions, the core-utils region, the achievement-data region, the run-tracking region, the profile-storage-constants region, the profile-factories region, the profile-store-core region, and the profile-state-snapshot region in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css`, `src/data/encounter-data.js`, `src/utils/core-utils.js`, `src/data/achievement-data.js`, `src/state/run-tracking.js`, `src/state/profile-storage-constants.js`, `src/state/profile-factories.js`, `src/state/profile-store-core.js`, and `src/state/profile-state-snapshot.js` instead. Do not remove any BEGIN/END marker comments or the `// << SPLIT: hiddenSubtypePools >>` line — the build script requires all of them.
 
 ---
 

--- a/docs/current-game-structure.md
+++ b/docs/current-game-structure.md
@@ -12,7 +12,7 @@ Evolution Game is a browser-based single-player survival simulation. The player 
 
 The game runs from a single HTML file (`game/play.html`, ~18,400 lines). There is no bundler and no server. Open the file in a browser and it works.
 
-Eight source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
+Nine source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
 
 | Source file | What it contains | In play.html |
 |-------------|-----------------|--------------|
@@ -24,6 +24,7 @@ Eight source extractions are complete. The playable file `game/play.html` still 
 | `src/state/profile-storage-constants.js` | Profile/storage key constants (7 `const` declarations) | One inline JS region (~line 4481) |
 | `src/state/profile-factories.js` | Profile factory helpers (`profileGenerateId`, `profileEmptyStore`, `profileDefaultStats`) | One inline JS region (~line 4500) |
 | `src/state/profile-store-core.js` | Profile store core helpers (`profileLoadStore`, `profileSaveStore`, `profileCreateNew`, `profileGetActive`, `profileCheckBuildCompatibility`) | One inline JS region (~line 4514) |
+| `src/state/profile-state-snapshot.js` | Profile active-run capture/restore helpers (`profileCaptureWorldArrays`, `profileCaptureState`, `profileRestoreState`) | One inline JS region (~line 4579) |
 
 `scripts/build_play_html.mjs` inlines all source files back into `game/play.html`. Only configuration-like declarations and simple factory/helper functions are extracted — `profileCaptureWorldArrays`, `profileCaptureState`, `profileRestoreState`, `profileUpdateStats`, `profileOnRunEnd`, fossil record logic, active-run logic, achievement persistence, save/load logic, and all other game code remain inside `game/play.html`. All JavaScript engine code and HTML structure also remain inside `game/play.html` for now.
 
@@ -279,9 +280,10 @@ flowchart TD
 | 4491–4499 | Profile state variables (currentProfileId, currentRunId, runGodModeUsed, etc.) |
 | 4500–4512 | Profile factory helpers — generated, source is `src/state/profile-factories.js` |
 | 4514–4577 | Profile store core helpers — generated, source is `src/state/profile-store-core.js` |
-| 4579–4768 | Remaining profile functions (profileCaptureWorldArrays, profileCaptureState, profileRestoreState, profileUpdateStats, profileOnRunEnd, etc.) |
-| 4769–4800 | Run-tracking state factory (`freshRunTracking`) — generated, source is `src/state/run-tracking.js` |
-| 4806–4871 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source is `src/data/achievement-data.js` |
+| 4579–4718 | Profile state snapshot helpers — generated, source is `src/state/profile-state-snapshot.js` |
+| 4720–4770 | Remaining profile functions (profileKnowledgeCount, profileBuildRunSummary, profileUpdateStats, profileOnRunEnd, etc.) |
+| 4771–4802 | Run-tracking state factory (`freshRunTracking`) — generated, source is `src/state/run-tracking.js` |
+| 4808–4873 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source is `src/data/achievement-data.js` |
 | 4867–5829 | Achievement persistence (load/save/check), profile stats, profiles, save/load, Field Journal, Fossil Record |
 | 5830–5924 | Core utilities — generated, source is `src/utils/core-utils.js`: pure helpers (clamp, roll, choice, clonePlain, escapeHtml, etc.) |
 | 5925–6036 | Remaining utilities: logging, debug helpers, narration setters |
@@ -337,6 +339,7 @@ The rebuild plan (see `docs/project-plan.md`) targets extraction in this rough o
 | `src/state/profile-storage-constants.js` | `// BEGIN/END GENERATED JS: src/state/profile-storage-constants.js` |
 | `src/state/profile-factories.js` | `// BEGIN/END GENERATED JS: src/state/profile-factories.js` |
 | `src/state/profile-store-core.js` | `// BEGIN/END GENERATED JS: src/state/profile-store-core.js` |
+| `src/state/profile-state-snapshot.js` | `// BEGIN/END GENERATED JS: src/state/profile-state-snapshot.js` |
 
 The source file `src/data/encounter-data.js` contains a `// << SPLIT: hiddenSubtypePools >>` line dividing part 1 (encounters + encounterTables) from part 2 (hiddenSubtypePools). The build script splits on this marker and inlines each part into its respective location in `play.html`. All other source files have no split marker — each maps to one contiguous region.
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -22,7 +22,8 @@ Run through this every time a new version becomes the stable build.
 - [ ] If `src/state/profile-storage-constants.js` was changed, `node scripts/build_play_html.mjs` was run to inline the profile/storage constants into `game/play.html`
 - [ ] If `src/state/profile-factories.js` was changed, `node scripts/build_play_html.mjs` was run to inline the profile factory helpers into `game/play.html`
 - [ ] If `src/state/profile-store-core.js` was changed, `node scripts/build_play_html.mjs` was run to inline the profile store core helpers into `game/play.html`
-- [ ] The generated regions in `game/play.html` were not hand-edited (CSS → `src/styles/game.css`; encounter data → `src/data/encounter-data.js`; utility helpers → `src/utils/core-utils.js`; achievement defs → `src/data/achievement-data.js`; run-tracking factory → `src/state/run-tracking.js`; profile/storage constants → `src/state/profile-storage-constants.js`; profile factory helpers → `src/state/profile-factories.js`; profile store core helpers → `src/state/profile-store-core.js`)
+- [ ] If `src/state/profile-state-snapshot.js` was changed, `node scripts/build_play_html.mjs` was run to inline the profile state snapshot helpers into `game/play.html`
+- [ ] The generated regions in `game/play.html` were not hand-edited (CSS → `src/styles/game.css`; encounter data → `src/data/encounter-data.js`; utility helpers → `src/utils/core-utils.js`; achievement defs → `src/data/achievement-data.js`; run-tracking factory → `src/state/run-tracking.js`; profile/storage constants → `src/state/profile-storage-constants.js`; profile factory helpers → `src/state/profile-factories.js`; profile store core helpers → `src/state/profile-store-core.js`; profile state snapshot helpers → `src/state/profile-state-snapshot.js`)
 
 ## Syntax and render check
 

--- a/game/play.html
+++ b/game/play.html
@@ -4576,6 +4576,7 @@ function profileCheckBuildCompatibility(profile) {
 }
 // END GENERATED JS: src/state/profile-store-core.js
 
+// BEGIN GENERATED JS: src/state/profile-state-snapshot.js
 function profileCaptureWorldArrays() {
   return {
     terrain: terrain.map(row => row.slice()),
@@ -4714,6 +4715,7 @@ function profileRestoreState(state) {
     });
   }
 }
+// END GENERATED JS: src/state/profile-state-snapshot.js
 
 function profileKnowledgeCount() {
   return Object.keys(player.knowledgeByEncounterKey || {}).length;

--- a/scripts/build_play_html.mjs
+++ b/scripts/build_play_html.mjs
@@ -15,6 +15,7 @@
 //   6. src/state/profile-storage-constants.js → one JS region (~line 4481)
 //   7. src/state/profile-factories.js → one JS region (~line 4500)
 //   8. src/state/profile-store-core.js → one JS region (~line 4514)
+//   9. src/state/profile-state-snapshot.js → one JS region (~line 4579)
 //
 // Why inline (not external files): game/play.html must open straight from
 // disk — or via the GitHub Pages link — with no build step and no runtime
@@ -40,6 +41,7 @@ const RUNTRACK_SOURCE = resolve(repoRoot, 'src/state/run-tracking.js');
 const PROFCONST_SOURCE   = resolve(repoRoot, 'src/state/profile-storage-constants.js');
 const PROFFACT_SOURCE    = resolve(repoRoot, 'src/state/profile-factories.js');
 const PROFCORE_SOURCE    = resolve(repoRoot, 'src/state/profile-store-core.js');
+const PROFSNAP_SOURCE    = resolve(repoRoot, 'src/state/profile-state-snapshot.js');
 const PLAY_HTML          = resolve(repoRoot, 'game/play.html');
 
 // CSS markers (CSS comment style, inside <style>)
@@ -76,6 +78,10 @@ const JS_END_PROFFACT   = '// END GENERATED JS: src/state/profile-factories.js';
 const JS_BEGIN_PROFCORE = '// BEGIN GENERATED JS: src/state/profile-store-core.js';
 const JS_END_PROFCORE   = '// END GENERATED JS: src/state/profile-store-core.js';
 
+// Profile-state-snapshot markers (JS comment style, inside <script>)
+const JS_BEGIN_PROFSNAP = '// BEGIN GENERATED JS: src/state/profile-state-snapshot.js';
+const JS_END_PROFSNAP   = '// END GENERATED JS: src/state/profile-state-snapshot.js';
+
 // The split comment that divides the source file into part1 and part2.
 // It is NOT inlined into game/play.html.
 const JS_SPLIT  = '// << SPLIT: hiddenSubtypePools >>';
@@ -108,6 +114,7 @@ if (!existsSync(RUNTRACK_SOURCE))  fail('cannot find src/state/run-tracking.js')
 if (!existsSync(PROFCONST_SOURCE)) fail('cannot find src/state/profile-storage-constants.js');
 if (!existsSync(PROFFACT_SOURCE))  fail('cannot find src/state/profile-factories.js');
 if (!existsSync(PROFCORE_SOURCE))  fail('cannot find src/state/profile-store-core.js');
+if (!existsSync(PROFSNAP_SOURCE))  fail('cannot find src/state/profile-state-snapshot.js');
 if (!existsSync(PLAY_HTML))        fail('cannot find game/play.html');
 
 const css          = readFileSync(CSS_SOURCE,       'utf8');
@@ -118,6 +125,7 @@ const jsRunTrack   = readFileSync(RUNTRACK_SOURCE,  'utf8');
 const jsProfConst  = readFileSync(PROFCONST_SOURCE, 'utf8');
 const jsProfFact   = readFileSync(PROFFACT_SOURCE,  'utf8');
 const jsProfCore   = readFileSync(PROFCORE_SOURCE,  'utf8');
+const jsProfSnap   = readFileSync(PROFSNAP_SOURCE,  'utf8');
 let   html         = readFileSync(PLAY_HTML,        'utf8');
 
 // --- Split encounter-data into two parts at the SPLIT marker ---
@@ -137,6 +145,7 @@ html = inlineRegion(html, JS_BEGIN_RUNTRACK,  JS_END_RUNTRACK,  jsRunTrack.repla
 html = inlineRegion(html, JS_BEGIN_PROFCONST, JS_END_PROFCONST, jsProfConst.replace(/\s+$/, ''), 'profile-storage-constants');
 html = inlineRegion(html, JS_BEGIN_PROFFACT,  JS_END_PROFFACT,  jsProfFact.replace(/\s+$/, ''),  'profile-factories');
 html = inlineRegion(html, JS_BEGIN_PROFCORE,  JS_END_PROFCORE,  jsProfCore.replace(/\s+$/, ''),  'profile-store-core');
+html = inlineRegion(html, JS_BEGIN_PROFSNAP,  JS_END_PROFSNAP,  jsProfSnap.replace(/\s+$/, ''),  'profile-state-snapshot');
 
 if (html === original) {
   console.log('build_play_html: no change — game/play.html already matches all source files.');

--- a/src/state/profile-state-snapshot.js
+++ b/src/state/profile-state-snapshot.js
@@ -1,0 +1,138 @@
+function profileCaptureWorldArrays() {
+  return {
+    terrain: terrain.map(row => row.slice()),
+    altitude: altitude.map(row => row.slice()),
+    landform: landform.map(row => row.slice()),
+    habitat: habitat.map(row => row.slice()),
+    muddyShallows: muddyShallows.map(row => row.slice()),
+    lianaBridges: lianaBridges.map(row => row.slice())
+  };
+}
+
+function profileCaptureState() {
+  const logEl = document.getElementById("log");
+  const logLines = logEl ? Array.from(logEl.querySelectorAll("p")).slice(-PROFILE_LOG_CAP).map(p => ({
+    text: p.textContent,
+    className: p.className
+  })) : [];
+
+  return {
+    worldArrays: profileCaptureWorldArrays(),
+    player: JSON.parse(JSON.stringify(player)),
+    waterState: JSON.parse(JSON.stringify(waterState)),
+    currentEncounter: currentEncounter ? JSON.parse(JSON.stringify(currentEncounter)) : null,
+    tileEncounterQueue: JSON.parse(JSON.stringify(tileEncounterQueue)),
+    carcass: carcass ? JSON.parse(JSON.stringify(carcass)) : null,
+    interruptedFood: interruptedFood ? JSON.parse(JSON.stringify(interruptedFood)) : null,
+    nearbyEntities: JSON.parse(JSON.stringify(nearbyEntities)),
+    persistentEntities: JSON.parse(JSON.stringify(persistentEntities)),
+    worldRegistry: JSON.parse(JSON.stringify(worldRegistry)),
+    nextRegistryId,
+    exploredTiles: Array.from(exploredTiles),
+    nextEntityId,
+    nextInstanceId,
+    knownMapEntities: JSON.parse(JSON.stringify(knownMapEntities)),
+    staticTileContents: JSON.parse(JSON.stringify(staticTileContents)),
+    consumedStaticTileKeys: JSON.parse(JSON.stringify(consumedStaticTileKeys)),
+    burnedTiles: JSON.parse(JSON.stringify(burnedTiles)),
+    dangerGrace,
+    recentPredatorWarning: recentPredatorWarning ? JSON.parse(JSON.stringify(recentPredatorWarning)) : null,
+    activePursuit: activePursuit ? JSON.parse(JSON.stringify(activePursuit)) : null,
+    investigationText,
+    investigationEncounterRef,
+    lastLookText,
+    lastLookTurn,
+    lastNarration,
+    groupSceneNotice: groupSceneNotice ? JSON.parse(JSON.stringify(groupSceneNotice)) : null,
+    heardText,
+    smellText,
+    nearbyRecentSocial: nearbyRecentSocial ? JSON.parse(JSON.stringify(nearbyRecentSocial)) : null,
+    lastActionKind,
+    lastDamageContext: lastDamageContext ? JSON.parse(JSON.stringify(lastDamageContext)) : null,
+    debugLastAction: debugLastAction ? JSON.parse(JSON.stringify(debugLastAction)) : null,
+    callStreak,
+    lastCallTurn,
+    socialGroup: JSON.parse(JSON.stringify(socialGroup)),
+    noiseLevel,
+    lastCravingCueTurn,
+    lastRiskMemoryCueTurn,
+    individualSocialState: individualSocialState ? JSON.parse(JSON.stringify(individualSocialState)) : null,
+    lastHabitatKey,
+    environment: JSON.parse(JSON.stringify(environment)),
+    timeState: {phase: timeState.phase, phaseTurn: timeState.phaseTurn, sleepTurnsRemaining: timeState.sleepTurnsRemaining},
+    debugTrace: debugTrace.slice(-PROFILE_TRACE_CAP),
+    logLines
+  };
+}
+
+function profileRestoreState(state) {
+  if (state.worldArrays) {
+    for (let xi = 0; xi < WORLD_SIZE; xi++) {
+      for (let yi = 0; yi < WORLD_SIZE; yi++) {
+        terrain[xi][yi] = state.worldArrays.terrain[xi][yi];
+        altitude[xi][yi] = state.worldArrays.altitude[xi][yi];
+        landform[xi][yi] = state.worldArrays.landform[xi][yi];
+        habitat[xi][yi] = state.worldArrays.habitat[xi][yi];
+        muddyShallows[xi][yi] = state.worldArrays.muddyShallows[xi][yi];
+        lianaBridges[xi][yi] = state.worldArrays.lianaBridges[xi][yi];
+      }
+    }
+  }
+
+  Object.assign(player, state.player);
+  waterState = state.waterState;
+  currentEncounter = state.currentEncounter;
+  tileEncounterQueue = state.tileEncounterQueue;
+  carcass = state.carcass;
+  interruptedFood = state.interruptedFood;
+  nearbyEntities = state.nearbyEntities;
+  persistentEntities = state.persistentEntities;
+  worldRegistry = state.worldRegistry;
+  nextRegistryId = state.nextRegistryId;
+  exploredTiles = new Set(state.exploredTiles);
+  nextEntityId = state.nextEntityId;
+  nextInstanceId = state.nextInstanceId;
+  knownMapEntities = state.knownMapEntities;
+  staticTileContents = state.staticTileContents;
+  consumedStaticTileKeys = state.consumedStaticTileKeys;
+  burnedTiles = state.burnedTiles;
+  dangerGrace = state.dangerGrace;
+  recentPredatorWarning = state.recentPredatorWarning;
+  activePursuit = state.activePursuit;
+  investigationText = state.investigationText;
+  investigationEncounterRef = state.investigationEncounterRef;
+  lastLookText = state.lastLookText;
+  lastLookTurn = state.lastLookTurn;
+  lastNarration = state.lastNarration;
+  groupSceneNotice = state.groupSceneNotice;
+  heardText = state.heardText;
+  smellText = state.smellText;
+  nearbyRecentSocial = state.nearbyRecentSocial;
+  lastActionKind = state.lastActionKind;
+  lastDamageContext = state.lastDamageContext;
+  debugLastAction = state.debugLastAction;
+  callStreak = state.callStreak;
+  lastCallTurn = state.lastCallTurn;
+  socialGroup = state.socialGroup;
+  noiseLevel = state.noiseLevel;
+  lastCravingCueTurn = state.lastCravingCueTurn;
+  lastRiskMemoryCueTurn = state.lastRiskMemoryCueTurn;
+  individualSocialState = state.individualSocialState;
+  lastHabitatKey = state.lastHabitatKey;
+  Object.assign(environment, state.environment);
+  timeState.phase = state.timeState.phase;
+  timeState.phaseTurn = state.timeState.phaseTurn;
+  timeState.sleepTurnsRemaining = state.timeState.sleepTurnsRemaining;
+  if (Array.isArray(state.debugTrace)) debugTrace = state.debugTrace;
+
+  const logEl = document.getElementById("log");
+  if (logEl && Array.isArray(state.logLines)) {
+    logEl.innerHTML = "";
+    state.logLines.forEach(entry => {
+      const p = document.createElement("p");
+      p.textContent = entry.text;
+      if (entry.className) p.className = entry.className;
+      logEl.appendChild(p);
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Ninth controlled extraction in the build scaffold series. Moves three profile active-run state capture/restore helper functions out of `game/play.html` into `src/state/profile-state-snapshot.js`, and wires them into `scripts/build_play_html.mjs` so they are inlined back at build time.

`game/play.html` remains the directly playable artifact — all content is still inline, no runtime dependencies.

---

## What changed

- **Created** `src/state/profile-state-snapshot.js` — holds exactly three functions:
  - `profileCaptureWorldArrays()` — returns a deep copy of the six world-grid arrays
  - `profileCaptureState()` — builds the full active-run snapshot object
  - `profileRestoreState(state)` — writes a captured snapshot back into the live game state, including the log DOM
- **`game/play.html`** — the three function declarations replaced with a single `// BEGIN/END GENERATED JS: src/state/profile-state-snapshot.js` region; all surrounding code unchanged
- **`scripts/build_play_html.mjs`** — wired to read `src/state/profile-state-snapshot.js` and inline it into the new region; now inlines all nine source files (CSS, encounter data, core utils, achievement definitions, run-tracking state factory, profile/storage constants, profile factory helpers, profile store core helpers, profile state snapshot helpers)
- **`README.md`** — repo layout tree and build scaffold table updated
- **`docs/current-game-structure.md`** — line-range table, build scaffold table, and marker table updated
- **`docs/architecture-notes.md`** — generated regions list, line-range table, fragile areas, and do-not-edit directive updated
- **`docs/release-checklist.md`** — build step checklist updated with profile-state-snapshot entry
- **`CHANGELOG.txt`** — entry added

---

## Scope confirmation

Only `profileCaptureWorldArrays`, `profileCaptureState`, and `profileRestoreState` were extracted. The three functions were contiguous in the original file; they are replaced by a single generated region placed immediately after the profile-store-core region and before `profileKnowledgeCount`.

`profileKnowledgeCount`, `profileBuildRunSummary`, `profileRunIsGodMode`, `profileUpdateStats`, `profileOnRunEnd`, active-run lifecycle logic, fossil record logic, achievement persistence, and save/load logic all remain in `game/play.html` unchanged.

- Only `profileCaptureWorldArrays`, `profileCaptureState`, and `profileRestoreState` were extracted.
- No function bodies changed.
- No call sites changed.
- No saved field names changed.
- No restored field names changed.
- No save schema changed.
- No active-run behaviour changed.
- No gameplay logic changed.
- No CSS, encounter data, achievement data, run-tracking data, profile constants, profile factories, or profile-store-core code changed.

---

## Verification

- `node scripts/build_play_html.mjs` ran after adding markers — reported **no change** (inline block already matched source exactly)
- `node scripts/check_html_js_syntax.mjs` passed with no errors
- Inline region diff confirmed byte-for-byte match between `src/state/profile-state-snapshot.js` and the generated region in `game/play.html`
- Marker placement: BEGIN at line 4579, END at line 4718; profile-store-core region ends at line 4577 immediately before; `profileKnowledgeCount` at line 4720 immediately after — load order preserved
- Browser manual check not run by Claude; awaiting George's browser smoke test.

---

## Scope

- [ ] Gameplay logic
- [ ] UI/layout
- [ ] Bot/debug tools
- [ ] App-loading/PWA files
- [x] Documentation/workflow
- [x] Repository structure (source extraction / build scaffold)

---

## Smoke check

Static review only. `game/play.html` was not opened in a browser this session. The syntax check passed and the build script confirmed idempotency. George should open `game/play.html` in a browser and confirm the game loads and a saved run still resumes before merging.

---

Documentation updated: `README.md`, `docs/current-game-structure.md`, `docs/architecture-notes.md`, `docs/release-checklist.md`, `CHANGELOG.txt`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKFcTXWzunyBYGnVrpUzLd)_