### PR TITLE
Fix four scene/investigation text bugs: duplication, YOU SEE pursuit, smell narration, forage subtype

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,23 @@
+[2026-06-05 scene-text-bugs | Claude]
+Four scene/investigation text bugs fixed in game/play.html.
+
+- Issue A — Scene text duplication: dangerous-layer "no encounter" warning was passed to both
+  addLog() and setNarration(), causing the same sentence to appear in the event alert box AND
+  in the scene description body. Removed the setNarration() call; addLog() alone is correct here.
+- Issue B — YOU SEE contradicts active pursuit: renderSenses() fell through to "no animal or food
+  source clearly visible" even when activePursuit was active. Added an activePursuit branch before
+  the fallback so YOU SEE reads "[predator name] is still close." during a chase.
+- Issue C — Mammal-smell narration overlap: the scene body and the YOU SMELL line were both
+  interpreting the same mammal-scent signal, and the narration used the phrase "or memory" which
+  reads as nonsensical. Narration now reads "Something alive has been through here recently."
+  which is distinct from the YOU SMELL directional text.
+- Issue D — hiddenSubtypeSuspicionText() used animal-prey language for forage hidden subtypes:
+  rank >= 4 ("bold warning cues, little fear, no hurry to escape") and rank >= 2 ("Slow, exposed
+  prey is often defended") both used predation framing that makes no sense for mushrooms or plant
+  items. Added kind !== "animal" branches for both ranks with forage-appropriate language.
+- Verification: node scripts/check_html_js_syntax.mjs — all checks passed.
+- No gameplay logic, stat values, spawn tables, or encounter data changed.
+
 [2026-06-05 flavour-text-fixes | Claude]
 Flavour text audit fixes — seen/investigated text corrected across 20+ encounter entries; isInvertebrateEncounter regex extended.
 

--- a/docs/bug-guardrails.md
+++ b/docs/bug-guardrails.md
@@ -182,6 +182,60 @@ If a PR adds any new invertebrate encounter entry, explicitly check `isInvertebr
 
 ---
 
+## BG-006 — addLog + setNarration dual-call causes event text to appear twice in the scene panel
+
+**Status:** Active guardrail
+
+**Observed failure:**
+A no-encounter danger-layer warning was passed to both `addLog()` (which writes to the event alert box) and `setNarration()` (which writes to the scene description body). The same sentence appeared in both places in the same render cycle.
+
+**Player/tester symptom:**
+Identical text shown in the brown alert box at the top of the scene panel AND in the plain scene description text immediately below it.
+
+**Root cause:**
+`setNarration()` sets `lastNarration`, which the scene body renderer reads directly. Any code path that calls both `addLog(text)` and `setNarration(text)` with the same string will duplicate the text in the UI. Only one of the two should be used for any given string. Event notifications belong in `addLog`; scene-state descriptions belong in `setNarration`.
+
+**Known affected area:**
+- `game/play.html` — any code path calling `addLog` and `setNarration` with the same string
+
+**Future guardrail:**
+When writing code that produces a player-facing string, decide whether it is an event (use `addLog`) or a scene state (use `setNarration`). Do not call both with the same text.
+
+**Required PR check:**
+- Search for `setNarration` calls adjacent to `addLog` calls and verify they are not using the same string.
+
+**Reviewer instruction:**
+If a PR adds a code path that calls both `addLog(text)` and `setNarration(text)` with the same content, flag it before merge.
+
+---
+
+## BG-007 — hiddenSubtypeSuspicionText uses animal-predation language for forage/plant hidden subtypes
+
+**Status:** Active guardrail
+
+**Observed failure:**
+`hiddenSubtypeSuspicionText()` returns investigation narration that references "prey", "defended", and "bold warning cues, little fear, no hurry to escape" — all of which are animal-predation framing. When a poisonous forage item (e.g., brown mushrooms) spawned as a hidden-subtype variant, investigation showed "Slow, exposed prey is often defended. This one deserves care." for a fungus.
+
+**Player/tester symptom:**
+Investigation text for a mushroom read as if the player were investigating a defensive animal.
+
+**Root cause:**
+`hiddenSubtypeSuspicionText()` had no `kind` check. The rank >= 4 and rank >= 2 branches generated text written for animals regardless of the encounter's kind.
+
+**Known affected area:**
+- `game/play.html` — `hiddenSubtypeSuspicionText()` function
+
+**Future guardrail:**
+When writing investigation or suspicion text in `hiddenSubtypeSuspicionText()`, add a `kind !== "animal"` guard for any branch whose language is specific to animals (predator posture, prey behaviour, escape response, etc.).
+
+**Required PR check:**
+- If modifying `hiddenSubtypeSuspicionText()`, verify that all return branches are checked: does the narration text make sense for both an animal and a forage/plant/nest/remedy item?
+
+**Reviewer instruction:**
+If investigation text contains "prey", "defended", "flee", "posture", or similar animal-behaviour language in a branch that can fire for forage items, flag it before merge.
+
+---
+
 ## Entry template for future bugs
 
 ```md

--- a/game/play.html
+++ b/game/play.html
@@ -8329,7 +8329,7 @@ function randomFalseClue() {
     {
       sense: "smell",
       text: `A musky mammalian smell seems to come from the ${dir}, but it may be old scent held in wet bark.`,
-      narration: `The smell of mammal hangs in the air. It may be predator, prey, or memory.`
+      narration: `The smell of mammal is in the air. Something alive has been through here recently.`
     },
     {
       sense: "hear",
@@ -10763,7 +10763,6 @@ function layerPerilCheck(actionText) {
         ? "The forest floor feels busy with hidden movement. It is not a place to linger without a reason."
         : "The high branches expose you against gaps in the canopy. Height helps, but it advertises movement.";
       addLog(text, "threat");
-      setNarration(text);
     }
     return false;
   }
@@ -12678,8 +12677,14 @@ function hiddenSubtypeSuspicionText(e, level) {
     return {log: "uncertain food; more evidence needed", narration: "You can read some signs, but not enough to trust them.", className: "minor"};
   }
   if (level < 4) {
-    if (rank >= 4) return {log: "strong warning signs, exact identity uncertain", narration: "The signs are bad: bold warning cues, little fear, and no hurry to escape.", className: "threat"};
-    if (rank >= 2) return {log: "probable chemical/toxin risk", narration: "Slow, exposed prey is often defended. This one deserves care.", className: "poison"};
+    if (rank >= 4) {
+      if (e.kind !== "animal") return {log: "strong toxin warning, exact identity uncertain", narration: "Strong warning signs on a food source — this may be deadly. Do not eat until you are certain.", className: "threat"};
+      return {log: "strong warning signs, exact identity uncertain", narration: "The signs are bad: bold warning cues, little fear, and no hurry to escape.", className: "threat"};
+    }
+    if (rank >= 2) {
+      if (e.kind !== "animal") return {log: "probable chemical/toxin risk", narration: "Something here carries a chemical risk. The signs are real but the severity is uncertain.", className: "poison"};
+      return {log: "probable chemical/toxin risk", narration: "Slow, exposed prey is often defended. This one deserves care.", className: "poison"};
+    }
     if (rank >= 1) return {log: "possible mild toxin or bad taste", narration: "There are warning hints, but they are weak. Treat it as uncertain, not safe.", className: "poison"};
     return {log: "probably edible, but not certain", narration: "It looks promising, but certainty only comes with experience and risk.", className: "food"};
   }
@@ -17595,6 +17600,8 @@ function renderSenses() {
     seeText.innerHTML = formatCueText("water surrounds you; there is no forest structure to climb here.");
     hearText.innerHTML = formatCueText("water breaks against your body and hides other movement.");
     smellTextEl.innerHTML = formatCueText("wet mineral scent and riverbank rot press close.");
+  } else if (activePursuit && activePursuit.name) {
+    seeText.innerHTML = formatCueText(`${activePursuit.name} is still close.`);
   } else {
     seeText.innerHTML = formatCueText("no animal or food source clearly visible." + nearbyWaterText() + staticScarcityCueAt());
   }


### PR DESCRIPTION
## Summary

Four text/rendering bugs identified from playthrough screenshots, all in `game/play.html`.

---

### Issue A — Scene text duplicated in alert box and scene body

**Root cause:** A no-encounter danger-layer warning called both `addLog(text, "threat")` and `setNarration(text)` with the same string. `addLog` writes to the event alert box; `setNarration` sets `lastNarration` which the scene body renderer reads. Both fired in the same cycle → identical sentence in both panels.

**Fix:** Removed the `setNarration()` call. The log notification is correct and sufficient here; the scene body shows ambient content.

---

### Issue B — YOU SEE reads "no animal visible" during an active pursuit

**Root cause:** `renderSenses()` fell through to the `"no animal or food source clearly visible."` fallback regardless of `activePursuit` state. The pursuit card was rendered correctly below, but the YOU SEE sensory line contradicted it.

**Fix:** Added an `activePursuit` branch before the fallback. During a chase, YOU SEE now reads `"[predator name] is still close."`.

---

### Issue C — Mammal-smell narration overlapped with YOU SMELL and used "or memory"

**Root cause:** The scene body narration and the YOU SMELL line both interpreted the same mammal-scent signal. The narration text ended with "It may be predator, prey, or memory." — "or memory" is opaque shorthand for "the animal has passed" but reads as nonsensical without that unpacking. The YOU SMELL line independently covered the "old scent" angle with better phrasing.

**Fix:** Narration changed to `"Something alive has been through here recently."` — distinct from the directional YOU SMELL text and unambiguous.

---

### Issue D — hiddenSubtypeSuspicionText used animal-predation language for forage items

**Root cause:** `hiddenSubtypeSuspicionText()` had no `kind` check. The rank >= 4 branch said "bold warning cues, little fear, and no hurry to escape" and the rank >= 2 branch said "Slow, exposed prey is often defended. This one deserves care." — both written for animals. Poisonous brown mushrooms (a hidden-subtype forage item with rank 2) showed the prey-defence language on investigation.

**Fix:** Added `kind !== "animal"` guards for both ranks. Non-animal hidden subtypes (forage, plant, fungal) now receive:
- rank >= 4: `"Strong warning signs on a food source — this may be deadly. Do not eat until you are certain."`
- rank >= 2: `"Something here carries a chemical risk. The signs are real but the severity is uncertain."`

---

## Verification

- `node scripts/check_html_js_syntax.mjs` — all checks passed

## Files changed

- `game/play.html` — all four fixes
- `CHANGELOG.txt` — entry added
- `docs/bug-guardrails.md` — BG-006 and BG-007 added

## Documentation gate

Documentation updated: `docs/bug-guardrails.md` (BG-006 — addLog+setNarration dual-call pattern; BG-007 — hiddenSubtypeSuspicionText kind guard).

`README.md`, `docs/current-game-structure.md`, `docs/architecture-notes.md`, `docs/project-plan.md`, `docs/release-checklist.md`, `.github/pull_request_template.md`, `CLAUDE.md` checked; no wider docs required because all changes are targeted bug fixes within existing functions — no system architecture, module structure, build process, or file layout changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKFcTXWzunyBYGnVrpUzLd)_