### PR TITLE
Extract profile run lifecycle source

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,28 @@
+[2026-06-04 extract-profile-run-lifecycle | Claude]
+Tenth controlled extraction — profile run summary/lifecycle helpers extracted and build script extended.
+
+- Created src/state/profile-run-lifecycle.js: eight run-summary/run-lifecycle functions moved mechanically from game/play.html, byte-identical to the originals.
+  - profileKnowledgeCount(): counts unlocked encounter knowledge entries.
+  - profileBuildRunSummary(outcome): builds the per-run summary object recorded in run history.
+  - profileRunIsGodMode(summary): flags a run as god-mode/QA-assisted.
+  - profileUpdateStats(profile, summary): folds a run summary into cross-run profile stats.
+  - profileOnRunEnd(outcome): finalises a run, records history, updates stats, checks achievements, resets run state.
+  - profileSaveActiveRun(): captures and persists the active run snapshot.
+  - profileStartNewRun(): initialises run-tracking variables for a fresh run.
+  - profileResumeActiveRun(profile): restores a saved run after a build-compatibility check.
+  - profileClearActiveRun does not exist in the codebase, so it was not extracted (the task listed it conditionally).
+  - No function names changed. No function bodies changed. No run summary fields, profile stats fields, or activeRun fields changed. No save schema, resume behaviour, or death/win handling changed.
+- Edited game/play.html: the eight functions are NOT contiguous (the run-tracking and achievement-data generated regions, the achievement persistence/toast system, updateRunTracking, and the Field Journal helpers sit between them). Rather than move any non-approved code, the source was inlined into THREE generated regions using [1/3], [2/3], [3/3] markers, leaving every function exactly where it already lived.
+  - [1/3] profileKnowledgeCount, profileBuildRunSummary, profileRunIsGodMode, profileUpdateStats — between profileRestoreState and the run-tracking region.
+  - [2/3] profileOnRunEnd, profileSaveActiveRun — between updateRunTracking and profileLoadFieldJournal.
+  - [3/3] profileStartNewRun, profileResumeActiveRun — between journalMarkFirstSeen and the win-modal section.
+  - No code was moved. No call sites changed. game/play.html remains the directly playable artifact.
+- Extended scripts/build_play_html.mjs: now inlines CSS, encounter data, core utils, achievement definitions, run-tracking state factory, profile/storage constants, profile factory helpers, profile store core helpers, profile state snapshot helpers, and profile run lifecycle helpers. The new source uses two split markers (// << SPLIT: profileOnRunEnd >> and // << SPLIT: profileStartNewRun >>) to divide its three parts; the build script splits on them and inlines each part. Fails clearly if src/state/profile-run-lifecycle.js, its region markers, or its split markers are missing, or if split markers are out of order. Idempotent.
+- game/evolution_game_v66_57.html NOT changed: historical archive, not kept byte-synced between releases.
+- Docs: README.md (repo layout tree + build scaffold table), docs/current-game-structure.md (line-range table, build scaffold table, marker table, split-marker note), docs/architecture-notes.md (generated regions + markers, line-range table, fragile-area note, split-marker note), docs/release-checklist.md (build step check for profile-run-lifecycle).
+- Verification: node scripts/build_play_html.mjs (idempotent — no change) and node scripts/check_html_js_syntax.mjs both pass. The three inline regions reconstructed (with split markers) verified to match the source file byte-for-byte; each of the eight functions confirmed present exactly once.
+- Source/build structure change only. No gameplay logic, function bodies, call sites, run summary fields, profile stats fields, activeRun fields, save schema, resume behaviour, death/win handling, achievement logic, fossil record logic, Field Journal logic, rendering, CSS, encounter data, or any existing extracted source file changed.
+
 [2026-06-04 extract-profile-state-snapshot | Claude]
 Ninth controlled extraction — profile active-run state capture/restore helpers extracted and build script extended.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ evolution-game/
 │       ├── profile-storage-constants.js  Profile/storage constant declarations (inlined into play.html by the build script)
 │       ├── profile-factories.js      Profile factory/helper functions source (inlined into play.html by the build script)
 │       ├── profile-store-core.js     Profile store core helpers source (inlined into play.html by the build script)
-│       └── profile-state-snapshot.js Profile state capture/restore helpers source (inlined into play.html by the build script)
+│       ├── profile-state-snapshot.js Profile state capture/restore helpers source (inlined into play.html by the build script)
+│       └── profile-run-lifecycle.js  Profile run summary/lifecycle helpers source (inlined into play.html by the build script)
 ├── docs/
 │   ├── current-game-structure.md     How the game works now: systems, flows, line ranges
 │   ├── documentation-map.md          What each doc covers and when to update it
@@ -143,19 +144,20 @@ The rebuild is not a rewrite, not a framework migration, and not a gameplay rede
 
 ### Build scaffold
 
-Nine source extractions are complete:
+Ten source extractions are complete:
 
 | Source file | What it contains | Destination in play.html |
 |-------------|-----------------|--------------------------|
 | `src/styles/game.css` | All CSS | Inline `<style>` block |
-| `src/data/encounter-data.js` | `encounters`, `encounterTables`, `hiddenSubtypePools` | Two JS regions (~line 1040 and ~line 6037) |
-| `src/utils/core-utils.js` | Pure stateless helper functions | One JS region (~line 5835) |
-| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions only; persistence stays in play.html) | One JS region (~line 4806) |
-| `src/state/run-tracking.js` | `freshRunTracking()` (factory only; save/profile logic stays in play.html) | One JS region (~line 4769) |
+| `src/data/encounter-data.js` | `encounters`, `encounterTables`, `hiddenSubtypePools` | Two JS regions (~line 1040 and ~line 6069) |
+| `src/utils/core-utils.js` | Pure stateless helper functions | One JS region (~line 5853) |
+| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions only; persistence stays in play.html) | One JS region (~line 4810) |
+| `src/state/run-tracking.js` | `freshRunTracking()` (factory only; save/profile logic stays in play.html) | One JS region (~line 4773) |
 | `src/state/profile-storage-constants.js` | Profile/storage key constants (7 `const` declarations; all profile logic stays in play.html) | One JS region (~line 4481) |
 | `src/state/profile-factories.js` | Profile factory/helper functions (`profileGenerateId`, `profileEmptyStore`, `profileDefaultStats`; all other profile logic stays in play.html) | One JS region (~line 4500) |
 | `src/state/profile-store-core.js` | Profile store core helpers (`profileLoadStore`, `profileSaveStore`, `profileCreateNew`, `profileGetActive`, `profileCheckBuildCompatibility`; all other profile logic stays in play.html) | One JS region (~line 4514) |
 | `src/state/profile-state-snapshot.js` | Profile active-run capture/restore helpers (`profileCaptureWorldArrays`, `profileCaptureState`, `profileRestoreState`; all other profile logic stays in play.html) | One JS region (~line 4579) |
+| `src/state/profile-run-lifecycle.js` | Profile run summary/lifecycle helpers (`profileKnowledgeCount`, `profileBuildRunSummary`, `profileRunIsGodMode`, `profileUpdateStats`, `profileOnRunEnd`, `profileSaveActiveRun`, `profileStartNewRun`, `profileResumeActiveRun`; all other profile logic stays in play.html) | Three JS regions (~line 4720, ~line 5013, ~line 5152) |
 
 `game/play.html` keeps all content **inline** so it stays directly playable with no build step or runtime dependency. To regenerate `game/play.html` after editing any source file:
 

--- a/docs/architecture-notes.md
+++ b/docs/architecture-notes.md
@@ -8,7 +8,7 @@ This document is a map of how the game HTML file is organised. Read this before 
 
 The entire game lives in one large HTML file (`game/play.html`, ~18,400 lines). There is no build step, no bundler, and no separate JavaScript files. Everything — CSS, HTML structure, and all JavaScript — is in one file.
 
-Nine source files have been extracted and are inlined back into `game/play.html` by `scripts/build_play_html.mjs`. The playable file still ships all content inline, so it works with no build step at runtime. The build script replaces only the regions between these marker comments:
+Ten source files have been extracted and are inlined back into `game/play.html` by `scripts/build_play_html.mjs`. The playable file still ships all content inline, so it works with no build step at runtime. The build script replaces only the regions between these marker comments:
 
 **CSS** (inside the `<style>` block) — source `src/styles/game.css`:
 ```
@@ -86,9 +86,25 @@ This region sits between the profile-stats update code and the `[ACHIEVEMENTS]` 
 ```
 This region sits between `freshRunTracking` and `loadAchievements`, preserving load order and access to surrounding functions/globals (e.g. the `check` callbacks reference `socialGroup`). Only the definitions array is extracted; achievement persistence (`loadAchievements`, `saveAchievements`, `checkAchievements`), profile/save logic, and achievement rendering/toast logic remain in `game/play.html`. Achievement definitions should be edited in `src/data/achievement-data.js`, not inside the generated region of `game/play.html`.
 
-`src/data/encounter-data.js` uses a `// << SPLIT: hiddenSubtypePools >>` line to divide part 1 from part 2; the build script splits on it and inlines each part into its region. The split marker itself is not inlined. All other source files have no split marker and each maps to one contiguous region.
+**Profile run lifecycle helpers** (inside the `<script>` block) — eight run-summary/run-lifecycle functions, inlined into THREE separate regions because the source functions are not contiguous in `game/play.html` (other already-generated regions and unrelated systems sit between them):
+```
+// BEGIN GENERATED JS: src/state/profile-run-lifecycle.js [1/3]   (~line 4720)
+...profileKnowledgeCount, profileBuildRunSummary, profileRunIsGodMode, profileUpdateStats...
+// END GENERATED JS: src/state/profile-run-lifecycle.js [1/3]
 
-**Edit CSS in `src/styles/game.css`, encounter data in `src/data/encounter-data.js`, pure utility helpers in `src/utils/core-utils.js`, achievement definitions in `src/data/achievement-data.js`, run-tracking factory in `src/state/run-tracking.js`, profile/storage constants in `src/state/profile-storage-constants.js`, profile factory helpers in `src/state/profile-factories.js`, profile store core helpers in `src/state/profile-store-core.js`, and profile state snapshot helpers in `src/state/profile-state-snapshot.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
+// BEGIN GENERATED JS: src/state/profile-run-lifecycle.js [2/3]   (~line 5013)
+...profileOnRunEnd, profileSaveActiveRun...
+// END GENERATED JS: src/state/profile-run-lifecycle.js [2/3]
+
+// BEGIN GENERATED JS: src/state/profile-run-lifecycle.js [3/3]   (~line 5152)
+...profileStartNewRun, profileResumeActiveRun...
+// END GENERATED JS: src/state/profile-run-lifecycle.js [3/3]
+```
+Part [1/3] sits between `profileRestoreState` and the run-tracking region; part [2/3] sits between `updateRunTracking` and `profileLoadFieldJournal`; part [3/3] sits between `journalMarkFirstSeen` and the win-modal section. The functions stay exactly where they were — no code was moved. The achievement system, Field Journal helpers, and run-tracking/achievement-data generated regions that sit between them are NOT part of this source file and remain in `game/play.html`. (`profileClearActiveRun` does not exist in the codebase, so it was not extracted.) Profile run lifecycle helpers should be edited in `src/state/profile-run-lifecycle.js`, not inside the generated regions of `game/play.html`.
+
+`src/data/encounter-data.js` uses a `// << SPLIT: hiddenSubtypePools >>` line to divide part 1 from part 2; the build script splits on it and inlines each part into its region. `src/state/profile-run-lifecycle.js` uses two split lines (`// << SPLIT: profileOnRunEnd >>` and `// << SPLIT: profileStartNewRun >>`) to divide its three parts. The split markers themselves are not inlined. All other source files have no split marker and each maps to one contiguous region.
+
+**Edit CSS in `src/styles/game.css`, encounter data in `src/data/encounter-data.js`, pure utility helpers in `src/utils/core-utils.js`, achievement definitions in `src/data/achievement-data.js`, run-tracking factory in `src/state/run-tracking.js`, profile/storage constants in `src/state/profile-storage-constants.js`, profile factory helpers in `src/state/profile-factories.js`, profile store core helpers in `src/state/profile-store-core.js`, profile state snapshot helpers in `src/state/profile-state-snapshot.js`, and profile run lifecycle helpers in `src/state/profile-run-lifecycle.js`, then run `node scripts/build_play_html.mjs` — do not hand-edit the generated regions.** The build script never touches code outside the marked regions.
 
 `game/evolution_game_v66_57.html` is the versioned archive of an earlier build. It is a historical snapshot and is not kept byte-in-sync with `game/play.html` between releases; `game/play.html` is the stable public-facing copy that gets replaced on each release.
 
@@ -110,23 +126,27 @@ This region sits between `freshRunTracking` and `loadAchievements`, preserving l
 | 4500–4512 | Profile factory helpers — generated, source in `src/state/profile-factories.js` |
 | 4514–4577 | Profile store core helpers — generated, source in `src/state/profile-store-core.js` |
 | 4579–4718 | Profile state snapshot helpers — generated, source in `src/state/profile-state-snapshot.js` |
-| 4720–4770 | Remaining profile functions (profileKnowledgeCount, profileBuildRunSummary, profileUpdateStats, profileOnRunEnd, etc.) |
-| 4771–4802 | Run-tracking state factory (`freshRunTracking`) — generated, source in `src/state/run-tracking.js` |
-| 4808–4873 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source in `src/data/achievement-data.js` |
-| 4867–5829 | Achievement persistence (load/save/check), profile stats, profiles, save/load, Field Journal, Fossil Record |
-| 5830–5924 | Core utility helpers — generated, source in `src/utils/core-utils.js`: pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation) |
-| 5925–6036 | Remaining [UTILS]: logging, narration setters, noise, risk memory (not extracted — side effects) |
-| 6037–6115 | hiddenSubtypePools — generated, source in `src/data/encounter-data.js` [2/2] |
-| 6116–7614 | Remaining utilities + turn flow: `startTurn`, `endTurn`, metabolism, ecology tick |
-| 7613–8429 | Nearby entity simulation: spawning, persistence, world registry |
-| 8430–11327 | Social system, same-species encounters, group management, calls |
-| 11328–11826 | Threat and predator logic: pursuit, escalation, flee/fight resolution |
-| 11827–12523 | Player action handlers: move, eat, drink, climb, wait, groom, look, etc. |
-| 12524–14471 | Investigation system, carcass interactions, encounter resolution helpers, Field Journal render |
-| 14472–15839 | Bot/QA: `botState`, strategy, step execution, goal planner, loop detection |
-| 15840–16687 | Debug helpers: compact/full report generation, GitHub API push, debug downloads |
-| 16688–17140 | Rendering helpers: encounter card HTML builder, button state logic |
-| 17141–18434 | Main `render()` function, event listeners, game initialisation call, tag extension pass |
+| 4720–4771 | Profile run lifecycle [1/3] (profileKnowledgeCount, profileBuildRunSummary, profileRunIsGodMode, profileUpdateStats) — generated, source in `src/state/profile-run-lifecycle.js` |
+| 4773–4804 | Run-tracking state factory (`freshRunTracking`) — generated, source in `src/state/run-tracking.js` |
+| 4810–4875 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source in `src/data/achievement-data.js` |
+| 4877–5012 | Achievement persistence (load/save/check), toast queue, `updateRunTracking` |
+| 5013–5099 | Profile run lifecycle [2/3] (profileOnRunEnd, profileSaveActiveRun) — generated, source in `src/state/profile-run-lifecycle.js` |
+| 5101–5151 | Field Journal helpers (profileLoadFieldJournal, profileWriteJournalEntry, getEncounterLogCategory, journalMarkFirstSeen) |
+| 5152–5202 | Profile run lifecycle [3/3] (profileStartNewRun, profileResumeActiveRun) — generated, source in `src/state/profile-run-lifecycle.js` |
+| 5204–5851 | Win modal, profile panel UI, profile stats, profiles, save/load, Field Journal render, Fossil Record |
+| 5853–5942 | Core utility helpers — generated, source in `src/utils/core-utils.js`: pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation) |
+| 5943–6068 | Remaining [UTILS]: logging, narration setters, noise, risk memory (not extracted — side effects) |
+| 6069–6147 | hiddenSubtypePools — generated, source in `src/data/encounter-data.js` [2/2] |
+| 6148–7646 | Remaining utilities + turn flow: `startTurn`, `endTurn`, metabolism, ecology tick |
+| 7645–8461 | Nearby entity simulation: spawning, persistence, world registry |
+| 8462–11359 | Social system, same-species encounters, group management, calls |
+| 11360–11858 | Threat and predator logic: pursuit, escalation, flee/fight resolution |
+| 11859–12555 | Player action handlers: move, eat, drink, climb, wait, groom, look, etc. |
+| 12556–14503 | Investigation system, carcass interactions, encounter resolution helpers, Field Journal render |
+| 14504–15871 | Bot/QA: `botState`, strategy, step execution, goal planner, loop detection |
+| 15872–16719 | Debug helpers: compact/full report generation, GitHub API push, debug downloads |
+| 16720–17172 | Rendering helpers: encounter card HTML builder, button state logic |
+| 17173–18466 | Main `render()` function, event listeners, game initialisation call, tag extension pass |
 
 ---
 
@@ -176,7 +196,7 @@ All rendering is done by a single `render()` call that redraws the map, UI panel
 - **`game/play.html` and `game/evolution_game_v66_57.html` must be kept in sync** on each release. If you edit one, copy the change to the other, or replace `play.html` entirely.
 - **`index.html` and `manifest.json` must both reference `game/play.html`.** The syntax check script verifies `index.html`. Check `manifest.json` manually on releases.
 - **`player.knowledge` / `player.classKnowledge`** accumulate across runs and feed the Field Journal. Incorrect resets at run boundaries lose journal data permanently.
-- **The CSS region, both encounter-data regions, the core-utils region, the achievement-data region, the run-tracking region, the profile-storage-constants region, the profile-factories region, the profile-store-core region, and the profile-state-snapshot region in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css`, `src/data/encounter-data.js`, `src/utils/core-utils.js`, `src/data/achievement-data.js`, `src/state/run-tracking.js`, `src/state/profile-storage-constants.js`, `src/state/profile-factories.js`, `src/state/profile-store-core.js`, and `src/state/profile-state-snapshot.js` instead. Do not remove any BEGIN/END marker comments or the `// << SPLIT: hiddenSubtypePools >>` line — the build script requires all of them.
+- **The CSS region, both encounter-data regions, the core-utils region, the achievement-data region, the run-tracking region, the profile-storage-constants region, the profile-factories region, the profile-store-core region, the profile-state-snapshot region, and the three profile-run-lifecycle regions in `game/play.html` are generated.** Hand edits are overwritten on the next `node scripts/build_play_html.mjs`. Edit `src/styles/game.css`, `src/data/encounter-data.js`, `src/utils/core-utils.js`, `src/data/achievement-data.js`, `src/state/run-tracking.js`, `src/state/profile-storage-constants.js`, `src/state/profile-factories.js`, `src/state/profile-store-core.js`, `src/state/profile-state-snapshot.js`, and `src/state/profile-run-lifecycle.js` instead. Do not remove any BEGIN/END marker comments, the `// << SPLIT: hiddenSubtypePools >>` line, or the `// << SPLIT: profileOnRunEnd >>` / `// << SPLIT: profileStartNewRun >>` lines — the build script requires all of them.
 
 ---
 

--- a/docs/current-game-structure.md
+++ b/docs/current-game-structure.md
@@ -12,19 +12,20 @@ Evolution Game is a browser-based single-player survival simulation. The player 
 
 The game runs from a single HTML file (`game/play.html`, ~18,400 lines). There is no bundler and no server. Open the file in a browser and it works.
 
-Nine source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
+Ten source extractions are complete. The playable file `game/play.html` still contains all content inline (between marker comments) so it works with no build step or runtime dependency.
 
 | Source file | What it contains | In play.html |
 |-------------|-----------------|--------------|
 | `src/styles/game.css` | All CSS | Inline `<style>` block |
 | `src/data/encounter-data.js` | `encounters`, `encounterTables`, `hiddenSubtypePools` | Two inline JS regions |
-| `src/utils/core-utils.js` | Pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation helpers) | One inline JS region (~line 5835) |
-| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions array only) | One inline JS region (~line 4806) |
-| `src/state/run-tracking.js` | `freshRunTracking()` factory (run-tracking schema only) | One inline JS region (~line 4769) |
+| `src/utils/core-utils.js` | Pure stateless helpers (clamp, roll, choice, clonePlain, escapeHtml, chooseWeighted, text-sanitisation helpers) | One inline JS region (~line 5853) |
+| `src/data/achievement-data.js` | `ACHIEVEMENT_DEFS` (definitions array only) | One inline JS region (~line 4810) |
+| `src/state/run-tracking.js` | `freshRunTracking()` factory (run-tracking schema only) | One inline JS region (~line 4773) |
 | `src/state/profile-storage-constants.js` | Profile/storage key constants (7 `const` declarations) | One inline JS region (~line 4481) |
 | `src/state/profile-factories.js` | Profile factory helpers (`profileGenerateId`, `profileEmptyStore`, `profileDefaultStats`) | One inline JS region (~line 4500) |
 | `src/state/profile-store-core.js` | Profile store core helpers (`profileLoadStore`, `profileSaveStore`, `profileCreateNew`, `profileGetActive`, `profileCheckBuildCompatibility`) | One inline JS region (~line 4514) |
 | `src/state/profile-state-snapshot.js` | Profile active-run capture/restore helpers (`profileCaptureWorldArrays`, `profileCaptureState`, `profileRestoreState`) | One inline JS region (~line 4579) |
+| `src/state/profile-run-lifecycle.js` | Profile run summary/lifecycle helpers (`profileKnowledgeCount`, `profileBuildRunSummary`, `profileRunIsGodMode`, `profileUpdateStats`, `profileOnRunEnd`, `profileSaveActiveRun`, `profileStartNewRun`, `profileResumeActiveRun`) | Three inline JS regions (~line 4720, ~line 5013, ~line 5152) |
 
 `scripts/build_play_html.mjs` inlines all source files back into `game/play.html`. Only configuration-like declarations and simple factory/helper functions are extracted — `profileCaptureWorldArrays`, `profileCaptureState`, `profileRestoreState`, `profileUpdateStats`, `profileOnRunEnd`, fossil record logic, active-run logic, achievement persistence, save/load logic, and all other game code remain inside `game/play.html`. All JavaScript engine code and HTML structure also remain inside `game/play.html` for now.
 
@@ -281,23 +282,27 @@ flowchart TD
 | 4500–4512 | Profile factory helpers — generated, source is `src/state/profile-factories.js` |
 | 4514–4577 | Profile store core helpers — generated, source is `src/state/profile-store-core.js` |
 | 4579–4718 | Profile state snapshot helpers — generated, source is `src/state/profile-state-snapshot.js` |
-| 4720–4770 | Remaining profile functions (profileKnowledgeCount, profileBuildRunSummary, profileUpdateStats, profileOnRunEnd, etc.) |
-| 4771–4802 | Run-tracking state factory (`freshRunTracking`) — generated, source is `src/state/run-tracking.js` |
-| 4808–4873 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source is `src/data/achievement-data.js` |
-| 4867–5829 | Achievement persistence (load/save/check), profile stats, profiles, save/load, Field Journal, Fossil Record |
-| 5830–5924 | Core utilities — generated, source is `src/utils/core-utils.js`: pure helpers (clamp, roll, choice, clonePlain, escapeHtml, etc.) |
-| 5925–6036 | Remaining utilities: logging, debug helpers, narration setters |
-| 6037–6115 | hiddenSubtypePools — generated, source is `src/data/encounter-data.js` [2/2] |
-| 6116–7614 | Remaining utilities, turn flow: startTurn, endTurn, metabolism, ecology tick |
-| 7613–8429 | Nearby entity simulation: spawning, persistence, world registry |
-| 8430–11327 | Social system, same-species encounters, group management, calls |
-| 11328–11826 | Threat and predator logic: pursuit, escalation, flee/fight resolution |
-| 11827–12523 | Player action handlers: move, eat, drink, climb, wait, groom, look, etc. |
-| 12524–14471 | Investigation system, carcass interactions, encounter resolution helpers, Field Journal render |
-| 14472–15839 | Bot/QA: botState, strategy, step execution, goal planner, loop detection |
-| 15840–16687 | Debug helpers: compact/full report generation, GitHub API push, debug downloads |
-| 16688–17140 | Rendering helpers: encounter card HTML builder, button state logic |
-| 17141–18434 | Main render function, event listeners, game initialisation call, tag extension pass |
+| 4720–4771 | Profile run lifecycle [1/3] (profileKnowledgeCount, profileBuildRunSummary, profileRunIsGodMode, profileUpdateStats) — generated, source is `src/state/profile-run-lifecycle.js` |
+| 4773–4804 | Run-tracking state factory (`freshRunTracking`) — generated, source is `src/state/run-tracking.js` |
+| 4810–4875 | Achievement definitions (`ACHIEVEMENT_DEFS`, 50 defs) — generated, source is `src/data/achievement-data.js` |
+| 4877–5012 | Achievement persistence (load/save/check), toast queue, updateRunTracking |
+| 5013–5099 | Profile run lifecycle [2/3] (profileOnRunEnd, profileSaveActiveRun) — generated, source is `src/state/profile-run-lifecycle.js` |
+| 5101–5151 | Field Journal helpers (profileLoadFieldJournal, profileWriteJournalEntry, getEncounterLogCategory, journalMarkFirstSeen) |
+| 5152–5202 | Profile run lifecycle [3/3] (profileStartNewRun, profileResumeActiveRun) — generated, source is `src/state/profile-run-lifecycle.js` |
+| 5204–5851 | Win modal, profile panel UI, profile stats, profiles, save/load, Field Journal render, Fossil Record |
+| 5853–5942 | Core utilities — generated, source is `src/utils/core-utils.js`: pure helpers (clamp, roll, choice, clonePlain, escapeHtml, etc.) |
+| 5943–6068 | Remaining utilities: logging, debug helpers, narration setters |
+| 6069–6147 | hiddenSubtypePools — generated, source is `src/data/encounter-data.js` [2/2] |
+| 6148–7646 | Remaining utilities, turn flow: startTurn, endTurn, metabolism, ecology tick |
+| 7645–8461 | Nearby entity simulation: spawning, persistence, world registry |
+| 8462–11359 | Social system, same-species encounters, group management, calls |
+| 11360–11858 | Threat and predator logic: pursuit, escalation, flee/fight resolution |
+| 11859–12555 | Player action handlers: move, eat, drink, climb, wait, groom, look, etc. |
+| 12556–14503 | Investigation system, carcass interactions, encounter resolution helpers, Field Journal render |
+| 14504–15871 | Bot/QA: botState, strategy, step execution, goal planner, loop detection |
+| 15872–16719 | Debug helpers: compact/full report generation, GitHub API push, debug downloads |
+| 16720–17172 | Rendering helpers: encounter card HTML builder, button state logic |
+| 17173–18466 | Main render function, event listeners, game initialisation call, tag extension pass |
 
 ---
 
@@ -340,7 +345,10 @@ The rebuild plan (see `docs/project-plan.md`) targets extraction in this rough o
 | `src/state/profile-factories.js` | `// BEGIN/END GENERATED JS: src/state/profile-factories.js` |
 | `src/state/profile-store-core.js` | `// BEGIN/END GENERATED JS: src/state/profile-store-core.js` |
 | `src/state/profile-state-snapshot.js` | `// BEGIN/END GENERATED JS: src/state/profile-state-snapshot.js` |
+| `src/state/profile-run-lifecycle.js` [1/3] | `// BEGIN/END GENERATED JS: src/state/profile-run-lifecycle.js [1/3]` |
+| `src/state/profile-run-lifecycle.js` [2/3] | `// BEGIN/END GENERATED JS: src/state/profile-run-lifecycle.js [2/3]` |
+| `src/state/profile-run-lifecycle.js` [3/3] | `// BEGIN/END GENERATED JS: src/state/profile-run-lifecycle.js [3/3]` |
 
-The source file `src/data/encounter-data.js` contains a `// << SPLIT: hiddenSubtypePools >>` line dividing part 1 (encounters + encounterTables) from part 2 (hiddenSubtypePools). The build script splits on this marker and inlines each part into its respective location in `play.html`. All other source files have no split marker — each maps to one contiguous region.
+The source file `src/data/encounter-data.js` contains a `// << SPLIT: hiddenSubtypePools >>` line dividing part 1 (encounters + encounterTables) from part 2 (hiddenSubtypePools). The source file `src/state/profile-run-lifecycle.js` contains two split lines (`// << SPLIT: profileOnRunEnd >>` and `// << SPLIT: profileStartNewRun >>`) dividing it into three parts, because the eight functions are not contiguous in `play.html` (other generated regions and unrelated systems sit between them). The build script splits on these markers and inlines each part into its respective location in `play.html`. All other source files have no split marker — each maps to one contiguous region.
 
 Run `node scripts/build_play_html.mjs` after editing any source file. Do not hand-edit generated regions in `game/play.html`. This document will be updated as each further extraction completes.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -23,7 +23,8 @@ Run through this every time a new version becomes the stable build.
 - [ ] If `src/state/profile-factories.js` was changed, `node scripts/build_play_html.mjs` was run to inline the profile factory helpers into `game/play.html`
 - [ ] If `src/state/profile-store-core.js` was changed, `node scripts/build_play_html.mjs` was run to inline the profile store core helpers into `game/play.html`
 - [ ] If `src/state/profile-state-snapshot.js` was changed, `node scripts/build_play_html.mjs` was run to inline the profile state snapshot helpers into `game/play.html`
-- [ ] The generated regions in `game/play.html` were not hand-edited (CSS → `src/styles/game.css`; encounter data → `src/data/encounter-data.js`; utility helpers → `src/utils/core-utils.js`; achievement defs → `src/data/achievement-data.js`; run-tracking factory → `src/state/run-tracking.js`; profile/storage constants → `src/state/profile-storage-constants.js`; profile factory helpers → `src/state/profile-factories.js`; profile store core helpers → `src/state/profile-store-core.js`; profile state snapshot helpers → `src/state/profile-state-snapshot.js`)
+- [ ] If `src/state/profile-run-lifecycle.js` was changed, `node scripts/build_play_html.mjs` was run to inline the profile run lifecycle helpers into `game/play.html`
+- [ ] The generated regions in `game/play.html` were not hand-edited (CSS → `src/styles/game.css`; encounter data → `src/data/encounter-data.js`; utility helpers → `src/utils/core-utils.js`; achievement defs → `src/data/achievement-data.js`; run-tracking factory → `src/state/run-tracking.js`; profile/storage constants → `src/state/profile-storage-constants.js`; profile factory helpers → `src/state/profile-factories.js`; profile store core helpers → `src/state/profile-store-core.js`; profile state snapshot helpers → `src/state/profile-state-snapshot.js`; profile run lifecycle helpers → `src/state/profile-run-lifecycle.js`)
 
 ## Syntax and render check
 

--- a/game/play.html
+++ b/game/play.html
@@ -4717,6 +4717,7 @@ function profileRestoreState(state) {
 }
 // END GENERATED JS: src/state/profile-state-snapshot.js
 
+// BEGIN GENERATED JS: src/state/profile-run-lifecycle.js [1/3]
 function profileKnowledgeCount() {
   return Object.keys(player.knowledgeByEncounterKey || {}).length;
 }
@@ -4767,6 +4768,7 @@ function profileUpdateStats(profile, summary) {
   s.totalTurns = (s.totalTurns || 0) + (summary.turnsSurvived || 0);
   s.totalMatings = (s.totalMatings || 0) + (summary.matingCount || 0);
 }
+// END GENERATED JS: src/state/profile-run-lifecycle.js [1/3]
 
 // BEGIN GENERATED JS: src/state/run-tracking.js
 function freshRunTracking() {
@@ -5008,6 +5010,7 @@ function updateRunTracking() {
   rt.tilesExplored = newTiles;
 }
 
+// BEGIN GENERATED JS: src/state/profile-run-lifecycle.js [2/3]
 function profileOnRunEnd(outcome) {
   if (!currentProfileId) return;
   const store = profileLoadStore();
@@ -5093,6 +5096,7 @@ function profileSaveActiveRun() {
   }
   profileUpdatePanelUI();
 }
+// END GENERATED JS: src/state/profile-run-lifecycle.js [2/3]
 
 function profileLoadFieldJournal() {
   if (!currentProfileId) return {};
@@ -5145,6 +5149,7 @@ function journalMarkFirstSeen(e) {
   profileWriteJournalEntry(typeKey, entry);
 }
 
+// BEGIN GENERATED JS: src/state/profile-run-lifecycle.js [3/3]
 function profileStartNewRun() {
   currentRunId = profileGenerateId("run");
   runStartedAt = new Date().toISOString();
@@ -5194,6 +5199,7 @@ function profileResumeActiveRun(profile) {
   profileUpdatePanelUI();
   return true;
 }
+// END GENERATED JS: src/state/profile-run-lifecycle.js [3/3]
 
 // ===== WIN MODAL =====
 

--- a/scripts/build_play_html.mjs
+++ b/scripts/build_play_html.mjs
@@ -16,6 +16,10 @@
 //   7. src/state/profile-factories.js → one JS region (~line 4500)
 //   8. src/state/profile-store-core.js → one JS region (~line 4514)
 //   9. src/state/profile-state-snapshot.js → one JS region (~line 4579)
+//  10. src/state/profile-run-lifecycle.js → three JS regions:
+//        [1/3] knowledge/summary/stats helpers (~line 4720)
+//        [2/3] run-end + active-run save       (~line 5013)
+//        [3/3] start-new + resume helpers      (~line 5152)
 //
 // Why inline (not external files): game/play.html must open straight from
 // disk — or via the GitHub Pages link — with no build step and no runtime
@@ -42,6 +46,7 @@ const PROFCONST_SOURCE   = resolve(repoRoot, 'src/state/profile-storage-constant
 const PROFFACT_SOURCE    = resolve(repoRoot, 'src/state/profile-factories.js');
 const PROFCORE_SOURCE    = resolve(repoRoot, 'src/state/profile-store-core.js');
 const PROFSNAP_SOURCE    = resolve(repoRoot, 'src/state/profile-state-snapshot.js');
+const PROFLIFE_SOURCE    = resolve(repoRoot, 'src/state/profile-run-lifecycle.js');
 const PLAY_HTML          = resolve(repoRoot, 'game/play.html');
 
 // CSS markers (CSS comment style, inside <style>)
@@ -82,9 +87,22 @@ const JS_END_PROFCORE   = '// END GENERATED JS: src/state/profile-store-core.js'
 const JS_BEGIN_PROFSNAP = '// BEGIN GENERATED JS: src/state/profile-state-snapshot.js';
 const JS_END_PROFSNAP   = '// END GENERATED JS: src/state/profile-state-snapshot.js';
 
+// Profile-run-lifecycle markers (JS comment style, inside <script>) — three parts
+const JS_BEGIN_PROFLIFE1 = '// BEGIN GENERATED JS: src/state/profile-run-lifecycle.js [1/3]';
+const JS_END_PROFLIFE1   = '// END GENERATED JS: src/state/profile-run-lifecycle.js [1/3]';
+const JS_BEGIN_PROFLIFE2 = '// BEGIN GENERATED JS: src/state/profile-run-lifecycle.js [2/3]';
+const JS_END_PROFLIFE2   = '// END GENERATED JS: src/state/profile-run-lifecycle.js [2/3]';
+const JS_BEGIN_PROFLIFE3 = '// BEGIN GENERATED JS: src/state/profile-run-lifecycle.js [3/3]';
+const JS_END_PROFLIFE3   = '// END GENERATED JS: src/state/profile-run-lifecycle.js [3/3]';
+
 // The split comment that divides the source file into part1 and part2.
 // It is NOT inlined into game/play.html.
 const JS_SPLIT  = '// << SPLIT: hiddenSubtypePools >>';
+
+// The two split comments that divide profile-run-lifecycle.js into three parts.
+// They are NOT inlined into game/play.html.
+const JS_SPLIT_PROFLIFE_A = '// << SPLIT: profileOnRunEnd >>';
+const JS_SPLIT_PROFLIFE_B = '// << SPLIT: profileStartNewRun >>';
 
 function fail(msg) {
   console.error(`build_play_html: ERROR: ${msg}`);
@@ -115,6 +133,7 @@ if (!existsSync(PROFCONST_SOURCE)) fail('cannot find src/state/profile-storage-c
 if (!existsSync(PROFFACT_SOURCE))  fail('cannot find src/state/profile-factories.js');
 if (!existsSync(PROFCORE_SOURCE))  fail('cannot find src/state/profile-store-core.js');
 if (!existsSync(PROFSNAP_SOURCE))  fail('cannot find src/state/profile-state-snapshot.js');
+if (!existsSync(PROFLIFE_SOURCE))  fail('cannot find src/state/profile-run-lifecycle.js');
 if (!existsSync(PLAY_HTML))        fail('cannot find game/play.html');
 
 const css          = readFileSync(CSS_SOURCE,       'utf8');
@@ -126,6 +145,7 @@ const jsProfConst  = readFileSync(PROFCONST_SOURCE, 'utf8');
 const jsProfFact   = readFileSync(PROFFACT_SOURCE,  'utf8');
 const jsProfCore   = readFileSync(PROFCORE_SOURCE,  'utf8');
 const jsProfSnap   = readFileSync(PROFSNAP_SOURCE,  'utf8');
+const jsProfLife   = readFileSync(PROFLIFE_SOURCE,  'utf8');
 let   html         = readFileSync(PLAY_HTML,        'utf8');
 
 // --- Split encounter-data into two parts at the SPLIT marker ---
@@ -133,6 +153,16 @@ const splitIdx = jsData.indexOf(JS_SPLIT);
 if (splitIdx === -1) fail(`missing split marker in src/data/encounter-data.js: ${JS_SPLIT}`);
 const jsPart1 = jsData.slice(0, splitIdx).replace(/\s+$/, '');
 const jsPart2 = jsData.slice(splitIdx + JS_SPLIT.length).replace(/^\n/, '').replace(/\s+$/, '');
+
+// --- Split profile-run-lifecycle into three parts at its two SPLIT markers ---
+const lifeSplitA = jsProfLife.indexOf(JS_SPLIT_PROFLIFE_A);
+if (lifeSplitA === -1) fail(`missing split marker in src/state/profile-run-lifecycle.js: ${JS_SPLIT_PROFLIFE_A}`);
+const lifeSplitB = jsProfLife.indexOf(JS_SPLIT_PROFLIFE_B);
+if (lifeSplitB === -1) fail(`missing split marker in src/state/profile-run-lifecycle.js: ${JS_SPLIT_PROFLIFE_B}`);
+if (lifeSplitB < lifeSplitA) fail('profile-run-lifecycle split markers are out of order');
+const jsLife1 = jsProfLife.slice(0, lifeSplitA).replace(/\s+$/, '');
+const jsLife2 = jsProfLife.slice(lifeSplitA + JS_SPLIT_PROFLIFE_A.length, lifeSplitB).replace(/^\n/, '').replace(/\s+$/, '');
+const jsLife3 = jsProfLife.slice(lifeSplitB + JS_SPLIT_PROFLIFE_B.length).replace(/^\n/, '').replace(/\s+$/, '');
 
 // --- Apply all regions ---
 const original = html;
@@ -146,6 +176,9 @@ html = inlineRegion(html, JS_BEGIN_PROFCONST, JS_END_PROFCONST, jsProfConst.repl
 html = inlineRegion(html, JS_BEGIN_PROFFACT,  JS_END_PROFFACT,  jsProfFact.replace(/\s+$/, ''),  'profile-factories');
 html = inlineRegion(html, JS_BEGIN_PROFCORE,  JS_END_PROFCORE,  jsProfCore.replace(/\s+$/, ''),  'profile-store-core');
 html = inlineRegion(html, JS_BEGIN_PROFSNAP,  JS_END_PROFSNAP,  jsProfSnap.replace(/\s+$/, ''),  'profile-state-snapshot');
+html = inlineRegion(html, JS_BEGIN_PROFLIFE1, JS_END_PROFLIFE1, jsLife1, 'profile-run-lifecycle [1/3]');
+html = inlineRegion(html, JS_BEGIN_PROFLIFE2, JS_END_PROFLIFE2, jsLife2, 'profile-run-lifecycle [2/3]');
+html = inlineRegion(html, JS_BEGIN_PROFLIFE3, JS_END_PROFLIFE3, jsLife3, 'profile-run-lifecycle [3/3]');
 
 if (html === original) {
   console.log('build_play_html: no change — game/play.html already matches all source files.');

--- a/src/state/profile-run-lifecycle.js
+++ b/src/state/profile-run-lifecycle.js
@@ -1,0 +1,186 @@
+function profileKnowledgeCount() {
+  return Object.keys(player.knowledgeByEncounterKey || {}).length;
+}
+
+function profileBuildRunSummary(outcome) {
+  const sz = (socialGroup.members || []).length;
+  if (sz > runMaxGroupSize) runMaxGroupSize = sz;
+  const dc = player.deathContext;
+  return {
+    runId: currentRunId || profileGenerateId("run"),
+    buildId: GAME_VERSION,
+    startedAt: runStartedAt || new Date().toISOString(),
+    endedAt: new Date().toISOString(),
+    outcome,
+    turnsSurvived: player.turn,
+    deathCause: dc ? String(dc.message || "") : "",
+    deathContextSource: dc && dc.context ? String(dc.context.source || "") : "",
+    matingCount: player.matingCount || 0,
+    matingGoal: 5,
+    maxGroupSize: runMaxGroupSize,
+    finalSize: player.size,
+    finalLifeStage: typeof isPlayerMature === "function" ? (isPlayerMature() ? "adult" : "juvenile") : "unknown",
+    knowledgeUnlockCount: profileKnowledgeCount(),
+    seed: currentRunId || "",
+    usedGodMode: runGodModeUsed,
+    qaBackUses: runQaBackUses
+  };
+}
+
+function profileRunIsGodMode(summary) {
+  return !!(summary.usedGodMode || summary.qaBackUses > 0);
+}
+
+function profileUpdateStats(profile, summary) {
+  const s = profile.stats;
+  const gm = profileRunIsGodMode(summary);
+  if (gm) {
+    s.godModeRuns = (s.godModeRuns || 0) + 1;
+  } else {
+    s.totalRuns = (s.totalRuns || 0) + 1;
+    if (summary.outcome === "death") s.deaths = (s.deaths || 0) + 1;
+    if (summary.outcome === "win") { s.wins = (s.wins || 0) + 1; s.completedRuns = (s.completedRuns || 0) + 1; }
+    if (summary.outcome === "abandoned") s.completedRuns = (s.completedRuns || 0) + 1;
+  }
+  if (summary.turnsSurvived > (s.bestTurn || 0)) s.bestTurn = summary.turnsSurvived;
+  if (summary.matingCount > (s.bestMatingCount || 0)) s.bestMatingCount = summary.matingCount;
+  if (summary.knowledgeUnlockCount > (s.bestKnowledgeUnlocks || 0)) s.bestKnowledgeUnlocks = summary.knowledgeUnlockCount;
+  s.totalTurns = (s.totalTurns || 0) + (summary.turnsSurvived || 0);
+  s.totalMatings = (s.totalMatings || 0) + (summary.matingCount || 0);
+}
+// << SPLIT: profileOnRunEnd >>
+function profileOnRunEnd(outcome) {
+  if (!currentProfileId) return;
+  const store = profileLoadStore();
+  const profile = store.profiles[currentProfileId];
+  if (!profile) return;
+  const summary = profileBuildRunSummary(outcome);
+  profile.runHistory = profile.runHistory || [];
+  profile.runHistory.unshift(summary);
+  if (profile.runHistory.length > 20) profile.runHistory.length = 20;
+  profileUpdateStats(profile, summary);
+  profile.activeRun = null;
+  profile.lastPlayedAt = new Date().toISOString();
+  profileSaveStore(store);
+  checkAchievements();
+  runGodModeUsed = false;
+  runQaBackUses = 0;
+  runMaxGroupSize = 0;
+  runStartedAt = null;
+  winAchievedThisRun = false;
+  currentRunId = null;
+  runNewAchievements = [];
+  clearToastQueue();
+  profileUpdatePanelUI();
+}
+
+function profileSaveActiveRun() {
+  if (!currentProfileId) { addLog("No active profile — create one in Developer / QA tools.", "minor"); return; }
+  if (player.dead) { addLog("Cannot save: current run has ended.", "minor"); return; }
+  const store = profileLoadStore();
+  const profile = store.profiles[currentProfileId];
+  if (!profile) return;
+  let state;
+  try { state = profileCaptureState(); } catch (e) {
+    addLog("Save failed — could not capture state.", "minor");
+    addDebugTrace("profile-save-capture-error", {error: String(e)});
+    return;
+  }
+  let stateJson;
+  try { stateJson = JSON.stringify(state); } catch (e) {
+    addLog("Save failed — state could not be serialised.", "minor");
+    return;
+  }
+  const sizeKB = Math.round(stateJson.length / 1024);
+  if (sizeKB > 4000) addLog(`Save state is large (${sizeKB} KB). localStorage may reject it.`, "minor");
+
+  if (!currentRunId) currentRunId = profileGenerateId("run");
+  if (!runStartedAt) runStartedAt = new Date().toISOString();
+
+  profile.activeRun = {
+    runId: currentRunId,
+    startedAt: runStartedAt,
+    lastSavedAt: new Date().toISOString(),
+    buildId: GAME_VERSION,
+    seed: currentRunId,
+    runGodModeUsed,
+    runQaBackUses,
+    runNewAchievements: runNewAchievements.slice(),
+    summary: {
+      turn: player.turn,
+      x: player.x,
+      y: player.y,
+      z: player.z,
+      layer: typeof layers !== "undefined" ? (layers[player.z] || player.z) : player.z,
+      dead: player.dead,
+      matingCount: player.matingCount,
+      groupSize: (socialGroup.members || []).length,
+      lifeStage: typeof isPlayerMature === "function" ? (isPlayerMature() ? "adult" : "juvenile") : "unknown",
+      sex: player.sex
+    },
+    state
+  };
+  profile.lastPlayedAt = new Date().toISOString();
+  profile.buildId = GAME_VERSION;
+
+  const saved = profileSaveStore(store);
+  if (saved) {
+    addLog(`Run saved at turn ${player.turn} (${sizeKB} KB).`, "minor");
+    addDebugTrace("profile-run-saved", {turn: player.turn, sizeKB, runId: currentRunId});
+  } else {
+    addLog("Save failed — localStorage write error (quota or security). Run was not persisted.", "death");
+    addDebugTrace("profile-save-write-error", {turn: player.turn, sizeKB, runId: currentRunId});
+    profile.activeRun = null;
+  }
+  profileUpdatePanelUI();
+}
+// << SPLIT: profileStartNewRun >>
+function profileStartNewRun() {
+  currentRunId = profileGenerateId("run");
+  runStartedAt = new Date().toISOString();
+  runGodModeUsed = false;
+  runQaBackUses = 0;
+  runMaxGroupSize = 0;
+  winAchievedThisRun = false;
+  runNewAchievements = [];
+  clearToastQueue();
+  player.knowledgeByEncounterKey = profileLoadFieldJournal();
+  addDebugTrace("profile-new-run", {profileId: currentProfileId || "none", runId: currentRunId});
+}
+
+function profileResumeActiveRun(profile) {
+  if (!profile || !profile.activeRun || !profile.activeRun.state) {
+    addLog("No active run to resume.", "minor");
+    return false;
+  }
+  const compat = profileCheckBuildCompatibility(profile);
+  if (!compat.compatible) {
+    const ok = window.confirm(
+      "This profile was saved on build:\n" + compat.savedBuild +
+      "\n\nCurrent build:\n" + compat.localBuild +
+      "\n\nLoading may not be fully compatible. Continue?"
+    );
+    if (!ok) return false;
+  }
+  currentRunId = profile.activeRun.runId || profileGenerateId("run");
+  runStartedAt = profile.activeRun.startedAt || new Date().toISOString();
+  runGodModeUsed = !!(profile.activeRun.runGodModeUsed);
+  runQaBackUses = profile.activeRun.runQaBackUses || 0;
+  runMaxGroupSize = 0;
+  winAchievedThisRun = false;
+  runNewAchievements = Array.isArray(profile.activeRun.runNewAchievements) ? profile.activeRun.runNewAchievements.slice() : [];
+  clearToastQueue();
+  clearRunLogsForNewGame();
+  try {
+    profileRestoreState(profile.activeRun.state);
+  } catch (e) {
+    addLog("Resume failed — state could not be restored.", "minor");
+    addDebugTrace("profile-resume-error", {error: String(e)});
+    return false;
+  }
+  addLog("Run resumed at turn " + player.turn + ".", "minor");
+  addDebugTrace("profile-run-resumed", {runId: currentRunId, turn: player.turn});
+  render();
+  profileUpdatePanelUI();
+  return true;
+}


### PR DESCRIPTION
## Summary

Tenth controlled extraction in the build scaffold series. Moves eight profile run-summary/run-lifecycle helper functions out of `game/play.html` into `src/state/profile-run-lifecycle.js`, and wires them into `scripts/build_play_html.mjs` so they are inlined back at build time.

`game/play.html` remains the directly playable artifact — all content is still inline, no runtime dependencies.

---

## What changed

- **Created** `src/state/profile-run-lifecycle.js` — holds eight functions:
  - `profileKnowledgeCount()`
  - `profileBuildRunSummary(outcome)`
  - `profileRunIsGodMode(summary)`
  - `profileUpdateStats(profile, summary)`
  - `profileOnRunEnd(outcome)`
  - `profileSaveActiveRun()`
  - `profileStartNewRun()`
  - `profileResumeActiveRun(profile)`
- **`game/play.html`** — the eight functions wrapped in three generated regions (`[1/3]`, `[2/3]`, `[3/3]`); all surrounding code unchanged
- **`scripts/build_play_html.mjs`** — wired to read `src/state/profile-run-lifecycle.js`, split it on two markers, and inline the three parts; now inlines all ten source files
- **`README.md`** — repo layout tree and build scaffold table updated
- **`docs/current-game-structure.md`** — line-range table, build scaffold table, marker table, and split-marker note updated
- **`docs/architecture-notes.md`** — generated regions list, line-range table, fragile areas, do-not-edit directive, and split-marker note updated
- **`docs/release-checklist.md`** — build step checklist updated with profile-run-lifecycle entry
- **`CHANGELOG.txt`** — entry added

---

## Why three regions

The eight functions are **not contiguous** in `game/play.html`. Between them sit the run-tracking and achievement-data generated regions (owned by other source files), the entire achievement persistence/toast system, `updateRunTracking`, and the Field Journal helpers. Per the task's contiguity rule, no non-approved code was moved. Instead the source is divided by two split markers (`// << SPLIT: profileOnRunEnd >>` and `// << SPLIT: profileStartNewRun >>`) and inlined into three regions:

- `[1/3]` — `profileKnowledgeCount`, `profileBuildRunSummary`, `profileRunIsGodMode`, `profileUpdateStats` (between `profileRestoreState` and the run-tracking region)
- `[2/3]` — `profileOnRunEnd`, `profileSaveActiveRun` (between `updateRunTracking` and `profileLoadFieldJournal`)
- `[3/3]` — `profileStartNewRun`, `profileResumeActiveRun` (between `journalMarkFirstSeen` and the win-modal section)

Every function stays exactly where it already lived — zero code movement.

`profileClearActiveRun` (listed conditionally in the task) **does not exist** in the codebase, so it was not extracted.

---

## Scope confirmation

- Only the approved profile lifecycle functions were extracted (8 of the 9 named; `profileClearActiveRun` does not exist).
- No function bodies changed.
- No call sites changed.
- No run summary fields changed.
- No profile stats fields changed.
- No activeRun fields changed.
- No save schema changed.
- No resume behaviour changed.
- No death/win handling changed.
- No gameplay logic changed.
- No existing extracted source files changed.

`profileCaptureWorldArrays`, `profileCaptureState`, `profileRestoreState`, `profileLoadStore`, `profileSaveStore`, `profileCreateNew`, `profileGetActive`, `profileCheckBuildCompatibility`, achievement persistence, fossil record logic, and Field Journal logic all remain in `game/play.html` unchanged.

---

## Verification

- `node scripts/build_play_html.mjs` ran after adding markers — reported **no change** (inline blocks already matched source exactly)
- `node scripts/check_html_js_syntax.mjs` passed with no errors
- The three inline regions were reconstructed (re-joined with the two split markers) and diffed against `src/state/profile-run-lifecycle.js` — byte-for-byte match
- Each of the eight functions confirmed present exactly once in `game/play.html`
- Browser manual check not run by Claude; awaiting George's browser smoke test.

---

## Scope

- [ ] Gameplay logic
- [ ] UI/layout
- [ ] Bot/debug tools
- [ ] App-loading/PWA files
- [x] Documentation/workflow
- [x] Repository structure (source extraction / build scaffold)

---

## Smoke check

Static review only. `game/play.html` was not opened in a browser this session. The syntax check passed and the build script confirmed idempotency. Because this extraction covers run-end, save, and resume logic, George should open `game/play.html` in a browser and confirm the game loads, a run ends/records correctly, and a saved run resumes before merging.

---

Documentation updated: `README.md`, `docs/current-game-structure.md`, `docs/architecture-notes.md`, `docs/release-checklist.md`, `CHANGELOG.txt`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKFcTXWzunyBYGnVrpUzLd)_